### PR TITLE
ci: verify BYOAI bundle stays in sync with snip sources

### DIFF
--- a/.github/workflows/byoai-bundle-check.yml
+++ b/.github/workflows/byoai-bundle-check.yml
@@ -1,0 +1,38 @@
+name: BYOAI bundle freshness
+
+# Ensures jvd-mebs-snips.md and jvd-mebs-byoai-prompt.txt are
+# regenerated whenever any source file under the MEBS snips/
+# tree (or the byoai/ companion files) changes.
+#
+# Fails the PR if the committed bundle does not match what
+# regenerate-bundle.sh would produce right now.
+
+on:
+  pull_request:
+    paths:
+      - 'service_provider/metro_ethernet_business_services/configuration/snips/**'
+  push:
+    branches: [main]
+    paths:
+      - 'service_provider/metro_ethernet_business_services/configuration/snips/**'
+
+jobs:
+  check-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Regenerate bundle
+        working-directory: service_provider/metro_ethernet_business_services/configuration/snips/byoai
+        run: ./regenerate-bundle.sh
+
+      - name: Verify bundle is up to date
+        run: |
+          if ! git diff --exit-code -- \
+              'service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md' \
+              'service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-byoai-prompt.txt'; then
+            echo ""
+            echo "::error::BYOAI bundle is stale. Run regenerate-bundle.sh from the byoai/ folder and commit the result."
+            exit 1
+          fi
+          echo "Bundle is up to date."


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that fails any PR (or push to `main`) which modifies files under `service_provider/metro_ethernet_business_services/configuration/snips/` without regenerating the BYOAI bundle.

## Why

The two BYOAI artifacts — `jvd-mebs-snips.md` (the corpus AIs fetch) and `jvd-mebs-byoai-prompt.txt` (the shareable prompt) — are produced by `regenerate-bundle.sh` from the source snip files. If a contributor changes a snip and forgets to run the script, the bundle silently goes stale and AIs grounded against it generate configs from old patterns.

This workflow eliminates that footgun: it runs the script in CI and `git diff --exit-code`s the two generated files. Stale → red check → contributor told exactly which command to run.

## What it does

- Triggers on any change to `service_provider/metro_ethernet_business_services/configuration/snips/**`.
- Runs `regenerate-bundle.sh` on a clean checkout.
- Fails with a clear error message if either generated file differs from what the script would produce.

## Tested

Local dry run: regenerated bundle, `git diff --exit-code` clean — workflow logic mirrors that exactly.
