### PR TITLE
docs: rewrite 3stage_dc + tighten aidc parent READMEs

### DIFF
--- a/data_center/adc/3stage_dc/README.md
+++ b/data_center/adc/3stage_dc/README.md
@@ -1,15 +1,46 @@
-**3-stage EVPN-VXLAN Data Center Design**
+# 3-Stage EVPN/VXLAN Data Center Design
 
-The 3-Stage Data Center Design is the most common Juniper data center network architecture and offers
-comprehensive guidance on deploying a modern 3-stage data center fabric with EVPN-VXLAN. As with all Juniper data center JVDs, this solution follows best practices as determined by
-Juniper’s subject matter experts, including Juniper support teams. This JVD is the result of extensive consultation and testing to find the
-balance between capability, performance, and cost efficiency to meet the needs of scalable data center deployments.
+Validated configurations for the Juniper Validated Design *"3-Stage Data Center Design with Juniper Apstra."* This is the most common Juniper data center fabric architecture, built on EVPN/VXLAN with an **Edge-Routed Bridging (ERB)** overlay and a **lean spine** underlay.
 
-The 3-stage Datacenter design is based on the ERB design with lean spine. The border leaf switches were validated against different Juniper device models. For more information on this design refer the JVD link below:
-https://www.juniper.net/documentation/us/en/software/jvd/jvd-3-stage-datacenterdesign-with-juniper-apstra/index.html
+* JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-3-stage-datacenterdesign-with-juniper-apstra/index.html>
 
-The configurations uploaded here are validated configurations.
+The JVD validates the design against multiple Juniper switching platforms in each role, so customers can choose the platform that best matches their density, scale, and budget requirements.
 
