### PR TITLE
Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Juniper Validated Designs documentation
+    url: https://www.juniper.net/documentation/validated-designs/
+    about: Browse the published JVD documentation on juniper.net.
+  - name: Juniper Networks support
+    url: https://support.juniper.net/
+    about: For product support, licensing, or account issues, please use Juniper's official support channels — not this repo.

--- a/.github/ISSUE_TEMPLATE/jvd-content.yml
+++ b/.github/ISSUE_TEMPLATE/jvd-content.yml
@@ -1,0 +1,38 @@
+name: JVD content issue
+description: Report a problem with a specific JVD's configs, README, diagrams, or validation guidance.
+title: "[jvd] <jvd folder name>: "
+labels: ["jvd-content"]
+assignees:
+  - KB-x
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for issues with the JVD material itself —
+        wrong config, broken topology, missing platform, README typo,
+        etc. For problems with the portal site, use the **JVD Portal**
+        template instead.
+  - type: input
+    id: jvd
+    attributes:
+      label: Which JVD?
+      description: Folder path under the repo, e.g. `data_center/aidc/aiml_multitenancy_backend`.
+      placeholder: data_center/<area>/<jvd>
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem?
+      placeholder: e.g. The leaf-to-spine config in leaf_01.conf has a duplicate underlay BGP neighbor stanza.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested
+    attributes:
+      label: Suggested fix (optional)
+  - type: input
+    id: contact
+    attributes:
+      label: Your role (optional)
+      description: Helps us prioritize. e.g. customer SE, partner, internal Juniper.

--- a/.github/ISSUE_TEMPLATE/jvd-content.yml
+++ b/.github/ISSUE_TEMPLATE/jvd-content.yml
@@ -12,6 +12,8 @@ body:
         wrong config, broken topology, missing platform, README typo,
         etc. For problems with the portal site, use the **JVD Portal**
         template instead.
+
+        _Goes to Kevin Brown (@KB-x) for triage._
   - type: input
     id: jvd
     attributes:

--- a/.github/ISSUE_TEMPLATE/portal-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-bug.yml
@@ -12,6 +12,8 @@ body:
         <https://juniper.github.io/jvd/portal/>.
         For issues with a specific JVD's content (configs, READMEs,
         diagrams), please use the **JVD content issue** template instead.
+
+        _Goes to Kevin Brown (@KB-x) for triage._
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/portal-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-bug.yml
@@ -1,0 +1,38 @@
+name: JVD Portal — bug or request
+description: Report a problem with the JVD Portal site or request a feature.
+title: "[portal] "
+labels: ["portal"]
+assignees:
+  - KB-x
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the JVD Portal at
+        <https://juniper.github.io/jvd/portal/>.
+        For issues with a specific JVD's content (configs, READMEs,
+        diagrams), please use the **JVD content issue** template instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What were you doing and what went wrong?
+      placeholder: e.g. Filtering by PTX10001-36MR returns no results, but I expected the SRv6 JVD to appear.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: false
+  - type: input
+    id: browser
+    attributes:
+      label: Browser / OS
+      placeholder: e.g. Safari 18 on macOS 15
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot (optional)
+      description: Drag & drop an image here if it helps.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -12,6 +12,8 @@ body:
         please use <https://support.juniper.net/> instead — this repo
         is for the validated-design content and the portal that
         catalogs it.
+
+        _Goes to Kevin Brown (@KB-x) for triage._
   - type: textarea
     id: question
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,25 @@
+name: Question
+description: Ask a question about a JVD or the portal.
+title: "[question] "
+labels: ["question"]
+assignees:
+  - KB-x
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For Juniper product support (licensing, RMA, account issues),
+        please use <https://support.juniper.net/> instead — this repo
+        is for the validated-design content and the portal that
+        catalogs it.
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (optional)
+      description: Any background that helps us answer — your goal, the JVD you're looking at, etc.


### PR DESCRIPTION
Sets up the repo's first Issue templates so portal users (and future JVD readers) have a structured way to report problems instead of staring at a blank issue form.

**Templates added** (`.github/ISSUE_TEMPLATE/`):

- `portal-bug.yml` — JVD Portal site bugs / requests
- `jvd-content.yml` — problems with a specific JVD's configs / README / diagrams
- `question.yml` — general Q&A

**`config.yml`** routes off-topic traffic away from the repo:

- Juniper docs link for users who want to read the JVDs on juniper.net
- support.juniper.net for product support / licensing / RMA

All three templates default-assign to @KB-x for initial triage; we can broaden as the team picks up the rotation.

Companion to PR #77, which adds the "Report a problem" link in the portal footer that points to `/issues/new/choose`.