### PR TITLE
CHANGELOG: 2026-05-12 entry for JVD Portal launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ Release notes for the Juniper Validated Design (JVD) configuration repository.
 
 ---
 
+## 2026-05-12
+
+The JVD Portal — a public web catalog for browsing every Juniper
+Validated Design in this repository — is live at
+<https://juniper.github.io/jvd/portal/>.
+
+### New content
+
+- **JVD Portal** — A new public website at
+  <https://juniper.github.io/jvd/portal/> that catalogs all the
+  Juniper Validated Designs in this repository. Browse and filter by
+  area (Data Center, Enterprise WAN, Optical, Security, Service
+  Provider, Automation), platform family, and Junos vs Junos EVO. Each
+  card links straight back to the JVD's folder on GitHub for the full
+  README, reference diagrams, and per-device configurations. The
+  portal is a static site sourced from
+  [`portal/`](portal/) and republished automatically whenever that
+  directory changes on `main`.
+
+### What this means for you
+
+- Visit <https://juniper.github.io/jvd/portal/> to browse the full JVD
+  catalog in one place.
+- Use the area / platform / OS filters to narrow down to designs
+  relevant to your network.
+- Bookmark either the portal card or the linked GitHub folder — both
+  stay in sync with this repository.
+- If a JVD looks miscategorized or missing, open an issue or PR
+  against [`portal/src/data/jvds.json`](portal/src/data/jvds.json).
+
+<details>
+<summary>By the numbers</summary>
+
+| Area | Files added |
+| --- | ---: |
+| `portal/` (web app, configs, assets) | 65 |
+| `portal/scripts/` (catalog tooling) | 4 |
+| `.github/workflows/` (deploy pipeline) | 1 |
+| **Total** | **70** |
+
+</details>
+
+---
+
 ## 2026-05-11
 
 A new Service Provider JVD landed end-to-end this week, along with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,28 @@ Validated Design in this repository — is live at
   portal is a static site sourced from
   [`portal/`](portal/) and republished automatically whenever that
   directory changes on `main`.
+- **Catalog generator with Juniper API integration** — The portal's
+  catalog is now produced by
+  [`portal/scripts/generate-catalog.sh`](portal/scripts/generate-catalog.sh),
+  which pulls each JVD's authoritative validated-platforms list
+  directly from Juniper's documentation API
+  (`getAllPlatformNReleaseDetails4JvdId`) where a JVD ID is mapped in
+  [`portal/scripts/jvd-id-map.json`](portal/scripts/jvd-id-map.json),
+  and falls back to scanning the JVD's README and per-device configs
+  otherwise. Responses are cached locally in
+  [`portal/scripts/jvd-platforms-cache.json`](portal/scripts/jvd-platforms-cache.json)
+  so portal builds stay fully offline. Run with `--refresh` to pull
+  the latest API data and `--check` to verify the catalog is up to
+  date. Currently 19 of 20 JVDs are sourced from the API.
 
 ### What this means for you
 
 - Visit <https://juniper.github.io/jvd/portal/> to browse the full JVD
   catalog in one place.
 - Use the area / platform / OS filters to narrow down to designs
-  relevant to your network.
+  relevant to your network. Platform and OS chips reflect the same
+  validated platform lists published in each JVD's official Juniper
+  documentation, so what you filter on is what was actually tested.
 - Bookmark either the portal card or the linked GitHub folder — both
   stay in sync with this repository.
 - If a JVD looks miscategorized or missing, open an issue or PR
@@ -40,7 +55,7 @@ Validated Design in this repository — is live at
 | Area | Files added |
 | --- | ---: |
 | `portal/` (web app, configs, assets) | 65 |
-| `portal/scripts/` (catalog tooling) | 4 |
+| `portal/scripts/` (catalog tooling — generator, ID map, API cache) | 4 |
 | `.github/workflows/` (deploy pipeline) | 1 |
 | **Total** | **70** |
 


### PR DESCRIPTION
Adds a 2026-05-12 release-notes entry for the JVD Portal launch at https://juniper.github.io/jvd/portal/.

Covers the work landed in PRs #72 (portal init + GH Pages deploy workflow) and #73 (sync script).

Customer-facing focus: what the portal is, how to use it, and how to suggest fixes.