-![image](https://github.com/user-attachments/assets/42d066ab-2ef8-4df5-9c45-d5ee522f0940)
+![3-Stage data center reference architecture](images/3stage-architecture.png)
 
+## Hardware
 
+| Juniper Product | Role | Hostnames | Software |
+|---|---|---|---|
+| **QFX5220-32CD** | Spine | `dc1-spine1`, `dc1-spine2` | Junos OS Evolved 23.4R2-S3 |
+| **QFX5120-48Y** | Server leaf | `dc1-single-001-leaf1` | Junos OS 23.4R2-S3 |
+| **QFX5120-48Y** | ESI leaf pair | `dc1-esi-001-leaf1`, `dc1-esi-001-leaf2` | Junos OS 23.4R2-S3 |
+| **QFX5130-32CD** | Border leaf pair *(canonical)* | `dc1-border-leaf1`, `dc1-border-leaf2` | Junos OS Evolved 23.4R2-S3 |
+| ACX7100-48L | Border leaf pair *(alternative)* | — | Junos OS Evolved |
+| PTX10001-36MR | Border leaf pair *(alternative)* | — | Junos OS Evolved |
+| QFX5120-32C | Border leaf pair *(alternative)* | — | Junos OS |
+| QFX5700 | Border leaf pair *(alternative)* | — | Junos OS Evolved |
+
+## Configurations
+
+Common to every variant:
+
+| File | Role |
+|---|---|
+| [`spine1_qfx5220-32cd.conf`](configuration/conf/spine1_qfx5220-32cd.conf) | Spine 1 |
+| [`spine2_qfx5220-32cd.conf`](configuration/conf/spine2_qfx5220-32cd.conf) | Spine 2 |
+| [`esi-leaf1_qfx5120-48y.conf`](configuration/conf/esi-leaf1_qfx5120-48y.conf) | ESI leaf 1 |
+| [`esi-leaf2_qfx5120-48y.conf`](configuration/conf/esi-leaf2_qfx5120-48y.conf) | ESI leaf 2 |
+| [`server-leaf1_qfx5120-48y.conf`](configuration/conf/server-leaf1_qfx5120-48y.conf) | Single-homed server leaf |
+
+Border-leaf pair, by validated platform:
+
+| Platform | Border leaf 1 | Border leaf 2 |
+|---|---|---|
+| ACX7100-48L | [`borderleaf1_acx7100-48l.conf`](configuration/conf/borderleaf/borderleaf1_acx7100-48l.conf) | [`borderleaf2_acx7100-48l.conf`](configuration/conf/borderleaf/borderleaf2_acx7100-48l.conf) |
+| PTX10001-36MR | [`borderleaf1_ptx10001-36mr.conf`](configuration/conf/borderleaf/borderleaf1_ptx10001-36mr.conf) | [`borderleaf2_ptx10001-36mr.conf`](configuration/conf/borderleaf/borderleaf2_ptx10001-36mr.conf) |
+| QFX5120-32C | [`borderleaf1_qfx5120-32c.conf`](configuration/conf/borderleaf/borderleaf1_qfx5120-32c.conf) | [`borderleaf2_qfx5120-32c.conf`](configuration/conf/borderleaf/borderleaf2_qfx5120-32c.conf) |
+| **QFX5130-32CD** *(canonical)* | [`borderleaf1_qfx5130-32cd.conf`](configuration/conf/borderleaf/borderleaf1_qfx5130-32cd.conf) | [`borderleaf2_qfx5130-32cd.conf`](configuration/conf/borderleaf/borderleaf2_qfx5130-32cd.conf) |
+| QFX5700 | [`borderleaf1_qfx5700.conf`](configuration/conf/borderleaf/borderleaf1_qfx5700.conf) | [`borderleaf2_qfx5700.conf`](configuration/conf/borderleaf/borderleaf2_qfx5700.conf) |
+
+> The spine configurations show borderleaf-facing port assignments wired to the **QFX5130-32CD** variant of the JVD lab. When deploying with a different border-leaf platform, only the spine's borderleaf-facing port number changes; the rest of the spine configuration is identical.

--- a/data_center/aidc/README.md
+++ b/data_center/aidc/README.md
@@ -26,18 +26,3 @@ A typical Juniper AI cluster uses a **rail-optimized stripe architecture** on th
 | [`aiml_multitenancy_backend/`](aiml_multitenancy_backend/) | Backend (GPU) | EVPN/VXLAN GPU Backend Fabric for Multitenancy (GPUaaS) |
 
 Frontend and storage fabric JVDs will be added as separate sibling folders following the same `aiml_<topic>_<fabric>/` naming pattern.
-
-## Repo conventions for this folder
-
-```
-aidc/
-├── README.md                              ← this file
-├── images/                                ← cross-JVD diagrams
-└── <jvd>/
-    ├── README.md                          ← per-JVD overview, devices, links
-    ├── images/                            ← per-JVD diagrams
-    └── configuration/conf/                ← Junos hierarchical configs (*.conf)
-        └── <role><n>_<platform>.conf     ← e.g. spine1_qfx5240-64od.conf
-```
-
-Configuration files use the Junos hierarchical (curly-brace) format, named `<role><n>_<platform>.conf` so they sort by role and self-document the device model.


### PR DESCRIPTION
Closes out two leftover parent-README tweaks that were stashed during the data_center/adc/ reorganization.

## data_center/adc/3stage_dc/README.md
Rewrite the stub README into the standard JVD parent-README format:
- Header + JVD landing page link
- Local reference architecture image (`images/3stage-architecture.png`)
- Hardware table covering the canonical QFX5130-32CD border leaf and the four validated alternative border-leaf platforms (ACX7100-48L, PTX10001-36MR, QFX5120-32C, QFX5700)
- Common configuration table (spines, ESI leaves, single-homed server leaf)
- Border-leaf configuration table per validated platform
- Note explaining how the spine config relates to the canonical border-leaf variant

## data_center/aidc/README.md
Drop the internal "Repo conventions for this folder" section so the parent README stays customer-facing.

All file links resolve against the on-disk layout.