### PR TITLE
fix(aidc): reclassify aiml snip library as Junos EVO + add README

### DIFF
--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/README.md
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/README.md
@@ -1,0 +1,183 @@
+# AI/ML Multitenancy Backend — Configuration Snippets
+
+Reusable, templated config fragments extracted from the sanitized JVD
+configurations under [conf/](../conf/). Each snippet contains:
+
+- A 5-section header (Topic, Variant, Seen on, Highlights, Pair with, Variables).
+- `$VARIABLE` placeholders for tunable values; see [_variables.md](_variables.md)
+  for the master glossary.
+
+## Topology
+
+![Tenant isolation with EVPN Type-5 IP-VRFs and per-tenant VNIs](../../images/multitenancy-vni-separation.png)
+
+> Refer to the topology when reading any snippet — every device in this JVD is a
+> **Juniper QFX5240-64OD** running **Junos OS Evolved**. Two device roles appear
+> in the headers: leafs (`GPU-R{1,2}-L{1,2}`, AS 208–211) and spines
+> (`spine{1,2,3,4}`, AS 108–111).
+
+## Layout
+
+```
+snips/
+├── _variables.md
+└── evo/
+    ├── bootstrap/      # System base, FPC buffer monitor, gRPC TLS cert
+    ├── interfaces/     # Fabric P2P 400G breakout, AC sub-ports, IRB anycast, lo0
+    ├── transport/      # eBGP underlay, eBGP EVPN overlay, ECMP DLB flowlet, IPv6 RA
+    ├── policy/         # CLOS loop-prevention, redistribution, communities, PFE LB
+    ├── cos/            # RoCEv2 lossless (DSCP, PFC priority 3, ECN, schedulers)
+    ├── services/       # Per-tenant VRF with EVPN type-5 ip-prefix-routes
+    └── oam/            # LLDP, L2-learning telemetry, RSTP-disable
+```
+
+There is no `junos/` sibling tree — all eight devices in this JVD run Junos OS
+Evolved, so every snip lives under `evo/` and carries a
+`Variant: Evolved-OS (EVO)` header tag.
+
+## Snippet headers — `Seen on:` and `Pair with:`
+
+Every snippet starts with a C-style comment header containing two
+cross-reference fields:
+
+- **`Seen on:`** — every device in [`../conf/`](../conf/) that contains this
+  exact pattern, split by OS family. Because all devices here are EVO, the
+  `Junos:` line is always `(none)` and the `EVO:` line lists the specific
+  leafs / spines / both that carry the pattern.
+- **`Pair with:`** — other snippets in this library that work together to
+  deliver the same end-to-end function. All `Pair with:` references are
+  reciprocal.
+
+## LEAF vs SPINE combined snips
+
+Six snips contain both leaf-role and spine-role syntactic variants in a single
+file, delimited by clearly-marked sections:
+
+```
+/* --- LEAF variant --- */
+... leaf-side body ...
+
+/* --- SPINE variant --- */
+... spine-side body ...
+```
+
+Pick the section matching the role you're configuring at deploy time. This
+keeps the dependency graph (`Pair with:` references) unified across roles
+rather than fragmenting into two parallel snip trees.
+
+The combined snips are:
+
+- [evo/transport/bgp-ebgp-fabric-underlay.conf](evo/transport/bgp-ebgp-fabric-underlay.conf)
+- [evo/transport/bgp-ebgp-evpn-overlay.conf](evo/transport/bgp-ebgp-evpn-overlay.conf)
+- [evo/transport/routing-options-ecmp-frr.conf](evo/transport/routing-options-ecmp-frr.conf)
+- [evo/policy/clos-loop-prevention.conf](evo/policy/clos-loop-prevention.conf)
+- [evo/policy/allpodnetworks-direct-redistribution.conf](evo/policy/allpodnetworks-direct-redistribution.conf)
+- [evo/policy/community-definitions.conf](evo/policy/community-definitions.conf)
+
+## Templated values — `$VAR` placeholders
+
+Identifiers that vary per deployment (loopback addresses, BGP AS numbers,
+tenant VNIs, attachment-circuit interfaces, anycast MAC, etc.) appear as
+`$VAR` placeholders in the body of every snippet. JVD-wide constants
+(forwarding-class names, scheduler-map names, DSCP code-points, the
+`mgmt_junos` instance name) are left literal because they ARE the
+abstraction the JVD documents.
+
+Each snippet header includes a `Variables:` section listing the placeholders
+it uses, with example values from the device the snippet was extracted from.
+See [`_variables.md`](_variables.md) for the full glossary.
+
+The leading `/* ... */` header block is treated as documentation —
+placeholder text inside the header survives rendering verbatim, so the doc
+remains readable in both source and rendered form.
+
+To render a snippet with concrete values:
+
+```bash
+~/git-scripts/snips_render.py evo/transport/bgp-ebgp-fabric-underlay.conf vars.json > rendered.conf
+```
+
+To list every placeholder a snippet uses:
+
+```bash
+~/git-scripts/snips_render.py --extract evo/transport/bgp-ebgp-fabric-underlay.conf
+```
+
+## Snip index
+
+### Bootstrap
+
+| Snip | Purpose |
+|---|---|
+| [evo/bootstrap/system-grpc-netconf.conf](evo/bootstrap/system-grpc-netconf.conf) | System base — netconf/SSH, gRPC extension-service over TLS, mgmt instance |
+| [evo/bootstrap/chassis-buffer-monitor.conf](evo/bootstrap/chassis-buffer-monitor.conf) | Per-FPC traffic-manager buffer-monitor for AI/RoCE fabric visibility |
+| [evo/bootstrap/security-grpc-cert.conf](evo/bootstrap/security-grpc-cert.conf) | Local TLS certificate for the gRPC extension-service listener |
+
+### Interfaces
+
+| Snip | Purpose |
+|---|---|
+| [evo/interfaces/fabric-p2p-400g-breakout.conf](evo/interfaces/fabric-p2p-400g-breakout.conf) | 400G breakout to 2x sub-ports for fabric P2P /31 links (MTU 9216/9170) |
+| [evo/interfaces/tenant-gpu-server-link.conf](evo/interfaces/tenant-gpu-server-link.conf) | Per-tenant GPU-server-facing 400G sub-port with dual-stack /31 |
+| [evo/interfaces/irb-tenant-gateway.conf](evo/interfaces/irb-tenant-gateway.conf) | IRB anycast gateway per tenant — MTU 9000, shared virtual MAC |
+| [evo/interfaces/loopback-leaf.conf](evo/interfaces/loopback-leaf.conf) | Leaf loopback — primary unit (underlay/overlay) + per-VRF units |
+| [evo/interfaces/loopback-spine.conf](evo/interfaces/loopback-spine.conf) | Spine loopback — single unit serving both underlay router-id and EVPN overlay |
+
+### Transport
+
+| Snip | Purpose |
+|---|---|
+| [evo/transport/bgp-ebgp-fabric-underlay.conf](evo/transport/bgp-ebgp-fabric-underlay.conf) | eBGP fabric underlay — leaf↔spine /31 sessions, multipath, BFD 1s *(LEAF + SPINE variants)* |
+| [evo/transport/bgp-ebgp-evpn-overlay.conf](evo/transport/bgp-ebgp-evpn-overlay.conf) | eBGP EVPN overlay — loopback-to-loopback, multihop, signaling loops 2 *(LEAF + SPINE variants)* |
+| [evo/transport/routing-options-ecmp-frr.conf](evo/transport/routing-options-ecmp-frr.conf) | Routing-options — router-id, AS, ECMP fast-reroute, chained-composite-NH *(LEAF + SPINE variants)* |
+| [evo/transport/ecmp-dlb-flowlet.conf](evo/transport/ecmp-dlb-flowlet.conf) | ECMP DLB (Dynamic Load Balancing) flowlet — AI fabric load spreading |
+| [evo/transport/router-advertisement.conf](evo/transport/router-advertisement.conf) | IPv6 Router Advertisement on tenant GPU-server-facing interfaces |
+
+### Policy
+
+| Snip | Purpose |
+|---|---|
+| [evo/policy/clos-loop-prevention.conf](evo/policy/clos-loop-prevention.conf) | eBGP CLOS loop-prevention — spine tags outbound, leaf rejects tagged inbound *(LEAF + SPINE variants)* |
+| [evo/policy/allpodnetworks-direct-redistribution.conf](evo/policy/allpodnetworks-direct-redistribution.conf) | AllPodNetworks — direct-route redistribution into BGP with community tagging *(LEAF + SPINE variants)* |
+| [evo/policy/community-definitions.conf](evo/policy/community-definitions.conf) | BGP community definitions — tier markers, default redistribution, per-tenant *(LEAF + SPINE variants)* |
+| [evo/policy/tenant-community-export.conf](evo/policy/tenant-community-export.conf) | Per-tenant export policies — `AllPodNetworks-tenant-N` + `BGP-AOS-Policy-tenant-N` |
+| [evo/policy/pfe-load-balance.conf](evo/policy/pfe-load-balance.conf) | PFE per-packet load-balance policy (referenced by forwarding-table export) |
+
+### CoS
+
+| Snip | Purpose |
+|---|---|
+| [evo/cos/rdma-rocev2-lossless.conf](evo/cos/rdma-rocev2-lossless.conf) | RoCEv2 lossless CoS — DSCP classifier, PFC priority 3, ECN, lossless buffers, schedulers |
+
+### Services
+
+| Snip | Purpose |
+|---|---|
+| [evo/services/evpn-vrf-ip-prefix-routes.conf](evo/services/evpn-vrf-ip-prefix-routes.conf) | Per-tenant VRF with EVPN type-5 ip-prefix-routes (VXLAN encap) |
+
+### OAM
+
+| Snip | Purpose |
+|---|---|
+| [evo/oam/lldp-interface-all.conf](evo/oam/lldp-interface-all.conf) | LLDP enabled on all interfaces with descriptive port-id reporting |
+| [evo/oam/l2-learning-telemetry.conf](evo/oam/l2-learning-telemetry.conf) | L2-learning telemetry — stream remote MAC entries via gRPC |
+| [evo/oam/rstp-disable.conf](evo/oam/rstp-disable.conf) | RSTP disabled on spine — pure L3 device, no L2 loop protection needed |
+
+## Scope
+
+Snippets are **excerpts**, not standalone configs. They:
+
+- Preserve their original Junos hierarchy (e.g. an `evo/services/evpn-vrf-ip-prefix-routes.conf`
+  snippet contains the `routing-instances { … }` wrapper so it's syntactically
+  valid in context).
+- Are extracted from real, validated config in [`../conf/`](../conf/).
+- Are **not exhaustive** — only the most pedagogically valuable patterns are
+  extracted. The full configurations remain in [`../conf/`](../conf/) for
+  complete reference.
+
+## Pairing with documentation
+
+The patterns shown here are described and validated in the
+[AI Data Center Multitenancy with EVPN/VXLAN JVD](https://www.juniper.net/documentation/us/en/software/jvd/jvd-ai-dc-evpn-multitenancy/index.html)
+and specifically the
+[GPU Backend Fabric design page](https://www.juniper.net/documentation/us/en/software/jvd/jvd-ai-dc-evpn-multitenancy/evpnvxlan_gpu_backend_fabric_gpu_multitenancy.html).

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/_variables.md
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/_variables.md
@@ -1,7 +1,7 @@
 # Snip variable glossary
 
 This file documents every `$VARIABLE` used in the templated snips under
-`junos/`. Variables are alphabetical; the **Used in** column lists which
+`evo/`. Variables are alphabetical; the **Used in** column lists which
 snip categories reference each one.
 
 | Variable | Meaning | Typical example | Used in |

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/bootstrap/chassis-buffer-monitor.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/bootstrap/chassis-buffer-monitor.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   FPC traffic-manager buffer-monitor for AI/RoCE fabric visibility
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Enables per-FPC buffer-occupancy telemetry on QFX5240 — required to
@@ -12,7 +13,7 @@
  *  - Single-FPC pizza-box; replicate the `fpc N` block per slot on chassis
  *
  * Pair with:
- *  - junos/cos/rdma-rocev2-lossless.conf  (the buffer partitions being monitored)
+ *  - evo/cos/rdma-rocev2-lossless.conf  (the buffer partitions being monitored)
  */
 chassis {
     fpc 0 {

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/bootstrap/security-grpc-cert.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/bootstrap/security-grpc-cert.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Local TLS certificate for the gRPC extension-service listener
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Holds the `aos_grpc` cert/key pair referenced by the gRPC SSL stanza
@@ -12,7 +13,7 @@
  *    block references it by literal name
  *
  * Pair with:
- *  - junos/bootstrap/system-grpc-netconf.conf  (consumer of this certificate)
+ *  - evo/bootstrap/system-grpc-netconf.conf  (consumer of this certificate)
  *
  * Variables (example values from leaf1_qfx5240-64od):
  *   $GRPC_CERT_PEM   e.g. (PEM-encoded cert+key blob, masked at runtime)

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/bootstrap/system-grpc-netconf.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/bootstrap/system-grpc-netconf.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   System base — netconf/SSH, gRPC extension-service over TLS, mgmt instance
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - gRPC request-response listener on port 32767 with TLS, anchored to
@@ -15,7 +16,7 @@
  *  - Pairs with security/certificates for the `aos_grpc` local-cert
  *
  * Pair with:
- *  - junos/bootstrap/security-grpc-cert.conf  (provides the local-certificate)
+ *  - evo/bootstrap/security-grpc-cert.conf  (provides the local-certificate)
  *
  * Variables (example values from leaf1_qfx5240-64od):
  *   $HOSTNAME      e.g. GPU-R1-L1

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/cos/rdma-rocev2-lossless.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/cos/rdma-rocev2-lossless.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   RoCEv2 lossless CoS — DSCP classifier, PFC, ECN, lossless buffers, schedulers
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Two forwarding-classes carry the GPU traffic:
@@ -25,7 +26,7 @@
  *    scheduler-map to every et-* port automatically — no per-port repetition
  *
  * Pair with:
- *  - junos/bootstrap/chassis-buffer-monitor.conf  (telemetry for these buffers)
+ *  - evo/bootstrap/chassis-buffer-monitor.conf  (telemetry for these buffers)
  */
 class-of-service {
     classifiers {

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/fabric-p2p-400g-breakout.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/fabric-p2p-400g-breakout.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   400G breakout to 2x sub-ports for fabric P2P /31 links (MTU 9216/9170)
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Two-step pattern: parent port declares `number-of-sub-ports 2` +
@@ -14,7 +15,7 @@
  *  - No `family inet6` on fabric links (IPv6 is tenant-side only)
  *
  * Pair with:
- *  - junos/transport/bgp-ebgp-fabric-underlay.conf  (consumes these /31s as BGP local-addresses)
+ *  - evo/transport/bgp-ebgp-fabric-underlay.conf  (consumes these /31s as BGP local-addresses)
  *
  * Variables (example values from leaf1_qfx5240-64od et-0/0/0):
  *   $PHY_PORT      e.g. et-0/0/0

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/irb-tenant-gateway.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/irb-tenant-gateway.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   IRB anycast gateway per tenant — MTU 9000, shared virtual MAC
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - One IRB unit per tenant subnet; the SAME virtual MAC (00:1c:73:00:00:01)
@@ -15,8 +16,8 @@
  *    convention and stick to it across the fabric
  *
  * Pair with:
- *  - junos/services/evpn-vrf-ip-prefix-routes.conf  (VRFs that bind these IRB units)
- *  - junos/interfaces/loopback-leaf.conf  (companion lo0 units per VRF)
+ *  - evo/services/evpn-vrf-ip-prefix-routes.conf  (VRFs that bind these IRB units)
+ *  - evo/interfaces/loopback-leaf.conf  (companion lo0 units per VRF)
  *
  * Variables (example values from leaf1_qfx5240-64od irb.2 / tenant-1):
  *   $IRB_UNIT          e.g. 2

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/loopback-leaf.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/loopback-leaf.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Leaf loopback — primary unit (underlay/overlay) + per-VRF units
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - unit 0 is the device's underlay router-id and the EVPN overlay
@@ -15,9 +16,9 @@
  *    convention (see irb-tenant-gateway snip)
  *
  * Pair with:
- *  - junos/interfaces/irb-tenant-gateway.conf  (per-tenant IRB units)
- *  - junos/services/evpn-vrf-ip-prefix-routes.conf  (VRFs reference these lo0.N units)
- *  - junos/transport/bgp-ebgp-evpn-overlay.conf  (uses lo0.0 as local-address)
+ *  - evo/interfaces/irb-tenant-gateway.conf  (per-tenant IRB units)
+ *  - evo/services/evpn-vrf-ip-prefix-routes.conf  (VRFs reference these lo0.N units)
+ *  - evo/transport/bgp-ebgp-evpn-overlay.conf  (uses lo0.0 as local-address)
  *
  * Variables (example values from leaf1_qfx5240-64od):
  *   $LO0_V4            e.g. 10.0.1.9/32

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/loopback-spine.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/loopback-spine.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Spine loopback — single unit serving both underlay router-id and EVPN overlay
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Spines have NO tenant VRFs (pure underlay + EVPN route-relay), so a
@@ -12,8 +13,8 @@
  *    for future overlay AFs; underlay BGP today is v4-only
  *
  * Pair with:
- *  - junos/transport/bgp-ebgp-evpn-overlay.conf  (uses lo0.0 as local-address)
- *  - junos/transport/routing-options-ecmp-frr.conf  (router-id derived from lo0.0)
+ *  - evo/transport/bgp-ebgp-evpn-overlay.conf  (uses lo0.0 as local-address)
+ *  - evo/transport/routing-options-ecmp-frr.conf  (router-id derived from lo0.0)
  *
  * Variables (example values from spine1_qfx5240-64od):
  *   $LO0_V4    e.g. 10.0.0.8/32

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/tenant-gpu-server-link.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/interfaces/tenant-gpu-server-link.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Per-tenant GPU-server-facing 400G sub-port with dual-stack /31
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - Each GPU host attaches via 400G breakout sub-ports; each sub-port is
@@ -16,8 +17,8 @@
  *    9000B host frames pass without fragmentation across the entire path
  *
  * Pair with:
- *  - junos/services/evpn-vrf-ip-prefix-routes.conf  (the VRF that owns this interface)
- *  - junos/transport/router-advertisement.conf  (IPv6 GUA delivery)
+ *  - evo/services/evpn-vrf-ip-prefix-routes.conf  (the VRF that owns this interface)
+ *  - evo/transport/router-advertisement.conf  (IPv6 GUA delivery)
  *
  * Variables (example values from leaf1_qfx5240-64od et-0/0/12:0):
  *   $AC_INTF       e.g. et-0/0/12:0

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/oam/l2-learning-telemetry.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/oam/l2-learning-telemetry.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   L2-learning telemetry — stream remote MAC entries via gRPC
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - Enables export of remotely-learned MAC entries (i.e. EVPN-imported
@@ -12,7 +13,7 @@
  *  - Leaf-only — spines don't terminate EVPN MAC entries in this design
  *
  * Pair with:
- *  - junos/bootstrap/system-grpc-netconf.conf  (the gRPC channel that carries this telemetry)
+ *  - evo/bootstrap/system-grpc-netconf.conf  (the gRPC channel that carries this telemetry)
  */
 protocols {
     l2-learning {

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/oam/lldp-interface-all.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/oam/lldp-interface-all.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   LLDP enabled on all interfaces with descriptive port-id reporting
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - `port-id-subtype interface-name` makes the advertised LLDP port-id

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/oam/rstp-disable.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/oam/rstp-disable.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   RSTP disabled on spine — pure L3 device, no L2 loop protection needed
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Spines in this AI/ML CLOS are pure L3 (no IRB, no bridge-domain,

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/allpodnetworks-direct-redistribution.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/allpodnetworks-direct-redistribution.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   AllPodNetworks — direct-route redistribution into BGP with community tagging
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Redistributes locally-attached IPv4 + IPv6 direct routes into BGP
@@ -14,12 +15,12 @@
  *    first, then accepts everything else from `protocol bgp` (spine)
  *    or only EVPN-derived /32-/32 + /128-/128 host routes (leaf)
  *  - Leafs use the same skeleton but extend it with per-tenant
- *    variants (see junos/policy/tenant-community-export.conf)
+ *    variants (see evo/policy/tenant-community-export.conf)
  *
  * Pair with:
- *  - junos/policy/community-definitions.conf  (DEFAULT_DIRECT_V4 / V6)
- *  - junos/policy/tenant-community-export.conf  (per-tenant variants)
- *  - junos/transport/bgp-ebgp-fabric-underlay.conf  (consumes BGP-AOS-Policy)
+ *  - evo/policy/community-definitions.conf  (DEFAULT_DIRECT_V4 / V6)
+ *  - evo/policy/tenant-community-export.conf  (per-tenant variants)
+ *  - evo/transport/bgp-ebgp-fabric-underlay.conf  (consumes BGP-AOS-Policy)
  */
 
 /* --- SPINE variant (simpler — accepts all bgp-learned routes downstream) --- */

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/clos-loop-prevention.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/clos-loop-prevention.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   eBGP CLOS loop-prevention — spine tags outbound, leaf rejects tagged inbound
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Standard 3-stage CLOS loop-prevention without relying on AS-path filtering
@@ -16,9 +17,9 @@
  *    sides reference the same community values
  *
  * Pair with:
- *  - junos/policy/community-definitions.conf  (FROM_SPINE_EVPN_TIER / FROM_SPINE_FABRIC_TIER)
- *  - junos/transport/bgp-ebgp-fabric-underlay.conf  (consumer of LEAF_TO_SPINE_FABRIC_OUT / SPINE_TO_LEAF_FABRIC_OUT)
- *  - junos/transport/bgp-ebgp-evpn-overlay.conf   (consumer of LEAF_TO_SPINE_EVPN_OUT / SPINE_TO_LEAF_EVPN_OUT)
+ *  - evo/policy/community-definitions.conf  (FROM_SPINE_EVPN_TIER / FROM_SPINE_FABRIC_TIER)
+ *  - evo/transport/bgp-ebgp-fabric-underlay.conf  (consumer of LEAF_TO_SPINE_FABRIC_OUT / SPINE_TO_LEAF_FABRIC_OUT)
+ *  - evo/transport/bgp-ebgp-evpn-overlay.conf   (consumer of LEAF_TO_SPINE_EVPN_OUT / SPINE_TO_LEAF_EVPN_OUT)
  */
 
 /* --- SPINE variant (deploy on spine-role devices) --- */

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/community-definitions.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/community-definitions.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   BGP community definitions — tier markers, default redistribution, per-tenant
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - FROM_SPINE_*_TIER (0:14, 0:15) = CLOS loop-prevention markers stamped
@@ -20,9 +21,9 @@
  *    only the tier-specific DEFAULT_DIRECT lines per role
  *
  * Pair with:
- *  - junos/policy/clos-loop-prevention.conf  (consumer of FROM_SPINE_*_TIER)
- *  - junos/policy/allpodnetworks-direct-redistribution.conf  (consumer of DEFAULT_DIRECT_V4/V6)
- *  - junos/policy/tenant-community-export.conf  (consumer of TENANT-N_*)
+ *  - evo/policy/clos-loop-prevention.conf  (consumer of FROM_SPINE_*_TIER)
+ *  - evo/policy/allpodnetworks-direct-redistribution.conf  (consumer of DEFAULT_DIRECT_V4/V6)
+ *  - evo/policy/tenant-community-export.conf  (consumer of TENANT-N_*)
  *
  * Variables (example values from leaf1_qfx5240-64od / spine1_qfx5240-64od):
  *   $LOCAL_TIER_TAG    e.g. 5  (leaf) or 1 (spine)

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/pfe-load-balance.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/pfe-load-balance.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   PFE per-packet load-balance policy (referenced by forwarding-table export)
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Tells the FIB to install per-packet load-balance next-hops — the
@@ -13,8 +14,8 @@
  *    paths it can shift flows between
  *
  * Pair with:
- *  - junos/transport/routing-options-ecmp-frr.conf  (forwarding-table export PFE-LB)
- *  - junos/transport/ecmp-dlb-flowlet.conf  (the actual hashing behavior)
+ *  - evo/transport/routing-options-ecmp-frr.conf  (forwarding-table export PFE-LB)
+ *  - evo/transport/ecmp-dlb-flowlet.conf  (the actual hashing behavior)
  */
 policy-options {
     policy-statement PFE-LB {

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/tenant-community-export.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/policy/tenant-community-export.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Per-tenant export policies — AllPodNetworks-tenant-N + BGP-AOS-Policy-tenant-N
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - One pair of policies per tenant VRF — they're referenced by the
@@ -19,8 +20,8 @@
  *    storage VRF leaked into tenant-N via auto-export)
  *
  * Pair with:
- *  - junos/policy/community-definitions.conf  (TENANT-N_COMMUNITY_V4/V6, NON-TENANT_COMMUNITY_V4/V6)
- *  - junos/services/evpn-vrf-ip-prefix-routes.conf  (consumer of these per-tenant export policies)
+ *  - evo/policy/community-definitions.conf  (TENANT-N_COMMUNITY_V4/V6, NON-TENANT_COMMUNITY_V4/V6)
+ *  - evo/services/evpn-vrf-ip-prefix-routes.conf  (consumer of these per-tenant export policies)
  *
  * Variables (example values from leaf1_qfx5240-64od / tenant-1):
  *   $TENANT_TAG          e.g. tenant-1   (or "non-tenant")

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/services/evpn-vrf-ip-prefix-routes.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/services/evpn-vrf-ip-prefix-routes.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Per-tenant VRF with EVPN type-5 ip-prefix-routes (VXLAN encap)
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - Pure L3 VXLAN-EVPN multi-tenancy — each tenant is a `vrf` with
@@ -24,11 +25,11 @@
  *    plus the matching lo0.N unit (router-id anchor for EVPN)
  *
  * Pair with:
- *  - junos/policy/tenant-community-export.conf  (BGP-AOS-Policy-tenant-N)
- *  - junos/interfaces/tenant-gpu-server-link.conf  (the AC sub-ports listed here)
- *  - junos/interfaces/loopback-leaf.conf  (the lo0.N units listed here)
- *  - junos/interfaces/irb-tenant-gateway.conf  (companion anycast-gateway IRBs)
- *  - junos/transport/bgp-ebgp-evpn-overlay.conf  (carries these type-5 routes)
+ *  - evo/policy/tenant-community-export.conf  (BGP-AOS-Policy-tenant-N)
+ *  - evo/interfaces/tenant-gpu-server-link.conf  (the AC sub-ports listed here)
+ *  - evo/interfaces/loopback-leaf.conf  (the lo0.N units listed here)
+ *  - evo/interfaces/irb-tenant-gateway.conf  (companion anycast-gateway IRBs)
+ *  - evo/transport/bgp-ebgp-evpn-overlay.conf  (carries these type-5 routes)
  *
  * Variables (example values from leaf1_qfx5240-64od / tenant-1):
  *   $TENANT_NAME    e.g. tenant-1

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/bgp-ebgp-evpn-overlay.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/bgp-ebgp-evpn-overlay.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   eBGP EVPN overlay — loopback-to-loopback, multihop, signaling loops 2
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - eBGP EVPN overlay rides on top of the inet-unicast underlay; sessions
@@ -22,10 +23,10 @@
  *  - Deploy LEAF or SPINE variant per role
  *
  * Pair with:
- *  - junos/transport/bgp-ebgp-fabric-underlay.conf  (companion underlay; this snip carries the shared bgp-level knobs)
- *  - junos/policy/clos-loop-prevention.conf  (LEAF_TO_SPINE_EVPN_OUT / SPINE_TO_LEAF_EVPN_OUT)
- *  - junos/interfaces/loopback-leaf.conf  /  junos/interfaces/loopback-spine.conf
- *  - junos/services/evpn-vrf-ip-prefix-routes.conf  (consumer of EVPN type-5 routes)
+ *  - evo/transport/bgp-ebgp-fabric-underlay.conf  (companion underlay; this snip carries the shared bgp-level knobs)
+ *  - evo/policy/clos-loop-prevention.conf  (LEAF_TO_SPINE_EVPN_OUT / SPINE_TO_LEAF_EVPN_OUT)
+ *  - evo/interfaces/loopback-leaf.conf  /  evo/interfaces/loopback-spine.conf
+ *  - evo/services/evpn-vrf-ip-prefix-routes.conf  (consumer of EVPN type-5 routes)
  *
  * Variables (example values from leaf1_qfx5240-64od / spine1_qfx5240-64od):
  *   $PEER_NAME      e.g. spine1   (or gpu-r1-l1 from the spine side)

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/bgp-ebgp-fabric-underlay.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/bgp-ebgp-fabric-underlay.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   eBGP fabric underlay — leaf<->spine /31 sessions, multipath, BFD 1s
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Pure eBGP underlay — every device has a unique AS (leaf 208-211,
@@ -24,10 +25,10 @@
  *    to all BGP groups on the device. Always reassemble both snips.
  *
  * Pair with:
- *  - junos/transport/bgp-ebgp-evpn-overlay.conf  (companion overlay + shared bgp-level knobs)
- *  - junos/policy/clos-loop-prevention.conf  (LEAF_TO_SPINE_*  / SPINE_TO_LEAF_*)
- *  - junos/policy/allpodnetworks-direct-redistribution.conf  (BGP-AOS-Policy)
- *  - junos/interfaces/fabric-p2p-400g-breakout.conf  (the /31 links)
+ *  - evo/transport/bgp-ebgp-evpn-overlay.conf  (companion overlay + shared bgp-level knobs)
+ *  - evo/policy/clos-loop-prevention.conf  (LEAF_TO_SPINE_*  / SPINE_TO_LEAF_*)
+ *  - evo/policy/allpodnetworks-direct-redistribution.conf  (BGP-AOS-Policy)
+ *  - evo/interfaces/fabric-p2p-400g-breakout.conf  (the /31 links)
  *
  * Variables (example values from leaf1_qfx5240-64od / spine1_qfx5240-64od):
  *   $PEER_NAME       e.g. spine1   (or gpu-r1-l1 from the spine side)

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/ecmp-dlb-flowlet.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/ecmp-dlb-flowlet.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   ECMP DLB (Dynamic Load Balancing) flowlet — AI fabric load spreading
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - Flowlet-based DLB replaces classic 5-tuple ECMP — critical for
@@ -17,7 +18,7 @@
  *  - `flowset-table-size 2048` sizes the per-port DLB hardware table
  *
  * Pair with:
- *  - junos/transport/routing-options-ecmp-frr.conf  (forwarding-table export PFE-LB)
+ *  - evo/transport/routing-options-ecmp-frr.conf  (forwarding-table export PFE-LB)
  */
 forwarding-options {
     /* Load balancing policy label: AI-Core-Team-DLB */

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/router-advertisement.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/router-advertisement.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   IPv6 Router Advertisement on tenant GPU-server-facing interfaces
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od
  *
  * Highlights:
  *  - GPU hosts need IPv6 SLAAC for tenant traffic — the IRB anycast MAC
@@ -16,7 +17,7 @@
  *    tenant-server sub-port
  *
  * Pair with:
- *  - junos/interfaces/tenant-gpu-server-link.conf  (the interfaces being advertised on)
+ *  - evo/interfaces/tenant-gpu-server-link.conf  (the interfaces being advertised on)
  *
  * Variables (example values from leaf1_qfx5240-64od):
  *   $AC_INTF       e.g. et-0/0/12:0

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/routing-options-ecmp-frr.conf
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/evo/transport/routing-options-ecmp-frr.conf
@@ -1,8 +1,9 @@
 /*
  * Topic:   Routing-options — router-id, AS, ECMP fast-reroute, chained-composite-NH
+ * Variant: Evolved-OS (EVO)
  * Seen on:
- *   Junos: leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
- *   EVO:   (none)
+ *   Junos: (none)
+ *   EVO:   leaf1_qfx5240-64od leaf2_qfx5240-64od leaf3_qfx5240-64od leaf4_qfx5240-64od spine1_qfx5240-64od spine2_qfx5240-64od spine3_qfx5240-64od spine4_qfx5240-64od
  *
  * Highlights:
  *  - `ecmp-fast-reroute` enables sub-second restoration on link failure
@@ -16,8 +17,8 @@
  *  - `graceful-restart` at the global level enables GR for all protocols
  *
  * Pair with:
- *  - junos/policy/pfe-load-balance.conf  (PFE-LB policy referenced here)
- *  - junos/transport/ecmp-dlb-flowlet.conf  (companion forwarding-options block)
+ *  - evo/policy/pfe-load-balance.conf  (PFE-LB policy referenced here)
+ *  - evo/transport/ecmp-dlb-flowlet.conf  (companion forwarding-options block)
  *
  * Variables (example values from leaf1_qfx5240-64od / spine1_qfx5240-64od):
  *   $ROUTER_ID    e.g. 10.0.1.9   (lo0.0 v4 address)


### PR DESCRIPTION
## What's New
- Reclassified the \`aiml_multitenancy_backend\` snip library from Junos to **Junos OS Evolved (EVO)** — \`snips/junos/\` → \`snips/evo/\` via \`git mv\` (history preserved)
- Each snip header now carries a \`Variant: Evolved-OS (EVO)\` tag, \`Junos:\` becomes \`(none)\`, and \`EVO:\` lists the QFX5240-64OD devices
- New \`configuration/snips/README.md\` matching the established format used by \`service_provider/{srv6_core_edge,metro_ethernet_business_services,broadband_edge}\` libraries

## Why
QFX5240-64OD runs Junos OS Evolved, not classic Junos. The original library landed everything under \`snips/junos/\` because the extraction skill's family-classification table didn't list QFX. This PR corrects the classification so the library is consistent with the rest of the repo's conventions, and adds the README that the prior three snip libraries already have.

## Details
- 23 \`.conf\` snips renamed \`evo/...\` → \`evo/...\` (paths unchanged after the prefix)
- All 23 snip headers updated: inserted \`Variant: Evolved-OS (EVO)\` line after \`Topic:\`; swapped device list from \`Junos:\` to \`EVO:\`
- All \`Pair with:\` cross-references rewritten \`junos/...\` → \`evo/...\` (reciprocity preserved)
- \`_variables.md\` intro paragraph updated to point at \`evo/\` instead of \`junos/\`
- New \`README.md\` documents: topology image, layout, LEAF/SPINE combined-snip pattern, header conventions, \`$VAR\` placeholders, snip index table per category, scope, and a link back to the AI DC EVPN Multitenancy JVD landing page

## Testing
- \`git mv\` used for the directory rename — file history preserved
- Spot-checked 3 snips for correct header transform (Variant line + swapped Seen-on lines)
- \`grep -rn 'junos/' evo/\` returns no matches — all internal cross-refs resolve
- README renders cleanly; all internal links use the new \`evo/...\` paths

## Notes
- A companion fix to \`git-skills/.github/skills/jvd-extract-snips/SKILL.md\` is in flight to (a) extend the family-classification table to cover QFX (most QFX run EVO; verify per-platform), and (b) make README generation a required Phase C step. That update lives in the \`git-skills\` repo, not this one.
