### PR TITLE
feat(portal): add BYOAI model tips per launch tile

### DIFF
--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -155,6 +155,7 @@ export default function ByoaiSection() {
               <AiTile
                 name="Claude"
                 description="Anthropic's web app. Best for nuanced config refactoring and long, multi-turn JVD walk-throughs."
+                tip="Tip: pick Haiku 4.5 for the fastest experience."
                 href={claudeUrl}
                 disabled={!selected}
                 logo={<ClaudeLogo />}
@@ -163,6 +164,7 @@ export default function ByoaiSection() {
               <AiTile
                 name="ChatGPT"
                 description="OpenAI's web app. Wide reach and good for quick, single-shot config snippets."
+                tip="Tip: use Instant mode for the fastest experience."
                 href={chatGptUrl}
                 disabled={!selected}
                 logo={<ChatGptLogo />}
@@ -185,6 +187,7 @@ export default function ByoaiSection() {
 function AiTile({
   name,
   description,
+  tip,
   href,
   disabled,
   logo,
@@ -192,6 +195,7 @@ function AiTile({
 }: {
   name: string;
   description: string;
+  tip?: string;
   href: string;
   disabled: boolean;
   logo: React.ReactNode;
@@ -214,6 +218,9 @@ function AiTile({
         </div>
       </div>
       <p className="mt-3 text-xs leading-relaxed text-muted-foreground">{description}</p>
+      {tip && (
+        <p className="mt-2 text-[11px] italic leading-relaxed text-primary/80">{tip}</p>
+      )}
       <div className="mt-4 flex-1" />
       <div
         className={


### PR DESCRIPTION
## Why

Hands-on testing showed two model choices dramatically improve BYOAI launch quality and speed:
- **Claude Haiku 4.5** — fast and reliably prints the full menu without summarizing
- **ChatGPT Instant mode** — fastest path; recent model versions reliably show the menu

Surface that as a one-line tip under each launch tile so users get the best experience by default.

## What

- `ByoaiSection.tsx` — `AiTile` component now accepts an optional `tip` prop, rendered as a small italic accent line below the description
- Claude tile: "Tip: pick Haiku 4.5 for the fastest experience."
- ChatGPT tile: "Tip: use Instant mode for the fastest experience."

## Expected impact

- Cold-launch experience drops from ~1 min (default thinking models) to ~5–15 s when users follow the tip
- Menu visibility improves for new users who don't know which mode to pick

## Test

- `bun run build` clean
- TS no errors