### PR TITLE
chore: add PR template and release-notes config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+  Juniper/jvd PR template.
+  Fill in the sections below; delete any section that doesn't apply.
+  Keep the body externally-safe — every push notifies watchers and the
+  squashed PR body becomes part of the public release notes.
+-->
+
+## What's New
+<!-- One-line headline matching the PR title, then 2-4 bullets of
+     user-visible changes. Customer / watcher voice. -->
+
+
+
+## Why
+<!-- Problem statement and context. Include concrete numbers if
+     this is a perf or scale change. -->
+
+
+
+## Details
+<!-- Changes grouped by file or component, for reviewers. Include
+     subtle refactors or behavior changes that aren't obvious from
+     the diff. -->
+
+
+
+## Testing
+<!-- What was verified locally — commands run, manual checks,
+     screenshots for UI changes. -->
+
+
+
+<!--
+## Notes
+Optional. Use only when applicable:
+  - Source-of-truth (e.g. generated vs hand-edited files)
+  - Breaking changes / migration steps
+  - Follow-up work intentionally deferred to a later PR
+-->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,44 @@
+# Configuration for GitHub's auto-generated release notes.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Categories group merged PRs by LABEL (not by conventional-commit
+# title prefix). Apply the matching label to each PR — this can be
+# done manually or via a workflow that reads the PR title.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+  categories:
+    - title: ✨ Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - fix
+        - bug
+    - title: ⚡ Performance
+      labels:
+        - perf
+        - performance
+    - title: 📝 Documentation
+      labels:
+        - docs
+        - documentation
+    - title: ♻️ Refactor
+      labels:
+        - refactor
+    - title: 🧹 Chores & Tooling
+      labels:
+        - chore
+        - ci
+        - build
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## What's New
- New `.github/pull_request_template.md` pre-fills the PR composer with a "What's New / Why / Details / Testing" structure
- New `.github/release.yml` configures GitHub's auto-generated release notes to group merged PRs by category labels (Features / Bug Fixes / Performance / Documentation / Refactor / Chores / Security)

## Why
Standardizing the PR description format makes it easier for watchers to scan email notifications and gives customers a consistent voice across release notes. The release-notes config sets up the scaffolding so we can start tagging milestones (CalVer `vYYYY.MM`) without writing release bodies by hand later.

## Details
- `pull_request_template.md` — five sections (What's New, Why, Details, Testing, optional Notes). HTML comments explain each section and remind contributors that the body is externally-visible.
- `release.yml` — eight grouped categories that map to common conventional-commit prefixes (`feat`, `fix`, `perf`, `docs`, `refactor`, `chore`, `security`) plus a catch-all "Other Changes" bucket. Excludes anything labeled `ignore-for-release` or `dependencies` (e.g. Dependabot noise).

## Testing
- Verified template renders correctly by previewing the markdown locally
- `release.yml` schema follows the GitHub-documented format

## Notes
- Release-notes grouping requires PRs to carry the matching label (`feat`, `fix`, etc.). Today that means applying labels manually. A small follow-up workflow could auto-label from the conventional-commit title prefix — happy to ship that as a separate PR if useful.
- This PR doesn't tag a release; first CalVer tag (`v2026.05`) is a separate decision.
