### PR TITLE
feat(ewan_finance): add config-snippet template library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,98 @@ Release notes for the Juniper Validated Design (JVD) configuration repository.
 
 ---
 
+## 2026-05-21
+
+The Enterprise WAN for Finance & Stock Exchange JVD gains a full
+config-snippet library — 38 templates (22 Junos + 16 EVO) covering
+NG-MVPN multicast, EVPN active/standby, RSVP-TE P2MP tunnels,
+TWAMP monitoring, and low-latency QoS across 9 device roles.
+
+### New content
+
+- **Enterprise WAN Finance template library** — 38 reusable templates
+  for the [`ewan_finance`](enterprise_wan/ewan_finance/) JVD,
+  organized under
+  [`configuration/snips/`](enterprise_wan/ewan_finance/configuration/snips/)
+  with dual Junos and EVO trees across 9 categories:
+  `bootstrap/` (chassis, aggregated-devices, tunnel-services),
+  `interfaces/` (ESI LAG, IRB gateway, flexible-vlan, loopback,
+  VLAN bridge-domain),
+  `transport/` (iBGP inet-mvpn mesh, MPLS P2MP LSP, OSPF-TE
+  node-protection, RSVP signaling),
+  `policy/` (protocol redistribution, route-filter MED),
+  `cos/` (4-class EXP with strict-high LLQ for stock-exchange traffic),
+  `firewall/` (multicast forwarding-cache filter with CoS marking),
+  `oam/` (LLDP, TWAMP server, TWAMP client),
+  `services/` (NG-MVPN SPT-only with hot-root-standby, EVPN
+  virtual-switch ESI, L3VPN VRF, virtual-router with PIM),
+  and `multicast/` (forwarding-options resolve/mismatch rate tuning).
+  Each template carries the standard five-section header and a
+  [`_variables.md`](enterprise_wan/ewan_finance/configuration/snips/_variables.md)
+  glossary defines all ~80 parameters. A
+  [`README.md`](enterprise_wan/ewan_finance/configuration/snips/README.md)
+  documents the MX/ACX/PTX platform split, sibling pairs, and key
+  design patterns.
+
+- **New snip category: `multicast/`** — Introduced for multicast
+  forwarding-options tuning (resolve-rate, mismatch-rate). More
+  multicast patterns will land here as additional JVDs are templated.
+
+### What this means for you
+
+- If you're deploying NG-MVPN for finance or stock-exchange multicast
+  on MX/PTX/ACX platforms, start from the new
+  [ewan_finance template library](enterprise_wan/ewan_finance/configuration/snips/).
+  The 13 Junos↔EVO sibling pairs let you reference whichever OS you're
+  running without cross-tree lookups.
+- The MVPN instance template
+  (`junos/services/mvpn-instance.conf`) captures the full hot-root-standby
+  SPT-only pattern — a complex config that's easy to get wrong from scratch.
+- Browse the new templates at the
+  [JVD Portal Snip Library](https://juniper.github.io/jvd/portal/#snips),
+  filtered to the Enterprise WAN Finance JVD.
+
+---
+
+### By the numbers
+
+<details>
+<summary>Per-area changes</summary>
+
+| Area / JVD | Added | Modified | READMEs |
+| --- | ---: | ---: | ---: |
+| `enterprise_wan/ewan_finance` | 40 | 0 | 1 |
+| **TOTAL** | **40** | **0** | **1** |
+
+</details>
+
+<details>
+<summary>Net lines added by area</summary>
+
+| Area | Lines added | Net |
+| --- | ---: | ---: |
+| Junos templates (`junos/`) | 1,147 | +1,147 |
+| EVO templates (`evo/`) | 765 | +765 |
+| Documentation (`_variables.md` + `README.md`) | 347 | +347 |
+| **Total** | **2,259** | **+2,259** |
+
+</details>
+
+<details>
+<summary>ewan_finance content breakdown</summary>
+
+| Content | Files | Lines |
+| --- | ---: | ---: |
+| Junos templates (9 categories) | 22 | ~1,147 |
+| EVO templates (7 categories) | 16 | ~765 |
+| Variables glossary (`_variables.md`) | 1 | ~180 |
+| Snip-library `README.md` | 1 | ~167 |
+| **Total** | **40** | **2,259** |
+
+</details>
+
+---
+
 ## 2026-05-15
 
 A new AI/ML Data Center JVD lands its first reusable configuration

--- a/enterprise_wan/ewan_finance/configuration/snips/README.md
+++ b/enterprise_wan/ewan_finance/configuration/snips/README.md
@@ -1,0 +1,167 @@
+# Snip Library — Enterprise WAN for Finance & Stock Exchange
+
+Templated config-snippet library extracted from `ewan_finance/configuration/conf/`.
+
+## JVD Summary
+
+**Enterprise WAN for Finance and Stock Exchange** — ultra-low-latency multicast transport
+using NG-MVPN SPT-only (BGP Type-5/7), RSVP-TE P2MP provider-tunnels,
+EVPN Active/Standby with ESI multihoming, and TWAMP end-to-end monitoring.
+
+## Platforms
+
+| Device | Platform | OS | Role |
+|--------|----------|------|------|
+| wanedge1_mx304 | MX304 | Junos | WAN Edge (ESI LAG, EVPN, MVPN sender) |
+| wanedge2_mx10004 | MX10004 | Junos | WAN Edge (ESI LAG, EVPN, MVPN sender) |
+| ap1_mx304 | MX304 | Junos | Aggregation/PE (TWAMP server, MVPN) |
+| ap2_mx10004 | MX10004 | Junos | Aggregation/PE (TWAMP server, MVPN) |
+| cr1_acx7100-48l | ACX7100-48L | EVO | Core Router (TWAMP client, virtual-router) |
+| cr2_mx480 | MX480 | Junos | Core Router (TWAMP client, virtual-router) |
+| p1_ptx10003-80c | PTX10003-80C | EVO | P-router (MPLS/RSVP transit) |
+| p2_ptx10001-36mr | PTX10001-36MR | EVO | P-router (MPLS/RSVP transit) |
+| l2-l3_edge_acx7100 | ACX7100 | EVO | L2/L3 Edge (VLAN bridge, LAG) |
+
+## Layout
+
+```
+snips/
+├── _variables.md
+├── README.md
+├── junos/
+│   ├── bootstrap/
+│   │   └── chassis-config.conf
+│   ├── cos/
+│   │   └── exp-classifiers-schedulers.conf
+│   ├── firewall/
+│   │   └── multicast-fwd-cache-filter.conf
+│   ├── interfaces/
+│   │   ├── flexible-vlan-subinterface.conf
+│   │   ├── irb-l3-gateway.conf
+│   │   ├── lag-esi-lacp.conf
+│   │   ├── loopback-multi-af.conf
+│   │   └── physical-p2p-mpls.conf
+│   ├── multicast/
+│   │   └── forwarding-multicast-tuning.conf
+│   ├── oam/
+│   │   ├── lldp-discovery.conf
+│   │   ├── twamp-client.conf
+│   │   └── twamp-server.conf
+│   ├── policy/
+│   │   ├── protocol-redistribution.conf
+│   │   └── route-filter-med.conf
+│   ├── services/
+│   │   ├── evpn-virtual-switch-esi.conf
+│   │   ├── mvpn-instance.conf
+│   │   ├── virtual-router-instance.conf
+│   │   └── vrf-l3vpn.conf
+│   └── transport/
+│       ├── ibgp-core-mesh.conf
+│       ├── mpls-lsp-p2mp.conf
+│       ├── ospf-te-protection.conf
+│       └── rsvp-signaling.conf
+└── evo/
+    ├── bootstrap/
+    │   └── chassis-config.conf
+    ├── cos/
+    │   └── exp-classifiers-schedulers.conf
+    ├── interfaces/
+    │   ├── flexible-vlan-subinterface.conf
+    │   ├── lag-lacp.conf
+    │   ├── loopback-multi-af.conf
+    │   ├── physical-p2p-mpls.conf
+    │   └── vlan-bridge-domain.conf
+    ├── oam/
+    │   ├── lldp-discovery.conf
+    │   └── twamp-client.conf
+    ├── policy/
+    │   ├── protocol-redistribution.conf
+    │   └── route-filter-med.conf
+    ├── services/
+    │   └── virtual-router-instance.conf
+    └── transport/
+        ├── ibgp-core-mesh.conf
+        ├── mpls-interfaces.conf
+        ├── ospf-te-protection.conf
+        └── rsvp-signaling.conf
+```
+
+## Categories
+
+| Category | Junos | EVO | Description |
+|----------|:-----:|:---:|-------------|
+| bootstrap | 1 | 1 | Chassis hardware, aggregated-devices, FPC/PIC config |
+| interfaces | 5 | 5 | Physical P2P, LAG (ESI/LACP), IRB, loopback, VLAN bridge |
+| transport | 4 | 4 | iBGP, MPLS LSP/P2MP, OSPF-TE, RSVP signaling |
+| policy | 2 | 2 | Protocol redistribution, route-filter MED |
+| cos | 1 | 1 | EXP classifiers, forwarding classes, schedulers |
+| firewall | 1 | — | Multicast forwarding-cache filter with CoS marking |
+| oam | 3 | 2 | LLDP, TWAMP server, TWAMP client |
+| services | 4 | 1 | MVPN, EVPN virtual-switch, VRF L3VPN, virtual-router |
+| multicast | 1 | — | Forwarding-options resolve/mismatch rate tuning |
+| **Total** | **22** | **16** | **38 files** |
+
+## Junos ↔ EVO Sibling Pairs
+
+Patterns that appear on both OS families have a full-body file under each tree.
+
+| Snip | Junos | EVO |
+|------|-------|-----|
+| chassis-config | `junos/bootstrap/` | `evo/bootstrap/` |
+| physical-p2p-mpls | `junos/interfaces/` | `evo/interfaces/` |
+| loopback-multi-af | `junos/interfaces/` | `evo/interfaces/` |
+| flexible-vlan-subinterface | `junos/interfaces/` | `evo/interfaces/` |
+| ibgp-core-mesh | `junos/transport/` | `evo/transport/` |
+| ospf-te-protection | `junos/transport/` | `evo/transport/` |
+| rsvp-signaling | `junos/transport/` | `evo/transport/` |
+| protocol-redistribution | `junos/policy/` | `evo/policy/` |
+| route-filter-med | `junos/policy/` | `evo/policy/` |
+| exp-classifiers-schedulers | `junos/cos/` | `evo/cos/` |
+| lldp-discovery | `junos/oam/` | `evo/oam/` |
+| twamp-client | `junos/oam/` | `evo/oam/` |
+| virtual-router-instance | `junos/services/` | `evo/services/` |
+
+## Junos-Only Patterns
+
+| Snip | Why Junos-only |
+|------|----------------|
+| irb-l3-gateway | EVPN multihoming with IRB + static MAC (WAN edge role) |
+| lag-esi-lacp | ESI single-active DF election (WAN edge role) |
+| mpls-lsp-p2mp | P2MP LSP template + named LSPs (PE/sender role) |
+| multicast-fwd-cache-filter | Multicast CoS marking at L3 ingress |
+| forwarding-multicast-tuning | PFE resolve/mismatch rate (MX-specific knob) |
+| twamp-server | Reflector on AP nodes |
+| evpn-virtual-switch-esi | EVPN MPLS virtual-switch + bridge-domain |
+| mvpn-instance | NG-MVPN VRF with hot-root-standby |
+| vrf-l3vpn | L3VPN VRF with eBGP CE peering |
+
+## EVO-Only Patterns
+
+| Snip | Why EVO-only |
+|------|--------------|
+| lag-lacp | Simple LACP LAG without ESI (L2/L3 edge role) |
+| vlan-bridge-domain | L2-only VLAN membership (L2/L3 edge role) |
+| mpls-interfaces | MPLS interface enablement (P-router role) |
+
+## Key Design Patterns
+
+1. **NG-MVPN SPT-only with hot-root-standby** — Each WAN edge runs 10 MVPN instances
+   with sender-based-rpf and source-tree standby for sub-second multicast failover.
+
+2. **EVPN Active/Standby with ESI multihoming** — Per-VLAN ESI on ae0 units enables
+   per-service designated-forwarder election between wanedge1 and wanedge2.
+
+3. **TWAMP end-to-end monitoring** — AP nodes run TWAMP servers; CR nodes probe every
+   VRF with 100 probes/second for continuous latency/jitter measurement.
+
+4. **4-class EXP QoS with strict-high LLQ** — FC-LLQ (queue 2) carries stock-exchange
+   multicast with strict-high priority for deterministic low-latency forwarding.
+
+5. **RSVP-TE P2MP provider-tunnels** — Multicast transport uses pre-established P2MP
+   LSPs with link-protection and aggressive reoptimization.
+
+## Usage
+
+Each `.conf` file is self-documenting — open any file and read the 5-section header
+for context, highlights, related snips, and variable examples. Replace `$VARIABLES`
+with your site-specific values (see `_variables.md` for the full glossary).

--- a/enterprise_wan/ewan_finance/configuration/snips/_variables.md
+++ b/enterprise_wan/ewan_finance/configuration/snips/_variables.md
@@ -1,0 +1,180 @@
+# Variables Glossary
+
+All `$VARIABLE` placeholders used across the ewan_finance snip library.
+Replace these with site-specific values when deploying.
+
+## Identifiers & Addressing
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$LOCAL_ADDRESS` | BGP local-address (router-id loopback) | `10.200.50.12` |
+| `$LOCAL_AS` | BGP autonomous system number | `64512` |
+| `$ROUTER_ID_ADDRESS` | Primary loopback IPv4 with /32 mask | `10.200.50.13/32` |
+| `$MGMT_LOOPBACK` | Management loopback address | `10.255.163.148/32` |
+| `$ISO_ADDRESS` | IS-IS/CLNS NET address on lo0 | `47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00` |
+| `$IPV6_ADDRESS` | Primary IPv6 loopback address | `2001:db8::10:255:163:148/128` |
+| `$IPV4_ADDRESS` | Interface IPv4 address with mask | `10.101.23.2/24` |
+| `$ROUTE_DISTINGUISHER` | BGP route-distinguisher (router-id:id) | `10.200.50.12:61` |
+| `$VRF_TARGET` | VPN route-target community | `target:64512:11` |
+
+## Interfaces & LAG
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$INTERFACE_NAME` | Physical interface name | `et-0/0/0` |
+| `$AE_NAME` | Aggregated Ethernet (LAG) name | `ae0` |
+| `$DESCRIPTION` | Interface description string | `Link to P1Node to WANEdge1` |
+| `$MTU` | Interface MTU value | `1522` |
+| `$CORE_IFACE_1` .. `$CORE_IFACE_4` | Core transport interface.unit | `et-0/0/1.0` |
+| `$UNIT_ID` | Logical interface unit number | `1` |
+| `$VLAN_ID` | 802.1Q VLAN identifier | `1` |
+
+## LAG / ESI
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$ESI_ID` | Ethernet Segment Identifier (10 bytes) | `00:11:11:11:11:11:12:12:12:12` |
+| `$DF_PREFERENCE` | Designated-forwarder election preference | `150` |
+| `$LACP_PRIORITY` | LACP system priority | `100` |
+| `$LACP_SYSTEM_ID` | LACP system-id (must match across ESI peers) | `00:00:00:00:00:10` |
+| `$UNIT_ESI` | Per-unit ESI for per-VLAN DF election | `00:01:71:81:11:12:a1:00:00:01` |
+| `$UNIT_DF_PREFERENCE` | Per-unit DF preference value | `150` |
+
+## IRB
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$FILTER_NAME` | Firewall filter applied on IRB input | `mfc-filter` |
+| `$STATIC_MAC` | Static MAC for deterministic gateway | `00:10:94:00:00:01` |
+
+## Chassis
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$DEVICE_COUNT` | Aggregated Ethernet device-count | `25` |
+| `$FPC_SLOT` | FPC slot number | `0` |
+| `$PIC_SLOT` | PIC slot number | `0` |
+| `$TUNNEL_BW` | Tunnel-services bandwidth | `10g` |
+| `$PORT_ID` | Physical port number | `0` |
+| `$PORT_SPEED` | Port speed setting | `100g` |
+| `$BREAKOUT_PORT_ID` | Port to be broken out | `9` |
+| `$BREAKOUT_SPEED` | Per-lane speed after breakout | `10g` |
+| `$BREAKOUT_SUB_PORTS` | Number of breakout sub-ports | `4` |
+
+## BGP Peers
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$NEIGHBOR_1` .. `$NEIGHBOR_5` | iBGP peer addresses | `10.200.50.13` |
+| `$EXPORT_POLICY` | BGP group export policy list | `[ PS-send-ospf PS-BGP-TO-OSPF ]` |
+| `$CE_NEIGHBOR` | CE/TG BGP peer address | `172.16.1.2` |
+| `$CE_PEER_AS` | CE/TG peer autonomous system | `64513` |
+| `$AP_PEER_AS` | AP router peer AS (for CR VRs) | `64512` |
+| `$AP_NEIGHBOR_1` | AP1 peer address in virtual-router | `10.101.49.1` |
+| `$AP_NEIGHBOR_2` | AP2 peer address in virtual-router | `10.101.79.1` |
+| `$IXIA_PEER_AS` | Traffic generator peer AS | `64521` |
+| `$IXIA_NEIGHBOR` | Traffic generator peer address | `10.101.91.2` |
+
+## MPLS / RSVP
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$P2MP_LSP_NAME` | P2MP LSP template name | `P2MP` |
+| `$LSP_NAME_1` .. `$LSP_NAME_3` | Named unicast LSP | `lsp_to_AP1` |
+| `$LSP_DEST_1` .. `$LSP_DEST_3` | LSP destination (peer loopback) | `10.200.50.14` |
+
+## OSPF / BFD
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$BFD_INTERVAL` | BFD minimum-interval (ms) | `10` |
+| `$BFD_MULTIPLIER` | BFD detect-multiplier | `3` |
+
+## Policy
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$DIRECT_POLICY_NAME` | Direct-route redistribution policy | `PS-ADV_DIRECT` |
+| `$BGP_TO_OSPF_NAME` | BGP-to-OSPF leak policy | `PS-BGP-TO-OSPF` |
+| `$OSPF_TO_BGP_NAME` | OSPF-to-BGP export policy | `PS-send-ospf` |
+| `$MED_LOW_NAME` | Low-MED route-filter policy | `PS-med-10` |
+| `$MED_LOW_PREFIX` | Route-filter prefix for low MED | `10.101.0.0/16` |
+| `$MED_LOW_VALUE` | Low MED metric value | `10` |
+| `$MED_HIGH_NAME` | High-MED catch-all policy | `PS-med-30` |
+| `$MED_HIGH_VALUE` | High MED metric value | `30` |
+| `$EXPORT_POLICIES` | VR BGP export policy list | `[ med-10 med-30 ]` |
+
+## CoS
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$INTERFACE_1` .. `$INTERFACE_4` | CoS-applied interfaces | `et-0/0/1` |
+
+## Firewall
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$MCAST_DEST_PREFIX` | Multicast destination prefix to match | `225.0.0.0/16` |
+| `$FORWARDING_CLASS` | Target forwarding class for match | `FC-LLQ` |
+| `$UNICAST_DEST_1` | Unicast destination for VRF filter | `10.8.21.2/32` |
+| `$UNICAST_DEST_2` | Second unicast destination | `10.9.21.2/32` |
+| `$UNICAST_FWD_CLASS` | Forwarding class for unicast match | `FC-HIGH` |
+
+## Multicast / MVPN
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$RESOLVE_RATE` | Multicast PFE resolve-rate (pps) | `1000` |
+| `$MISMATCH_RATE` | RPF mismatch-rate (pps) | `1000` |
+| `$INSTANCE_NAME` | MVPN/VRF routing-instance name | `MVPN_INSTANCE1` |
+| `$CE_LOCAL_ADDRESS` | MVPN VRF local-address for CE peering | `172.16.1.1` |
+| `$MVPN_RT_IMPORT` | MVPN route-target import | `target:64512:101` |
+| `$MVPN_RT_EXPORT` | MVPN route-target export | `target:64512:101` |
+| `$RP_ADDRESS` | PIM Rendezvous Point address | `10.10.47.101` |
+| `$MCAST_GROUP_RANGE` | PIM multicast group-range prefix | `225.0.0.0/22` |
+| `$IRB_UNIT` | IRB interface bound to MVPN | `irb.1` |
+| `$LO_UNIT` | Loopback unit bound to MVPN | `lo0.1` |
+
+## EVPN
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$BD_NAME` | Bridge-domain name | `BD_EVPN_GROUP1` |
+| `$AE_UNIT` | LAG unit in bridge-domain | `ae0.1` |
+| `$IRB_UNIT` | Routing-interface in bridge-domain | `irb.1` |
+
+## L3VPN / Virtual-Router
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$VRF_NAME` | L3VPN VRF instance name | `VRF21` |
+| `$VR_NAME` | Virtual-router instance name | `VIRTUAL-ROUTER-V1` |
+| `$LOCAL_ADDRESS` | VRF eBGP local-address | `172.16.21.1` |
+| `$IFACE_AP1` | AP1-facing interface in VR | `et-5/0/0.1` |
+| `$IFACE_AP2` | AP2-facing interface in VR | `et-5/0/1.1` |
+| `$IFACE_TG` | Traffic-generator interface in VR | `xe-3/0/6.1` |
+
+## TWAMP / OAM
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$VRF_NAME_1` | TWAMP server VRF name | `MVPN_INSTANCE1` |
+| `$VRF_PORT_1` | TWAMP server port for VRF | `862` |
+| `$GLOBAL_PORT` | TWAMP server global port | `1862` |
+| `$CLIENT_LIST_NAME` | TWAMP client-list ACL name | `CR1_1` |
+| `$CLIENT_ADDRESS` | TWAMP client source address | `10.101.48.2/32` |
+| `$CONNECTION_NAME` | TWAMP client control-connection name | `CR24_1` |
+| `$DEST_PORT` | TWAMP client destination port | `862` |
+| `$ROUTING_INSTANCE` | TWAMP client routing-instance | `VIRTUAL-ROUTER-V1` |
+| `$TARGET_ADDRESS` | TWAMP probe target (server) address | `10.101.49.1` |
+| `$TEST_SESSION_NAME` | TWAMP test-session identifier | `T24_1` |
+| `$PROBE_COUNT` | Probes per test-session iteration | `100` |
+| `$PROBE_INTERVAL` | Probe interval in seconds | `1` |
+
+## VLAN Bridge-Domain (L2 Edge)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `$VLAN_NAME` | VLAN definition name | `vlan1` |
+| `$LAG_UNIT` | LAG unit in VLAN membership | `ae0.1` |
+| `$ACCESS_UNIT` | Access port unit in VLAN membership | `et-0/0/47.1` |

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/bootstrap/chassis-config.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/bootstrap/chassis-config.conf
@@ -1,0 +1,45 @@
+/*
+ * Topic:   Chassis hardware initialization — aggregated devices and FPC/PIC port speeds
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - aggregated-devices ethernet device-count reserves LAG interface namespace
+ *  - Per-port speed and sub-port breakout configured at PIC level
+ *  - dump-on-panic enables core dumps for hardware troubleshooting
+ *
+ * Pair with:
+ *  - evo/interfaces/physical-p2p-mpls.conf  (interfaces bound to these ports)
+ *  - evo/interfaces/lag-lacp.conf           (LAG interfaces using aggregated-devices)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $DEVICE_COUNT       e.g. 25
+ *   $FPC_SLOT           e.g. 0
+ *   $PIC_SLOT           e.g. 0
+ *   $PORT_ID            e.g. 0
+ *   $PORT_SPEED         e.g. 100g
+ *   $BREAKOUT_PORT_ID   e.g. 2
+ *   $BREAKOUT_SPEED     e.g. 10g
+ *   $BREAKOUT_SUB_PORTS e.g. 4
+ */
+
+chassis {
+    dump-on-panic;
+    aggregated-devices {
+        ethernet {
+            device-count $DEVICE_COUNT;
+        }
+    }
+    fpc $FPC_SLOT {
+        pic $PIC_SLOT {
+            port $PORT_ID {
+                speed $PORT_SPEED;
+            }
+            port $BREAKOUT_PORT_ID {
+                number-of-sub-ports $BREAKOUT_SUB_PORTS;
+                speed $BREAKOUT_SPEED;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/cos/exp-classifiers-schedulers.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/cos/exp-classifiers-schedulers.conf
@@ -1,0 +1,111 @@
+/*
+ * Topic:   MPLS EXP-based QoS — classifiers, forwarding classes, schedulers, and rewrite rules
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - 4 forwarding classes: FC-LLQ (strict-high, queue 2) for low-latency finance traffic,
+ *    FC-HIGH (queue 1), CONTROL (queue 3), BEST-EFFORT (queue 0)
+ *  - EXP classifier maps 3-bit MPLS EXP values to forwarding classes
+ *  - EXP rewrite rule re-marks egress frames to preserve QoS across hops
+ *  - scheduler-map applied per-interface with classifier + rewrite on each unit
+ *  - FC-LLQ uses strict-high priority for deterministic low-latency forwarding
+ *
+ * Pair with:
+ *  - evo/interfaces/physical-p2p-mpls.conf  (interfaces where CoS is applied)
+ *  - evo/transport/mpls-interfaces.conf     (MPLS transport carrying marked traffic)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $INTERFACE_1     e.g. et-0/0/0
+ *   $INTERFACE_2     e.g. et-0/0/1
+ *   $INTERFACE_3     e.g. et-0/0/3
+ *   $INTERFACE_4     e.g. et-0/0/4
+ */
+
+class-of-service {
+    classifiers {
+        exp EXP {
+            forwarding-class FC-HIGH {
+                loss-priority low code-points 001;
+            }
+            forwarding-class BEST-EFFORT {
+                loss-priority low code-points 000;
+            }
+            forwarding-class FC-LLQ {
+                loss-priority low code-points 010;
+            }
+            forwarding-class CONTROL {
+                loss-priority low code-points 011;
+            }
+        }
+    }
+    forwarding-classes {
+        class FC-HIGH queue-num 1;
+        class BEST-EFFORT queue-num 0;
+        class CONTROL queue-num 3;
+        class FC-LLQ queue-num 2;
+    }
+    interfaces {
+        $INTERFACE_1 {
+            scheduler-map sched-map;
+            unit 0 {
+                classifiers {
+                    exp EXP;
+                }
+                rewrite-rules {
+                    exp EXP_REWRITE;
+                }
+            }
+        }
+        $INTERFACE_2 {
+            scheduler-map sched-map;
+            unit 0 {
+                classifiers {
+                    exp EXP;
+                }
+                rewrite-rules {
+                    exp EXP_REWRITE;
+                }
+            }
+        }
+    }
+    rewrite-rules {
+        exp EXP_REWRITE {
+            forwarding-class FC-HIGH {
+                loss-priority low code-point 001;
+            }
+            forwarding-class BEST-EFFORT {
+                loss-priority low code-point 000;
+            }
+            forwarding-class FC-LLQ {
+                loss-priority low code-point 010;
+            }
+            forwarding-class CONTROL {
+                loss-priority low code-point 011;
+            }
+        }
+    }
+    scheduler-maps {
+        sched-map {
+            forwarding-class BEST-EFFORT scheduler s0;
+            forwarding-class FC-HIGH scheduler s1;
+            forwarding-class FC-LLQ scheduler s2;
+            forwarding-class CONTROL scheduler s3;
+        }
+    }
+    schedulers {
+        s0 {
+            priority low;
+        }
+        s1 {
+            priority low;
+        }
+        s2 {
+            priority strict-high;
+        }
+        s3 {
+            priority low;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/flexible-vlan-subinterface.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/flexible-vlan-subinterface.conf
@@ -1,0 +1,38 @@
+/*
+ * Topic:   Flexible VLAN-tagged subinterfaces with per-unit addressing
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - Body is structurally identical to the Junos sibling
+ *  - flexible-vlan-tagging + flexible-ethernet-services enables mixed encapsulation per-unit
+ *  - Each unit carries a distinct VLAN-ID and IPv4 /30 or /24 address for PE-CE connectivity
+ *  - Used for per-virtual-router PE-CE links on CR devices
+ *  - Multiple units (13+) on a single physical interface to scale VPN instances
+ *
+ * Pair with:
+ *  - evo/services/virtual-router-instance.conf  (VR instances bind these subinterfaces)
+ *  - evo/oam/twamp-client.conf                  (TWAMP probes use these as source)
+ *
+ * Variables (example values from cr1_acx7100-48l):
+ *   $INTERFACE_NAME   e.g. et-0/0/47
+ *   $DESCRIPTION      e.g. CR1_AP1
+ *   $UNIT_ID          e.g. 1
+ *   $VLAN_ID          e.g. 1
+ *   $IPV4_ADDRESS     e.g. 10.101.48.2/30
+ */
+
+interfaces {
+    $INTERFACE_NAME {
+        description "$DESCRIPTION";
+        flexible-vlan-tagging;
+        encapsulation flexible-ethernet-services;
+        unit $UNIT_ID {
+            vlan-id $VLAN_ID;
+            family inet {
+                address $IPV4_ADDRESS;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/lag-lacp.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/lag-lacp.conf
@@ -1,0 +1,40 @@
+/*
+ * Topic:   LAG with LACP active and vlan-bridge encapsulated units
+ * Seen on:
+ *   Junos: (none)
+ *   EVO:   l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - Aggregated Ethernet with LACP active for link bundling to dual-homed WAN edges
+ *  - flexible-vlan-tagging + flexible-ethernet-services for multi-VLAN trunk
+ *  - Per-unit vlan-bridge encapsulation ties into vlans{} bridge-domain membership
+ *  - MTU 1522 accommodates VLAN tag overhead
+ *
+ * Pair with:
+ *  - evo/interfaces/vlan-bridge-domain.conf       (VLANs referencing ae0 units)
+ *  - evo/bootstrap/chassis-config.conf            (aggregated-devices device-count)
+ *
+ * Variables (example values from l2-l3_edge_acx7100):
+ *   $AE_NAME         e.g. ae0
+ *   $DESCRIPTION     e.g. L2/L3 to WANEDGE1/2
+ *   $MTU             e.g. 1522
+ *   $VLAN_ID         e.g. 1
+ */
+
+interfaces {
+    $AE_NAME {
+        description "$DESCRIPTION";
+        flexible-vlan-tagging;
+        mtu $MTU;
+        encapsulation flexible-ethernet-services;
+        aggregated-ether-options {
+            lacp {
+                active;
+            }
+        }
+        unit $VLAN_ID {
+            encapsulation vlan-bridge;
+            vlan-id $VLAN_ID;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/loopback-multi-af.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/loopback-multi-af.conf
@@ -1,0 +1,48 @@
+/*
+ * Topic:   Loopback interface with IPv4, ISO, and IPv6 address families
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004 cr2_mx480
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr cr1_acx7100-48l l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - Primary/preferred IPv4 used as router-id and BGP local-address
+ *  - ISO address required for OSPF/IS-IS CLNS adjacency
+ *  - IPv6 primary enables dual-stack management and IPv6 BGP peering
+ *  - 127.0.0.x addresses used for internal loopback functions
+ *
+ * Pair with:
+ *  - evo/transport/ibgp-core-mesh.conf  (local-address sourced from lo0)
+ *  - evo/transport/ospf-te-protection.conf  (lo0 passive interface in area 0)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $ROUTER_ID_ADDRESS   e.g. 10.200.50.13/32
+ *   $MGMT_LOOPBACK       e.g. 10.255.163.148/32
+ *   $ISO_ADDRESS         e.g. 47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00
+ *   $IPV6_ADDRESS        e.g. 2001:db8::10:255:163:148/128
+ */
+
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address $ROUTER_ID_ADDRESS {
+                    primary;
+                    preferred;
+                }
+                address 127.0.0.1/32;
+                address 127.0.0.64/32;
+                address $MGMT_LOOPBACK {
+                    primary;
+                }
+            }
+            family iso {
+                address $ISO_ADDRESS;
+            }
+            family inet6 {
+                address $IPV6_ADDRESS {
+                    primary;
+                }
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/physical-p2p-mpls.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/physical-p2p-mpls.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:   Core point-to-point interfaces with inet/ISO/MPLS families
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - Multi-protocol family (inet + ISO + MPLS) on every core-facing link
+ *  - ISO enables IS-IS/CLNS routing; MPLS enables label switching
+ *  - /24 point-to-point addressing convention for inter-router links
+ *
+ * Pair with:
+ *  - evo/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)
+ *  - evo/transport/mpls-interfaces.conf     (MPLS enabled on these interfaces)
+ *  - evo/transport/rsvp-signaling.conf      (RSVP signaling on these interfaces)
+ *  - evo/bootstrap/chassis-config.conf      (port speed defined at chassis level)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $INTERFACE_NAME   e.g. et-0/0/0
+ *   $DESCRIPTION      e.g. Link to P1Node to WANEdge1
+ *   $IPV4_ADDRESS     e.g. 10.101.23.2/24
+ */
+
+interfaces {
+    $INTERFACE_NAME {
+        description "$DESCRIPTION";
+        unit 0 {
+            family inet {
+                address $IPV4_ADDRESS;
+            }
+            family iso;
+            family mpls;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/vlan-bridge-domain.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/vlan-bridge-domain.conf
@@ -1,0 +1,30 @@
+/*
+ * Topic:   Single-tag VLAN bridge-domains with interface membership binding
+ * Seen on:
+ *   Junos: (none)
+ *   EVO:   l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - Each VLAN defined with explicit vlan-id and interface membership
+ *  - Interfaces bound to VLANs via their vlan-bridge encapsulated units
+ *  - Dual-homed: ae0 (LAG to WAN edges) + et-0/0/47 (local access port)
+ *  - Simple L2-only switching — no IRB, no routing, no STP in this config
+ *
+ * Pair with:
+ *  - evo/interfaces/lag-lacp.conf                   (ae0 LAG carrying these VLANs)
+ *  - evo/interfaces/flexible-vlan-bridge.conf       (interface vlan-bridge units)
+ *
+ * Variables (example values from l2-l3_edge_acx7100):
+ *   $VLAN_NAME         e.g. vlan1
+ *   $VLAN_ID           e.g. 1
+ *   $LAG_UNIT          e.g. ae0.1
+ *   $ACCESS_UNIT       e.g. et-0/0/47.1
+ */
+
+vlans {
+    $VLAN_NAME {
+        vlan-id $VLAN_ID;
+        interface $LAG_UNIT;
+        interface $ACCESS_UNIT;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/oam/lldp-discovery.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/oam/lldp-discovery.conf
@@ -1,0 +1,20 @@
+/*
+ * Topic:   LLDP protocol enabled on all interfaces for neighbor discovery
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004 cr2_mx480
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr cr1_acx7100-48l l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - "interface all" enables LLDP on every physical port
+ *  - Essential for topology discovery and cable verification
+ *  - No per-interface filtering or hold-time tuning in this JVD
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   (no variables — static config)
+ */
+
+protocols {
+    lldp {
+        interface all;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/oam/twamp-client.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/oam/twamp-client.conf
@@ -1,0 +1,48 @@
+/*
+ * Topic:   TWAMP client with per-virtual-router control connections and test sessions
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - Body is structurally identical to the Junos sibling
+ *  - TWAMP client (RFC 5357) probes AP reflectors for per-VRF latency/jitter measurement
+ *  - One control-connection per VR targeting each AP server (dual-homed: AP1 + AP2)
+ *  - routing-instance scoping ensures probes originate from the correct VRF
+ *  - probe-count 100 at probe-interval 1s for continuous 100-second measurement cycles
+ *  - test-count 0 means infinite test iterations (continuous monitoring)
+ *
+ * Pair with:
+ *  - evo/services/virtual-router-instance.conf      (VR instances where probes originate)
+ *  - evo/interfaces/flexible-vlan-subinterface.conf (PE-CE links carrying probes)
+ *
+ * Variables (example values from cr1_acx7100-48l):
+ *   $CONNECTION_NAME     e.g. CR14_1
+ *   $DEST_PORT           e.g. 862
+ *   $ROUTING_INSTANCE    e.g. VIRTUAL-ROUTER-V1
+ *   $TARGET_ADDRESS      e.g. 10.101.48.1
+ *   $TEST_SESSION_NAME   e.g. T14_1
+ *   $PROBE_COUNT         e.g. 100
+ *   $PROBE_INTERVAL      e.g. 1
+ */
+
+services {
+    rpm {
+        twamp {
+            client {
+                control-connection $CONNECTION_NAME {
+                    control-type managed;
+                    destination-port $DEST_PORT;
+                    routing-instance $ROUTING_INSTANCE;
+                    target-address $TARGET_ADDRESS;
+                    test-count 0;
+                    test-session $TEST_SESSION_NAME {
+                        target-address $TARGET_ADDRESS;
+                        probe-count $PROBE_COUNT;
+                        probe-interval $PROBE_INTERVAL;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/policy/protocol-redistribution.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/policy/protocol-redistribution.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:   Routing policy statements for BGP/OSPF/direct protocol redistribution
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - PS-ADV_DIRECT: redistributes directly-connected routes into BGP
+ *  - PS-BGP-TO-OSPF: leaks BGP-learned routes into OSPF (for CE reachability)
+ *  - PS-send-ospf: exports OSPF routes into BGP for VPN distribution
+ *  - Simple accept-all policies — no route-filtering or manipulation
+ *
+ * Pair with:
+ *  - evo/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $DIRECT_POLICY_NAME   e.g. PS-ADV_DIRECT
+ *   $BGP_TO_OSPF_NAME     e.g. PS-BGP-TO-OSPF
+ *   $OSPF_TO_BGP_NAME     e.g. PS-send-ospf
+ */
+
+policy-options {
+    policy-statement $DIRECT_POLICY_NAME {
+        from protocol direct;
+        then accept;
+    }
+    policy-statement $BGP_TO_OSPF_NAME {
+        from protocol bgp;
+        then accept;
+    }
+    policy-statement $OSPF_TO_BGP_NAME {
+        from protocol ospf;
+        then accept;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/policy/route-filter-med.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/policy/route-filter-med.conf
@@ -1,0 +1,44 @@
+/*
+ * Topic:   Route-filter-based MED metric assignment for BGP export
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - Body is structurally identical to the Junos sibling
+ *  - PS-med-10: assigns MED 10 to specific infrastructure prefix (preferred path)
+ *  - PS-med-30: assigns MED 30 to all other prefixes (less-preferred backup)
+ *  - Used as export policy in virtual-router BGP groups to influence AP path selection
+ *
+ * Pair with:
+ *  - evo/services/virtual-router-instance.conf  (BGP group references these as export)
+ *  - evo/policy/protocol-redistribution.conf    (other policies in same policy-options)
+ *
+ * Variables (example values from cr1_acx7100-48l):
+ *   $MED_LOW_NAME       e.g. PS-med-10
+ *   $MED_LOW_PREFIX     e.g. 10.101.0.0/16
+ *   $MED_LOW_VALUE      e.g. 10
+ *   $MED_HIGH_NAME      e.g. PS-med-30
+ *   $MED_HIGH_VALUE     e.g. 30
+ */
+
+policy-options {
+    policy-statement $MED_LOW_NAME {
+        from {
+            route-filter $MED_LOW_PREFIX exact;
+        }
+        then {
+            metric $MED_LOW_VALUE;
+            accept;
+        }
+    }
+    policy-statement $MED_HIGH_NAME {
+        from {
+            route-filter 0.0.0.0/0 longer;
+        }
+        then {
+            metric $MED_HIGH_VALUE;
+            accept;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/services/virtual-router-instance.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/services/virtual-router-instance.conf
@@ -1,0 +1,78 @@
+/*
+ * Topic:   Virtual-router instance with BGP, PIM sparse-mode, and multicast RP
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - Body is structurally identical to the Junos sibling
+ *  - instance-type virtual-router: full routing table isolation without MPLS VPN signaling
+ *  - eBGP group "AP" peers to both AP nodes with MED export policy for path preference
+ *  - iBGP group "IXIA" for traffic-generator peering within the VR
+ *  - PIM sparse-mode with static RP pointing to AP node's loopback (multicast receiver side)
+ *  - Each VR gets unique multicast group-ranges matching the MVPN sender's PIM RP config
+ *
+ * Pair with:
+ *  - evo/interfaces/flexible-vlan-subinterface.conf (PE-CE interfaces bound to VR)
+ *  - evo/oam/twamp-client.conf                     (TWAMP probes originate per-VR)
+ *  - evo/policy/route-filter-med.conf              (MED export policies referenced)
+ *
+ * Variables (example values from cr1_acx7100-48l):
+ *   $VR_NAME             e.g. VIRTUAL-ROUTER-V1
+ *   $AP_PEER_AS          e.g. 64512
+ *   $AP_NEIGHBOR_1       e.g. 10.101.48.1
+ *   $AP_NEIGHBOR_2       e.g. 10.101.78.1
+ *   $EXPORT_POLICIES     e.g. [ med-10 med-30 ]
+ *   $IXIA_PEER_AS        e.g. 64521
+ *   $IXIA_NEIGHBOR       e.g. 10.101.81.2
+ *   $RP_ADDRESS          e.g. 10.10.47.101
+ *   $MCAST_GROUP_RANGE   e.g. 225.0.0.0/22
+ *   $IFACE_AP1           e.g. et-0/0/47.1
+ *   $IFACE_AP2           e.g. et-0/0/48.1
+ *   $IFACE_TG            e.g. et-0/0/46.1
+ */
+
+routing-instances {
+    $VR_NAME {
+        instance-type virtual-router;
+        protocols {
+            bgp {
+                group AP {
+                    type external;
+                    export $EXPORT_POLICIES;
+                    peer-as $AP_PEER_AS;
+                    neighbor $AP_NEIGHBOR_1;
+                    neighbor $AP_NEIGHBOR_2;
+                }
+                group IXIA {
+                    type internal;
+                    peer-as $IXIA_PEER_AS;
+                    neighbor $IXIA_NEIGHBOR;
+                }
+            }
+            pim {
+                rp {
+                    static {
+                        address $RP_ADDRESS {
+                            group-ranges {
+                                $MCAST_GROUP_RANGE;
+                            }
+                        }
+                    }
+                }
+                interface $IFACE_AP1 {
+                    mode sparse;
+                }
+                interface $IFACE_AP2 {
+                    mode sparse;
+                }
+                interface $IFACE_TG {
+                    mode sparse;
+                }
+            }
+        }
+        interface $IFACE_TG;
+        interface $IFACE_AP1;
+        interface $IFACE_AP2;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ibgp-core-mesh.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ibgp-core-mesh.conf
@@ -1,0 +1,63 @@
+/*
+ * Topic:   iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - family inet-vpn unicast + any for L3VPN route exchange
+ *  - family evpn signaling for EVPN Type-1 through Type-5
+ *  - family inet-mvpn signaling for NG-MVPN (multicast VPN) control plane
+ *  - family route-target enables RT-constrain to limit VPN route distribution
+ *  - BFD at 100ms × 3 for sub-second peer failure detection
+ *  - All peers in a single iBGP group (full mesh, no route-reflectors)
+ *
+ * Pair with:
+ *  - evo/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)
+ *  - evo/transport/mpls-interfaces.conf      (label transport for VPN families)
+ *  - evo/policy/protocol-redistribution.conf (export policies referenced in group)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $LOCAL_ADDRESS   e.g. 10.200.50.13
+ *   $LOCAL_AS        e.g. 64512
+ *   $EXPORT_POLICY   e.g. [ PS-send-ospf PS-BGP-TO-OSPF ]
+ *   $NEIGHBOR_1      e.g. 10.200.50.15
+ *   $NEIGHBOR_2      e.g. 10.200.50.14
+ *   $NEIGHBOR_3      e.g. 10.200.50.12
+ *   $NEIGHBOR_4      e.g. 10.200.50.11
+ *   $NEIGHBOR_5      e.g. 10.200.50.16
+ */
+
+protocols {
+    bgp {
+        group IBGP {
+            type internal;
+            local-address $LOCAL_ADDRESS;
+            family inet {
+                unicast;
+            }
+            family inet-vpn {
+                unicast;
+                any;
+            }
+            family evpn {
+                signaling;
+            }
+            family inet-mvpn {
+                signaling;
+            }
+            family route-target;
+            export $EXPORT_POLICY;
+            local-as $LOCAL_AS;
+            bfd-liveness-detection {
+                minimum-interval 100;
+                multiplier 3;
+            }
+            neighbor $NEIGHBOR_1;
+            neighbor $NEIGHBOR_2;
+            neighbor $NEIGHBOR_3;
+            neighbor $NEIGHBOR_4;
+            neighbor $NEIGHBOR_5;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/mpls-interfaces.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/mpls-interfaces.conf
@@ -1,0 +1,32 @@
+/*
+ * Topic:   MPLS protocol enablement on core and loopback interfaces
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - MPLS enabled on every core-facing interface for label switching
+ *  - lo0.0 included to support targeted LDP sessions and LSP origination
+ *  - Combined with RSVP-TE for traffic-engineered label-switched paths
+ *
+ * Pair with:
+ *  - evo/transport/rsvp-signaling.conf       (RSVP signals LSPs over these interfaces)
+ *  - evo/transport/ibgp-core-mesh.conf       (BGP VPN families ride over MPLS)
+ *  - evo/interfaces/physical-p2p-mpls.conf   (family mpls configured on interfaces)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $CORE_IFACE_1   e.g. et-0/0/0.0
+ *   $CORE_IFACE_2   e.g. et-0/0/3.0
+ *   $CORE_IFACE_3   e.g. et-0/0/1.0
+ *   $CORE_IFACE_4   e.g. et-0/0/4.0
+ */
+
+protocols {
+    mpls {
+        interface $CORE_IFACE_1;
+        interface $CORE_IFACE_2;
+        interface $CORE_IFACE_3;
+        interface $CORE_IFACE_4;
+        interface lo0.0;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ospf-te-protection.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ospf-te-protection.conf
@@ -1,0 +1,65 @@
+/*
+ * Topic:   OSPF with traffic engineering, node-link-protection, and BFD
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - traffic-engineering enables OSPF-TE extensions (RFC 3630) for RSVP-TE CSPF
+ *  - node-link-protection provides LFA backup for sub-50ms failover
+ *  - BFD at 10ms × 3 for ultra-fast adjacency failure detection (finance/low-latency)
+ *  - lo0.0 as passive ensures router-id reachability without forming adjacency
+ *  - All interfaces in area 0.0.0.0 (single-area backbone)
+ *
+ * Pair with:
+ *  - evo/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)
+ *  - evo/transport/mpls-interfaces.conf      (MPLS co-exists on same interfaces)
+ *  - evo/interfaces/physical-p2p-mpls.conf   (the physical interfaces referenced)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $CORE_IFACE_1   e.g. et-0/0/0.0
+ *   $CORE_IFACE_2   e.g. et-0/0/3.0
+ *   $CORE_IFACE_3   e.g. et-0/0/1.0
+ *   $CORE_IFACE_4   e.g. et-0/0/4.0
+ *   $BFD_INTERVAL   e.g. 10
+ *   $BFD_MULTIPLIER e.g. 3
+ */
+
+protocols {
+    ospf {
+        traffic-engineering;
+        area 0.0.0.0 {
+            interface $CORE_IFACE_1 {
+                node-link-protection;
+                bfd-liveness-detection {
+                    minimum-interval $BFD_INTERVAL;
+                    multiplier $BFD_MULTIPLIER;
+                }
+            }
+            interface $CORE_IFACE_2 {
+                node-link-protection;
+                bfd-liveness-detection {
+                    minimum-interval $BFD_INTERVAL;
+                    multiplier $BFD_MULTIPLIER;
+                }
+            }
+            interface $CORE_IFACE_3 {
+                node-link-protection;
+                bfd-liveness-detection {
+                    minimum-interval $BFD_INTERVAL;
+                    multiplier $BFD_MULTIPLIER;
+                }
+            }
+            interface $CORE_IFACE_4 {
+                node-link-protection;
+                bfd-liveness-detection {
+                    minimum-interval $BFD_INTERVAL;
+                    multiplier $BFD_MULTIPLIER;
+                }
+            }
+            interface lo0.0 {
+                passive;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/rsvp-signaling.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/rsvp-signaling.conf
@@ -1,0 +1,33 @@
+/*
+ * Topic:   RSVP-TE interface enablement for label-switched path signaling
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - RSVP enabled on all core transport interfaces and loopback
+ *  - Provides RSVP-TE signaling for traffic-engineered LSPs
+ *  - Works with OSPF-TE CSPF to compute constrained shortest paths
+ *  - lo0.0 included for targeted RSVP sessions (graceful restart, etc.)
+ *
+ * Pair with:
+ *  - evo/transport/mpls-interfaces.conf      (MPLS forwarding on same interfaces)
+ *  - evo/transport/ospf-te-protection.conf   (OSPF-TE provides path computation)
+ *  - evo/interfaces/physical-p2p-mpls.conf   (physical interfaces referenced)
+ *
+ * Variables (example values from p1_ptx10003-80c):
+ *   $CORE_IFACE_1   e.g. et-0/0/0.0
+ *   $CORE_IFACE_2   e.g. et-0/0/3.0
+ *   $CORE_IFACE_3   e.g. et-0/0/1.0
+ *   $CORE_IFACE_4   e.g. et-0/0/4.0
+ */
+
+protocols {
+    rsvp {
+        interface lo0.0;
+        interface $CORE_IFACE_1;
+        interface $CORE_IFACE_2;
+        interface $CORE_IFACE_3;
+        interface $CORE_IFACE_4;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/bootstrap/chassis-config.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/bootstrap/chassis-config.conf
@@ -1,0 +1,52 @@
+/*
+ * Topic:   Chassis hardware initialization — aggregated devices, FPC/PIC port speeds, tunnel-services
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - aggregated-devices ethernet device-count reserves LAG interface namespace
+ *  - tunnel-services bandwidth enables GRE/IP-IP tunnel encapsulation for MVPN
+ *  - Per-port speed and sub-port breakout at PIC level
+ *  - network-services enhanced-ip required for inet-mvpn and multicast forwarding
+ *
+ * Pair with:
+ *  - junos/interfaces/physical-p2p-mpls.conf  (interfaces bound to these ports)
+ *  - junos/interfaces/lag-esi-lacp.conf       (LAG interfaces using aggregated-devices)
+ *  - junos/services/mvpn-instance.conf        (MVPN uses tunnel-services)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $DEVICE_COUNT       e.g. 25
+ *   $FPC_SLOT           e.g. 0
+ *   $PIC_SLOT           e.g. 0
+ *   $TUNNEL_BW          e.g. 10g
+ *   $PORT_ID            e.g. 0
+ *   $PORT_SPEED         e.g. 100g
+ *   $BREAKOUT_PORT_ID   e.g. 9
+ *   $BREAKOUT_SPEED     e.g. 10g
+ *   $BREAKOUT_SUB_PORTS e.g. 4
+ */
+
+chassis {
+    dump-on-panic;
+    aggregated-devices {
+        ethernet {
+            device-count $DEVICE_COUNT;
+        }
+    }
+    fpc $FPC_SLOT {
+        pic $PIC_SLOT {
+            tunnel-services {
+                bandwidth $TUNNEL_BW;
+            }
+            port $PORT_ID {
+                speed $PORT_SPEED;
+            }
+            port $BREAKOUT_PORT_ID {
+                number-of-sub-ports $BREAKOUT_SUB_PORTS;
+                speed $BREAKOUT_SPEED;
+            }
+        }
+    }
+    network-services enhanced-ip;
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/cos/exp-classifiers-schedulers.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/cos/exp-classifiers-schedulers.conf
@@ -1,0 +1,109 @@
+/*
+ * Topic:   MPLS EXP-based QoS — classifiers, forwarding classes, schedulers, and rewrite rules
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - 4 forwarding classes: FC-LLQ (strict-high, queue 2) for low-latency finance traffic,
+ *    FC-HIGH (queue 1), CONTROL (queue 3), BEST-EFFORT (queue 0)
+ *  - EXP classifier maps 3-bit MPLS EXP values to forwarding classes
+ *  - EXP rewrite rule re-marks egress frames to preserve QoS across hops
+ *  - scheduler-map applied per-interface with classifier + rewrite on each unit
+ *  - FC-LLQ uses strict-high priority for deterministic low-latency forwarding
+ *
+ * Pair with:
+ *  - junos/interfaces/physical-p2p-mpls.conf  (interfaces where CoS is applied)
+ *  - junos/transport/mpls-lsp-p2mp.conf       (MPLS transport carrying marked traffic)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $INTERFACE_1     e.g. et-0/0/1
+ *   $INTERFACE_2     e.g. et-0/0/3
+ */
+
+class-of-service {
+    classifiers {
+        exp EXP {
+            forwarding-class FC-HIGH {
+                loss-priority low code-points 001;
+            }
+            forwarding-class BEST-EFFORT {
+                loss-priority low code-points 000;
+            }
+            forwarding-class FC-LLQ {
+                loss-priority low code-points 010;
+            }
+            forwarding-class CONTROL {
+                loss-priority low code-points 011;
+            }
+        }
+    }
+    forwarding-classes {
+        class FC-HIGH queue-num 1;
+        class BEST-EFFORT queue-num 0;
+        class CONTROL queue-num 3;
+        class FC-LLQ queue-num 2;
+    }
+    interfaces {
+        $INTERFACE_1 {
+            scheduler-map sched-map;
+            unit 0 {
+                classifiers {
+                    exp EXP;
+                }
+                rewrite-rules {
+                    exp EXP_REWRITE;
+                }
+            }
+        }
+        $INTERFACE_2 {
+            scheduler-map sched-map;
+            unit 0 {
+                classifiers {
+                    exp EXP;
+                }
+                rewrite-rules {
+                    exp EXP_REWRITE;
+                }
+            }
+        }
+    }
+    rewrite-rules {
+        exp EXP_REWRITE {
+            forwarding-class FC-HIGH {
+                loss-priority low code-point 001;
+            }
+            forwarding-class BEST-EFFORT {
+                loss-priority low code-point 000;
+            }
+            forwarding-class FC-LLQ {
+                loss-priority low code-point 010;
+            }
+            forwarding-class CONTROL {
+                loss-priority low code-point 011;
+            }
+        }
+    }
+    scheduler-maps {
+        sched-map {
+            forwarding-class BEST-EFFORT scheduler s0;
+            forwarding-class FC-HIGH scheduler s1;
+            forwarding-class FC-LLQ scheduler s2;
+            forwarding-class CONTROL scheduler s3;
+        }
+    }
+    schedulers {
+        s0 {
+            priority low;
+        }
+        s1 {
+            priority low;
+        }
+        s2 {
+            priority strict-high;
+        }
+        s3 {
+            priority low;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/firewall/multicast-fwd-cache-filter.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/firewall/multicast-fwd-cache-filter.conf
@@ -1,0 +1,48 @@
+/*
+ * Topic:   Multicast forwarding-cache filters with destination-based CoS marking
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - interface-specific allows per-IRB filter counters and statistics
+ *  - mfc-filter: classifies 225.0.0.0/16 multicast to FC-LLQ (strict-high) for stock exchange
+ *  - mfc-filter1/2/3: classify unicast VRF traffic into FC-HIGH / BEST-EFFORT / CONTROL
+ *  - Applied as input filter on IRB interfaces to mark at L3 ingress before MPLS encap
+ *  - Ensures multicast stock-exchange data gets low-latency queue treatment end-to-end
+ *
+ * Pair with:
+ *  - junos/interfaces/irb-l3-gateway.conf      (filter applied on IRB input)
+ *  - junos/cos/exp-classifiers-schedulers.conf  (forwarding classes referenced here)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $FILTER_NAME           e.g. mfc-filter
+ *   $MCAST_DEST_PREFIX     e.g. 225.0.0.0/16
+ *   $FORWARDING_CLASS      e.g. FC-LLQ
+ *   $UNICAST_DEST_1        e.g. 10.8.21.2/32
+ *   $UNICAST_DEST_2        e.g. 10.9.21.2/32
+ *   $UNICAST_FWD_CLASS     e.g. FC-HIGH
+ */
+
+firewall {
+    family inet {
+        filter $FILTER_NAME {
+            interface-specific;
+            term stock_exch {
+                from {
+                    destination-address {
+                        $MCAST_DEST_PREFIX;
+                    }
+                }
+                then {
+                    count c1;
+                    loss-priority low;
+                    forwarding-class $FORWARDING_CLASS;
+                }
+            }
+            term accept-all-else {
+                then accept;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/flexible-vlan-subinterface.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/flexible-vlan-subinterface.conf
@@ -1,0 +1,37 @@
+/*
+ * Topic:   Flexible VLAN-tagged subinterfaces with per-unit addressing
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - flexible-vlan-tagging + flexible-ethernet-services enables mixed encapsulation per-unit
+ *  - Each unit carries a distinct VLAN-ID and IPv4 /30 or /24 address for PE-CE connectivity
+ *  - Used for per-VRF / per-virtual-router PE-CE links on CR devices
+ *  - Multiple units (13+) on a single physical interface to scale VPN instances
+ *
+ * Pair with:
+ *  - junos/services/virtual-router-instance.conf  (VR instances bind these subinterfaces)
+ *  - junos/oam/twamp-client.conf                  (TWAMP probes use these as source)
+ *
+ * Variables (example values from cr2_mx480):
+ *   $INTERFACE_NAME   e.g. et-5/0/0
+ *   $DESCRIPTION      e.g. CR2_AP1
+ *   $UNIT_ID          e.g. 1
+ *   $VLAN_ID          e.g. 1
+ *   $IPV4_ADDRESS     e.g. 10.101.49.2/30
+ */
+
+interfaces {
+    $INTERFACE_NAME {
+        description "$DESCRIPTION";
+        flexible-vlan-tagging;
+        encapsulation flexible-ethernet-services;
+        unit $UNIT_ID {
+            vlan-id $VLAN_ID;
+            family inet {
+                address $IPV4_ADDRESS;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/irb-l3-gateway.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/irb-l3-gateway.conf
@@ -1,0 +1,37 @@
+/*
+ * Topic:   IRB L3 gateway with multicast forwarding-cache filter and static MAC
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - IRB provides L3 gateway for EVPN bridge-domains (routed multicast ingress)
+ *  - Input filter (mfc-filter) classifies multicast traffic into QoS forwarding classes
+ *  - Static MAC per unit ensures deterministic gateway MAC across EVPN active/standby
+ *  - One IRB unit per MVPN instance / EVPN bridge-domain
+ *
+ * Pair with:
+ *  - junos/services/evpn-virtual-switch-esi.conf  (bridge-domain routing-interface irb.N)
+ *  - junos/services/mvpn-instance.conf            (MVPN instance binds interface irb.N)
+ *  - junos/firewall/multicast-fwd-cache-filter.conf (mfc-filter applied here)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $UNIT_ID        e.g. 1
+ *   $FILTER_NAME    e.g. mfc-filter
+ *   $IPV4_ADDRESS   e.g. 172.16.1.1/24
+ *   $STATIC_MAC     e.g. 00:10:94:00:00:01
+ */
+
+interfaces {
+    irb {
+        unit $UNIT_ID {
+            family inet {
+                filter {
+                    input $FILTER_NAME;
+                }
+                address $IPV4_ADDRESS;
+            }
+            mac $STATIC_MAC;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/lag-esi-lacp.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/lag-esi-lacp.conf
@@ -1,0 +1,73 @@
+/*
+ * Topic:   ESI-based LAG with LACP, single-active DF election, and vlan-bridge units
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - Interface-level ESI with single-active redundancy for EVPN multihoming
+ *  - df-election-granularity per-esi with lacp-oos-on-ndf takes non-DF link out-of-service
+ *  - Per-unit ESI allows per-VLAN designated-forwarder assignment
+ *  - LACP system-priority + system-id must match across ESI peers (wanedge1 + wanedge2)
+ *  - vlan-bridge encapsulation on each unit ties into EVPN virtual-switch instances
+ *
+ * Pair with:
+ *  - junos/services/evpn-virtual-switch-esi.conf  (EVPN instances reference ae0 units)
+ *  - junos/interfaces/irb-l3-gateway.conf         (IRB interfaces for L3 gateway)
+ *  - junos/bootstrap/chassis-config.conf          (aggregated-devices device-count)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $AE_NAME             e.g. ae0
+ *   $DESCRIPTION         e.g. Link to WANEdge1 to L2/L3Edge AE
+ *   $MTU                 e.g. 1522
+ *   $ESI_ID              e.g. 00:11:11:11:11:11:12:12:12:12
+ *   $DF_PREFERENCE       e.g. 150
+ *   $LACP_PRIORITY       e.g. 100
+ *   $LACP_SYSTEM_ID      e.g. 00:00:00:00:00:10
+ *   $VLAN_ID             e.g. 1
+ *   $UNIT_ESI            e.g. 00:01:71:81:11:12:a1:00:00:01
+ *   $UNIT_DF_PREFERENCE  e.g. 150
+ */
+
+interfaces {
+    $AE_NAME {
+        description "$DESCRIPTION";
+        flexible-vlan-tagging;
+        mtu $MTU;
+        encapsulation flexible-ethernet-services;
+        esi {
+            $ESI_ID;
+            single-active;
+            df-election-granularity {
+                per-esi {
+                    lacp-oos-on-ndf;
+                }
+            }
+            df-election-type {
+                preference {
+                    value $DF_PREFERENCE;
+                }
+            }
+        }
+        aggregated-ether-options {
+            lacp {
+                active;
+                system-priority $LACP_PRIORITY;
+                system-id $LACP_SYSTEM_ID;
+            }
+        }
+        unit $VLAN_ID {
+            encapsulation vlan-bridge;
+            vlan-id $VLAN_ID;
+            esi {
+                $UNIT_ESI;
+                single-active;
+                df-election-type {
+                    preference {
+                        value $UNIT_DF_PREFERENCE;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/loopback-multi-af.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/loopback-multi-af.conf
@@ -1,0 +1,48 @@
+/*
+ * Topic:   Loopback interface with IPv4, ISO, and IPv6 address families
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004 cr2_mx480
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr cr1_acx7100-48l l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - Primary/preferred IPv4 used as router-id and BGP local-address
+ *  - ISO address required for OSPF/IS-IS CLNS adjacency
+ *  - IPv6 primary enables dual-stack management and IPv6 BGP peering
+ *  - 127.0.0.x addresses used for internal loopback functions
+ *
+ * Pair with:
+ *  - junos/transport/ibgp-core-mesh.conf       (local-address sourced from lo0)
+ *  - junos/transport/ospf-te-protection.conf   (lo0 passive interface in area 0)
+ *
+ * Variables (example values from ap1_mx304):
+ *   $ROUTER_ID_ADDRESS   e.g. 10.200.50.13/32
+ *   $MGMT_LOOPBACK       e.g. 10.255.163.148/32
+ *   $ISO_ADDRESS         e.g. 47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00
+ *   $IPV6_ADDRESS        e.g. 2001:db8::10:255:163:148/128
+ */
+
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address $ROUTER_ID_ADDRESS {
+                    primary;
+                    preferred;
+                }
+                address 127.0.0.1/32;
+                address 127.0.0.64/32;
+                address $MGMT_LOOPBACK {
+                    primary;
+                }
+            }
+            family iso {
+                address $ISO_ADDRESS;
+            }
+            family inet6 {
+                address $IPV6_ADDRESS {
+                    primary;
+                }
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/physical-p2p-mpls.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/physical-p2p-mpls.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:   Core point-to-point interfaces with inet/ISO/MPLS families
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - Multi-protocol family (inet + ISO + MPLS) on every core-facing link
+ *  - ISO enables IS-IS/CLNS routing; MPLS enables label switching
+ *  - /24 point-to-point addressing convention for inter-router links
+ *
+ * Pair with:
+ *  - junos/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)
+ *  - junos/transport/mpls-lsp-p2mp.conf       (MPLS LSPs traverse these interfaces)
+ *  - junos/transport/rsvp-signaling.conf      (RSVP signaling on these interfaces)
+ *  - junos/bootstrap/chassis-config.conf      (port speed defined at chassis level)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $INTERFACE_NAME   e.g. et-0/0/1
+ *   $DESCRIPTION      e.g. Link to WANEdge1 to WANEdge2
+ *   $IPV4_ADDRESS     e.g. 10.101.25.1/24
+ */
+
+interfaces {
+    $INTERFACE_NAME {
+        description "$DESCRIPTION";
+        unit 0 {
+            family inet {
+                address $IPV4_ADDRESS;
+            }
+            family iso;
+            family mpls;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/multicast/forwarding-multicast-tuning.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/multicast/forwarding-multicast-tuning.conf
@@ -1,0 +1,27 @@
+/*
+ * Topic:   Multicast forwarding-options tuning — resolve-rate and mismatch-rate
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - resolve-rate 1000 pps: max rate for resolving new multicast (S,G) entries in the PFE
+ *  - mismatch-rate 1000 pps: max rate for handling RPF mismatch packets to RE
+ *  - Critical for finance/stock-exchange multicast to prevent PFE drops during burst joins
+ *  - Default values (~100 pps) are insufficient for high-frequency multicast environments
+ *
+ * Pair with:
+ *  - junos/services/mvpn-instance.conf              (MVPN drives multicast state creation)
+ *  - junos/firewall/multicast-fwd-cache-filter.conf (CoS marking for multicast traffic)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $RESOLVE_RATE    e.g. 1000
+ *   $MISMATCH_RATE   e.g. 1000
+ */
+
+forwarding-options {
+    multicast {
+        resolve-rate $RESOLVE_RATE;
+        mismatch-rate $MISMATCH_RATE;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/oam/lldp-discovery.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/oam/lldp-discovery.conf
@@ -1,0 +1,20 @@
+/*
+ * Topic:   LLDP protocol enabled on all interfaces for neighbor discovery
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004 cr2_mx480
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr cr1_acx7100-48l l2-l3_edge_acx7100
+ *
+ * Highlights:
+ *  - "interface all" enables LLDP on every physical port
+ *  - Essential for topology discovery and cable verification
+ *  - No per-interface filtering or hold-time tuning in this JVD
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   (no variables — static config)
+ */
+
+protocols {
+    lldp {
+        interface all;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/oam/twamp-client.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/oam/twamp-client.conf
@@ -1,0 +1,49 @@
+/*
+ * Topic:   TWAMP client with per-virtual-router control connections and test sessions
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - TWAMP client (RFC 5357) probes AP reflectors for per-VRF latency/jitter measurement
+ *  - One control-connection per VR targeting each AP server (dual-homed: AP1 + AP2)
+ *  - routing-instance scoping ensures probes originate from the correct VRF
+ *  - probe-count 100 at probe-interval 1s for continuous 100-second measurement cycles
+ *  - test-count 0 means infinite test iterations (continuous monitoring)
+ *  - destination-port per connection matches server routing-instance-list port mapping
+ *
+ * Pair with:
+ *  - junos/oam/twamp-server.conf                    (AP nodes run the reflector)
+ *  - junos/services/virtual-router-instance.conf    (VR instances where probes originate)
+ *  - junos/interfaces/flexible-vlan-subinterface.conf (PE-CE links carrying probes)
+ *
+ * Variables (example values from cr2_mx480):
+ *   $CONNECTION_NAME     e.g. CR24_1
+ *   $DEST_PORT           e.g. 862
+ *   $ROUTING_INSTANCE    e.g. VIRTUAL-ROUTER-V1
+ *   $TARGET_ADDRESS      e.g. 10.101.49.1
+ *   $TEST_SESSION_NAME   e.g. T24_1
+ *   $PROBE_COUNT         e.g. 100
+ *   $PROBE_INTERVAL      e.g. 1
+ */
+
+services {
+    rpm {
+        twamp {
+            client {
+                control-connection $CONNECTION_NAME {
+                    control-type managed;
+                    destination-port $DEST_PORT;
+                    routing-instance $ROUTING_INSTANCE;
+                    target-address $TARGET_ADDRESS;
+                    test-count 0;
+                    test-session $TEST_SESSION_NAME {
+                        target-address $TARGET_ADDRESS;
+                        probe-count $PROBE_COUNT;
+                        probe-interval $PROBE_INTERVAL;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/oam/twamp-server.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/oam/twamp-server.conf
@@ -1,0 +1,52 @@
+/*
+ * Topic:   TWAMP server with per-VRF port mappings and client authentication lists
+ * Seen on:
+ *   Junos: ap1_mx304 ap2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - TWAMP server (RFC 5357) provides reflector endpoints for latency/jitter measurement
+ *  - routing-instance-list maps each MVPN/VRF to a unique port (862 + 49152-49163)
+ *  - Per-client address lists (CR1_N, CR2_N) restrict which probers can connect
+ *  - authentication-mode none for minimal overhead in controlled lab/DC environment
+ *  - "light" mode enables lightweight TWAMP-Light without full control session
+ *  - Port 1862 as global server port for non-VRF probes
+ *
+ * Pair with:
+ *  - junos/oam/twamp-client.conf         (CR nodes probe this server)
+ *  - junos/services/mvpn-instance.conf   (VRF instances whose latency is monitored)
+ *
+ * Variables (example values from ap1_mx304):
+ *   $VRF_NAME_1          e.g. MVPN_INSTANCE1
+ *   $VRF_PORT_1          e.g. 862
+ *   $VRF_NAME_2          e.g. MVPN_INSTANCE2
+ *   $VRF_PORT_2          e.g. 49152
+ *   $GLOBAL_PORT         e.g. 1862
+ *   $CLIENT_LIST_NAME    e.g. CR1_1
+ *   $CLIENT_ADDRESS      e.g. 10.101.48.2/32
+ */
+
+services {
+    rpm {
+        twamp {
+            server {
+                routing-instance-list {
+                    $VRF_NAME_1 {
+                        port $VRF_PORT_1;
+                    }
+                    $VRF_NAME_2 {
+                        port $VRF_PORT_2;
+                    }
+                }
+                authentication-mode none;
+                port $GLOBAL_PORT;
+                client-list $CLIENT_LIST_NAME {
+                    address {
+                        $CLIENT_ADDRESS;
+                    }
+                }
+                light;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/policy/protocol-redistribution.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/policy/protocol-redistribution.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:   Routing policy statements for BGP/OSPF/direct protocol redistribution
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - PS-ADV_DIRECT: redistributes directly-connected routes into BGP
+ *  - PS-BGP-TO-OSPF: leaks BGP-learned routes into OSPF (for CE reachability)
+ *  - PS-send-ospf: exports OSPF routes into BGP for VPN distribution
+ *  - Simple accept-all policies — no route-filtering or manipulation
+ *
+ * Pair with:
+ *  - junos/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $DIRECT_POLICY_NAME   e.g. PS-ADV_DIRECT
+ *   $BGP_TO_OSPF_NAME     e.g. PS-BGP-TO-OSPF
+ *   $OSPF_TO_BGP_NAME     e.g. PS-send-ospf
+ */
+
+policy-options {
+    policy-statement $DIRECT_POLICY_NAME {
+        from protocol direct;
+        then accept;
+    }
+    policy-statement $BGP_TO_OSPF_NAME {
+        from protocol bgp;
+        then accept;
+    }
+    policy-statement $OSPF_TO_BGP_NAME {
+        from protocol ospf;
+        then accept;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/policy/route-filter-med.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/policy/route-filter-med.conf
@@ -1,0 +1,44 @@
+/*
+ * Topic:   Route-filter-based MED metric assignment for BGP export
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - PS-med-10: assigns MED 10 to specific infrastructure prefix (preferred path)
+ *  - PS-med-30: assigns MED 30 to all other prefixes (less-preferred backup)
+ *  - Used as export policy in virtual-router BGP groups to influence AP path selection
+ *  - route-filter with "exact" match for precise prefix control
+ *
+ * Pair with:
+ *  - junos/services/virtual-router-instance.conf  (BGP group references these as export)
+ *  - junos/policy/protocol-redistribution.conf    (other policies in same policy-options)
+ *
+ * Variables (example values from cr2_mx480):
+ *   $MED_LOW_NAME       e.g. PS-med-10
+ *   $MED_LOW_PREFIX     e.g. 10.101.0.0/16
+ *   $MED_LOW_VALUE      e.g. 10
+ *   $MED_HIGH_NAME      e.g. PS-med-30
+ *   $MED_HIGH_VALUE     e.g. 30
+ */
+
+policy-options {
+    policy-statement $MED_LOW_NAME {
+        from {
+            route-filter $MED_LOW_PREFIX exact;
+        }
+        then {
+            metric $MED_LOW_VALUE;
+            accept;
+        }
+    }
+    policy-statement $MED_HIGH_NAME {
+        from {
+            route-filter 0.0.0.0/0 longer;
+        }
+        then {
+            metric $MED_HIGH_VALUE;
+            accept;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/evpn-virtual-switch-esi.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/evpn-virtual-switch-esi.conf
@@ -1,0 +1,50 @@
+/*
+ * Topic:   EVPN virtual-switch instance with MPLS encapsulation and bridge-domain
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - instance-type virtual-switch: provides per-tenant MAC/VLAN isolation
+ *  - EVPN with MPLS encapsulation for Type-2 MAC/IP and Type-3 IM route exchange
+ *  - default-gateway do-not-advertise: suppresses gateway MAC advertisement (anycast not used)
+ *  - no-control-word: omits 4-byte control word for compatibility with older MPLS nodes
+ *  - bridge-domain binds ESI LAG unit + IRB routing-interface for integrated routing/bridging
+ *  - One virtual-switch instance per VLAN/service (EVPN_ESI_LAG1 through LAG23)
+ *
+ * Pair with:
+ *  - junos/interfaces/lag-esi-lacp.conf     (ae0 units referenced in bridge-domains)
+ *  - junos/interfaces/irb-l3-gateway.conf   (IRB routing-interface for L3 gateway)
+ *  - junos/services/mvpn-instance.conf      (MVPN uses same IRB for multicast ingress)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $INSTANCE_NAME         e.g. EVPN_ESI_LAG1
+ *   $BD_NAME               e.g. BD_EVPN_GROUP1
+ *   $VLAN_ID               e.g. 1
+ *   $AE_UNIT               e.g. ae0.1
+ *   $IRB_UNIT              e.g. irb.1
+ *   $ROUTE_DISTINGUISHER   e.g. 10.200.50.12:1
+ *   $VRF_TARGET            e.g. target:61535:1
+ */
+
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type virtual-switch;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                default-gateway do-not-advertise;
+                no-control-word;
+            }
+        }
+        bridge-domains {
+            $BD_NAME {
+                vlan-id $VLAN_ID;
+                interface $AE_UNIT;
+                routing-interface $IRB_UNIT;
+            }
+        }
+        route-distinguisher $ROUTE_DISTINGUISHER;
+        vrf-target $VRF_TARGET;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/mvpn-instance.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/mvpn-instance.conf
@@ -1,0 +1,107 @@
+/*
+ * Topic:   NG-MVPN VRF instance with PIM, OSPF, BGP, and RSVP-TE provider-tunnel
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - instance-type vrf with mvpn protocol for NG-MVPN (RFC 6513/6514)
+ *  - mvpn-mode spt-only: shortest-path-tree only (no shared-tree), optimal for finance
+ *  - hot-root-standby with source-tree: pre-builds backup multicast tree for fast failover
+ *  - min-rate 3m + revert-delay 5: traffic threshold and holdoff for standby activation
+ *  - sender-based-rpf: validates multicast source via BGP MVPN routes (not RPF on IGP)
+ *  - PIM local RP with per-instance multicast group-ranges (225.0.x.0/22 per VRF)
+ *  - provider-tunnel rsvp-te with default-template: uses P2MP LSP for multicast transport
+ *  - Per-VRF OSPF for CE route distribution + BGP eBGP for traffic-generator peering
+ *
+ * Pair with:
+ *  - junos/transport/mpls-lsp-p2mp.conf               (P2MP template referenced)
+ *  - junos/interfaces/irb-l3-gateway.conf             (IRB interface bound to this VRF)
+ *  - junos/multicast/forwarding-multicast-tuning.conf (multicast PFE rate-limiting)
+ *  - junos/firewall/multicast-fwd-cache-filter.conf   (CoS marking on multicast ingress)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $INSTANCE_NAME       e.g. MVPN_INSTANCE1
+ *   $CE_LOCAL_ADDRESS    e.g. 172.16.1.1
+ *   $CE_NEIGHBOR         e.g. 172.16.1.2
+ *   $CE_PEER_AS          e.g. 64513
+ *   $MVPN_RT_IMPORT      e.g. target:64512:101
+ *   $MVPN_RT_EXPORT      e.g. target:64512:101
+ *   $RP_ADDRESS          e.g. 10.10.47.101
+ *   $MCAST_GROUP_RANGE   e.g. 225.0.0.0/22
+ *   $IRB_UNIT            e.g. irb.1
+ *   $LO_UNIT             e.g. lo0.1
+ *   $ROUTE_DISTINGUISHER e.g. 10.200.50.12:61
+ *   $VRF_TARGET          e.g. target:64512:11
+ */
+
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type vrf;
+        protocols {
+            bgp {
+                group custA_TGN {
+                    type external;
+                    local-address $CE_LOCAL_ADDRESS;
+                    export PS-ADV_DIRECT;
+                    neighbor $CE_NEIGHBOR {
+                        peer-as $CE_PEER_AS;
+                    }
+                }
+            }
+            mvpn {
+                sender-site;
+                mvpn-mode {
+                    spt-only;
+                }
+                route-target {
+                    import-target {
+                        target $MVPN_RT_IMPORT;
+                    }
+                    export-target {
+                        target $MVPN_RT_EXPORT;
+                    }
+                }
+                sender-based-rpf;
+                hot-root-standby {
+                    source-tree;
+                    min-rate {
+                        rate 3m;
+                        revert-delay 5;
+                    }
+                }
+            }
+            ospf {
+                area 0.0.0.0 {
+                    interface $LO_UNIT;
+                }
+                export PS-send-ospf;
+            }
+            pim {
+                join-prune-timeout 420;
+                rp {
+                    local {
+                        address $RP_ADDRESS;
+                        group-ranges {
+                            $MCAST_GROUP_RANGE;
+                        }
+                    }
+                }
+                interface $IRB_UNIT;
+                interface $LO_UNIT;
+            }
+        }
+        interface $IRB_UNIT;
+        interface $LO_UNIT;
+        route-distinguisher $ROUTE_DISTINGUISHER;
+        vrf-target $VRF_TARGET;
+        vrf-table-label;
+        provider-tunnel {
+            rsvp-te {
+                label-switched-path-template {
+                    default-template;
+                }
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/virtual-router-instance.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/virtual-router-instance.conf
@@ -1,0 +1,78 @@
+/*
+ * Topic:   Virtual-router instance with BGP, PIM sparse-mode, and multicast RP
+ * Seen on:
+ *   Junos: cr2_mx480
+ *   EVO:   cr1_acx7100-48l
+ *
+ * Highlights:
+ *  - instance-type virtual-router: full routing table isolation without MPLS VPN signaling
+ *  - eBGP group "AP" peers to both AP nodes with MED export policy for path preference
+ *  - iBGP group "IXIA" for traffic-generator peering within the VR
+ *  - PIM sparse-mode with static RP pointing to AP node's loopback (multicast receiver side)
+ *  - Each VR gets unique multicast group-ranges matching the MVPN sender's PIM RP config
+ *  - VRFs V21/V22/V23 omit PIM (unicast-only traffic classes)
+ *
+ * Pair with:
+ *  - junos/interfaces/flexible-vlan-subinterface.conf (PE-CE interfaces bound to VR)
+ *  - junos/oam/twamp-client.conf                     (TWAMP probes originate per-VR)
+ *  - junos/policy/route-filter-med.conf              (MED export policies referenced)
+ *
+ * Variables (example values from cr2_mx480):
+ *   $VR_NAME             e.g. VIRTUAL-ROUTER-V1
+ *   $AP_PEER_AS          e.g. 64512
+ *   $AP_NEIGHBOR_1       e.g. 10.101.49.1
+ *   $AP_NEIGHBOR_2       e.g. 10.101.79.1
+ *   $EXPORT_POLICIES     e.g. [ med-10 med-30 ]
+ *   $IXIA_PEER_AS        e.g. 64521
+ *   $IXIA_NEIGHBOR       e.g. 10.101.91.2
+ *   $RP_ADDRESS          e.g. 10.10.47.101
+ *   $MCAST_GROUP_RANGE   e.g. 225.0.0.0/22
+ *   $IFACE_AP1           e.g. et-5/0/0.1
+ *   $IFACE_AP2           e.g. et-5/0/1.1
+ *   $IFACE_TG            e.g. xe-3/0/6.1
+ */
+
+routing-instances {
+    $VR_NAME {
+        instance-type virtual-router;
+        protocols {
+            bgp {
+                group AP {
+                    type external;
+                    export $EXPORT_POLICIES;
+                    peer-as $AP_PEER_AS;
+                    neighbor $AP_NEIGHBOR_1;
+                    neighbor $AP_NEIGHBOR_2;
+                }
+                group IXIA {
+                    type internal;
+                    peer-as $IXIA_PEER_AS;
+                    neighbor $IXIA_NEIGHBOR;
+                }
+            }
+            pim {
+                rp {
+                    static {
+                        address $RP_ADDRESS {
+                            group-ranges {
+                                $MCAST_GROUP_RANGE;
+                            }
+                        }
+                    }
+                }
+                interface $IFACE_AP1 {
+                    mode sparse;
+                }
+                interface $IFACE_AP2 {
+                    mode sparse;
+                }
+                interface $IFACE_TG {
+                    mode sparse;
+                }
+            }
+        }
+        interface $IFACE_TG;
+        interface $IFACE_AP1;
+        interface $IFACE_AP2;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/vrf-l3vpn.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/vrf-l3vpn.conf
@@ -1,0 +1,51 @@
+/*
+ * Topic:   L3VPN VRF instance with external BGP peer (traffic-generator / CE device)
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - instance-type vrf for L3VPN isolation (non-multicast VRFs: VRF21/22/23)
+ *  - eBGP peering to traffic-generator or CE device in each VRF
+ *  - vrf-table-label enables per-VRF MPLS label for penultimate-hop popping
+ *  - route-distinguisher unique per-PE per-VRF for BGP path distinction
+ *  - vrf-target with shared RT allows route import/export between PE nodes
+ *  - IRB interface provides the VRF's L3 gateway
+ *
+ * Pair with:
+ *  - junos/interfaces/irb-l3-gateway.conf             (IRB bound to this VRF)
+ *  - junos/firewall/multicast-fwd-cache-filter.conf   (filter on IRB for these VRFs)
+ *  - junos/transport/ibgp-core-mesh.conf              (inet-vpn family carries VRF routes)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $VRF_NAME             e.g. VRF21
+ *   $LOCAL_ADDRESS        e.g. 172.16.21.1
+ *   $EXPORT_POLICY        e.g. PS-ADV_DIRECT
+ *   $CE_NEIGHBOR          e.g. 172.16.21.2
+ *   $CE_PEER_AS           e.g. 64513
+ *   $IRB_UNIT             e.g. irb.21
+ *   $ROUTE_DISTINGUISHER  e.g. 10.200.50.12:221
+ *   $VRF_TARGET           e.g. target:64512:21
+ */
+
+routing-instances {
+    $VRF_NAME {
+        instance-type vrf;
+        protocols {
+            bgp {
+                group TGN_AF {
+                    type external;
+                    local-address $LOCAL_ADDRESS;
+                    export $EXPORT_POLICY;
+                    neighbor $CE_NEIGHBOR {
+                        peer-as $CE_PEER_AS;
+                    }
+                }
+            }
+        }
+        interface $IRB_UNIT;
+        route-distinguisher $ROUTE_DISTINGUISHER;
+        vrf-target $VRF_TARGET;
+        vrf-table-label;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ibgp-core-mesh.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ibgp-core-mesh.conf
@@ -1,0 +1,63 @@
+/*
+ * Topic:   iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - family inet-vpn unicast + any for L3VPN route exchange
+ *  - family evpn signaling for EVPN Type-1 through Type-5
+ *  - family inet-mvpn signaling for NG-MVPN (multicast VPN) control plane
+ *  - family route-target enables RT-constrain to limit VPN route distribution
+ *  - BFD at 100ms × 3 for sub-second peer failure detection
+ *  - All peers in a single iBGP group (full mesh, no route-reflectors)
+ *
+ * Pair with:
+ *  - junos/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)
+ *  - junos/transport/mpls-lsp-p2mp.conf        (label transport for VPN families)
+ *  - junos/policy/protocol-redistribution.conf (export policies referenced in group)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $LOCAL_ADDRESS   e.g. 10.200.50.12
+ *   $LOCAL_AS        e.g. 64512
+ *   $EXPORT_POLICY   e.g. [ PS-send-ospf PS-BGP-TO-OSPF ]
+ *   $NEIGHBOR_1      e.g. 10.200.50.13
+ *   $NEIGHBOR_2      e.g. 10.200.50.14
+ *   $NEIGHBOR_3      e.g. 10.200.50.15
+ *   $NEIGHBOR_4      e.g. 10.200.50.11
+ *   $NEIGHBOR_5      e.g. 10.200.50.16
+ */
+
+protocols {
+    bgp {
+        group IBGP {
+            type internal;
+            local-address $LOCAL_ADDRESS;
+            family inet {
+                unicast;
+            }
+            family inet-vpn {
+                unicast;
+                any;
+            }
+            family evpn {
+                signaling;
+            }
+            family inet-mvpn {
+                signaling;
+            }
+            family route-target;
+            export $EXPORT_POLICY;
+            local-as $LOCAL_AS;
+            bfd-liveness-detection {
+                minimum-interval 100;
+                multiplier 3;
+            }
+            neighbor $NEIGHBOR_1;
+            neighbor $NEIGHBOR_2;
+            neighbor $NEIGHBOR_3;
+            neighbor $NEIGHBOR_4;
+            neighbor $NEIGHBOR_5;
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/mpls-lsp-p2mp.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/mpls-lsp-p2mp.conf
@@ -1,0 +1,54 @@
+/*
+ * Topic:   MPLS LSPs with P2MP template and named point-to-point paths
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   (none)
+ *
+ * Highlights:
+ *  - P2MP LSP template enables dynamic multipoint trees for NG-MVPN provider-tunnels
+ *  - optimize-aggressive + optimize-timer 5 enables frequent CSPF reoptimization
+ *  - link-protection on P2MP template provides FRR bypass tunnels
+ *  - Named unicast LSPs (lsp_to_*) provide pre-established paths to PE/AP peers
+ *  - retry-timer 5 for fast LSP re-establishment after failure
+ *
+ * Pair with:
+ *  - junos/transport/rsvp-signaling.conf     (RSVP signals these LSPs)
+ *  - junos/transport/ospf-te-protection.conf (CSPF uses OSPF-TE TED)
+ *  - junos/services/mvpn-instance.conf       (MVPN uses P2MP provider-tunnel)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $P2MP_LSP_NAME     e.g. P2MP
+ *   $LSP_NAME_1        e.g. lsp_to_AP1
+ *   $LSP_DEST_1        e.g. 10.200.50.14
+ *   $LSP_NAME_2        e.g. lsp_to_AP2
+ *   $LSP_DEST_2        e.g. 10.200.50.16
+ *   $LSP_NAME_3        e.g. lsp_to_PE2
+ *   $LSP_DEST_3        e.g. 10.200.50.15
+ *   $CORE_IFACE_1      e.g. et-0/0/1.0
+ *   $CORE_IFACE_2      e.g. et-0/0/3.0
+ */
+
+protocols {
+    mpls {
+        optimize-aggressive;
+        label-switched-path $P2MP_LSP_NAME {
+            template;
+            retry-timer 5;
+            optimize-timer 5;
+            link-protection;
+            p2mp;
+        }
+        label-switched-path $LSP_NAME_1 {
+            to $LSP_DEST_1;
+        }
+        label-switched-path $LSP_NAME_2 {
+            to $LSP_DEST_2;
+        }
+        label-switched-path $LSP_NAME_3 {
+            to $LSP_DEST_3;
+        }
+        interface $CORE_IFACE_1;
+        interface $CORE_IFACE_2;
+        interface lo0.0;
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ospf-te-protection.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ospf-te-protection.conf
@@ -1,0 +1,49 @@
+/*
+ * Topic:   OSPF with traffic engineering, node-link-protection, and BFD
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - traffic-engineering enables OSPF-TE extensions (RFC 3630) for RSVP-TE CSPF
+ *  - node-link-protection provides LFA backup for sub-50ms failover
+ *  - BFD at 10ms × 3 for ultra-fast adjacency failure detection (finance/low-latency)
+ *  - lo0.0 as passive ensures router-id reachability without forming adjacency
+ *  - All interfaces in area 0.0.0.0 (single-area backbone)
+ *
+ * Pair with:
+ *  - junos/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)
+ *  - junos/transport/mpls-lsp-p2mp.conf        (MPLS LSPs use CSPF paths)
+ *  - junos/interfaces/physical-p2p-mpls.conf   (the physical interfaces referenced)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $CORE_IFACE_1   e.g. et-0/0/1.0
+ *   $CORE_IFACE_2   e.g. et-0/0/3.0
+ *   $BFD_INTERVAL   e.g. 10
+ *   $BFD_MULTIPLIER e.g. 3
+ */
+
+protocols {
+    ospf {
+        traffic-engineering;
+        area 0.0.0.0 {
+            interface $CORE_IFACE_1 {
+                node-link-protection;
+                bfd-liveness-detection {
+                    minimum-interval $BFD_INTERVAL;
+                    multiplier $BFD_MULTIPLIER;
+                }
+            }
+            interface $CORE_IFACE_2 {
+                node-link-protection;
+                bfd-liveness-detection {
+                    minimum-interval $BFD_INTERVAL;
+                    multiplier $BFD_MULTIPLIER;
+                }
+            }
+            interface lo0.0 {
+                passive;
+            }
+        }
+    }
+}

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/rsvp-signaling.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/rsvp-signaling.conf
@@ -1,0 +1,29 @@
+/*
+ * Topic:   RSVP-TE interface enablement for label-switched path signaling
+ * Seen on:
+ *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *
+ * Highlights:
+ *  - RSVP enabled on all core transport interfaces and loopback
+ *  - Provides RSVP-TE signaling for traffic-engineered LSPs
+ *  - Works with OSPF-TE CSPF to compute constrained shortest paths
+ *  - lo0.0 included for targeted RSVP sessions (graceful restart, etc.)
+ *
+ * Pair with:
+ *  - junos/transport/mpls-lsp-p2mp.conf        (MPLS LSPs signaled via RSVP)
+ *  - junos/transport/ospf-te-protection.conf   (OSPF-TE provides path computation)
+ *  - junos/interfaces/physical-p2p-mpls.conf   (physical interfaces referenced)
+ *
+ * Variables (example values from wanedge1_mx304):
+ *   $CORE_IFACE_1   e.g. et-0/0/1.0
+ *   $CORE_IFACE_2   e.g. et-0/0/3.0
+ */
+
+protocols {
+    rsvp {
+        interface lo0.0;
+        interface $CORE_IFACE_1;
+        interface $CORE_IFACE_2;
+    }
+}

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,17 +1,19 @@
 {
-  "generatedAt": "2026-05-15T20:07:31.828Z",
+  "generatedAt": "2026-05-21T17:39:38.608Z",
   "counts": {
-    "total": 181,
-    "junos": 85,
-    "evo": 96,
-    "jvds": 4
+    "total": 267,
+    "junos": 131,
+    "evo": 136,
+    "jvds": 6
   },
   "categories": [
     "apply-groups",
     "bootstrap",
     "cos",
+    "ddos-mitigation",
     "firewall",
     "interfaces",
+    "multicast",
     "oam",
     "policy",
     "services",
@@ -24,6 +26,7 @@
     "Firewall",
     "Interfaces",
     "OAM",
+    "Other",
     "Policy & Routing",
     "QoS / CoS",
     "Service Overlay",
@@ -35,6 +38,7 @@
     "Business Services",
     "Core/Edge",
     "Data Center",
+    "Enterprise WAN",
     "MEF",
     "Metro",
     "SRv6",
@@ -62,6 +66,28 @@
         "junos": 30,
         "evo": 18,
         "total": 48
+      }
+    },
+    {
+      "id": "ewan_adv_core_edge",
+      "label": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "repoPath": "enterprise_wan/ewan_adv_core_edge",
+      "counts": {
+        "junos": 24,
+        "evo": 24,
+        "total": 48
+      }
+    },
+    {
+      "id": "ewan_finance",
+      "label": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "repoPath": "enterprise_wan/ewan_finance",
+      "counts": {
+        "junos": 22,
+        "evo": 16,
+        "total": 38
       }
     },
     {
@@ -1492,6 +1518,5969 @@
       "subfamily": "Routing Options",
       "usecases": [
         "Data Center"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/bootstrap/chassis-network-services",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "bootstrap",
+      "name": "chassis-network-services",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/bootstrap/chassis-network-services.conf",
+      "topic": "Chassis network-services and aggregated-device count (platform bootstrap)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "aggregated-devices ethernet device-count sets max ae interfaces (must precede ae config)",
+        "network-services enhanced-ip is REQUIRED on EVO for EVPN/MPLS service support",
+        "Without enhanced-ip, EVO defaults to ethernet mode (L2 only, no MPLS/VPN services)",
+        "This is the key EVO-specific bootstrap difference vs Junos MX platforms",
+        "Changing network-services requires a reboot — configure before deploying services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/lag-flexible-services.conf    (ae interfaces that need device-count)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/mpls-lsp.conf                  (MPLS services needing enhanced-ip)",
+          "id": null
+        },
+        {
+          "raw": "junos/bootstrap/chassis-network-services.conf (Junos sibling — no network-services line)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$DEVICE_COUNT",
+          "example": "25"
+        }
+      ],
+      "body": "chassis {\n    aggregated-devices {\n        ethernet {\n            device-count $DEVICE_COUNT;\n        }\n    }\n    network-services enhanced-ip;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">chassis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    aggregated-devices {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            device-count $DEVICE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    network-services enhanced-ip;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 145,
+      "lineCount": 8,
+      "techFamily": "Chassis",
+      "subfamily": "Chassis",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/cos/classifier-dscp-exp-8021p",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "classifier-dscp-exp-8021p",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/cos/classifier-dscp-exp-8021p.conf",
+      "topic": "Multi-field BA classifiers (DSCP, MPLS EXP, 802.1p → 8-class forwarding)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Identical 8-class model as Junos: BEST-EFFORT, LOW, MEDIUM, SIG-OAM, BUSINESS, REALTIME, NETWORK, CONTROL",
+        "DSCP classifier for CE-facing access interfaces",
+        "EXP classifier for core-facing MPLS interfaces",
+        "802.1p (ieee-802.1) classifier for VLAN-tagged service AC units",
+        "EVO uses the same class-of-service hierarchy as Junos — no syntax differences here"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/forwarding-class-map.conf   (queue-num mapping these classifiers feed into)",
+          "id": null
+        },
+        {
+          "raw": "evo/cos/rewrite-rules-exp.conf      (EXP rewrite on egress core interfaces)",
+          "id": null
+        },
+        {
+          "raw": "junos/cos/classifier-dscp-exp-8021p.conf  (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "class-of-service {\n    classifiers {\n        dscp DSCP {\n            forwarding-class BEST-EFFORT {\n                loss-priority low code-points be;\n            }\n            forwarding-class BUSINESS {\n                loss-priority low code-points [ cs4 af41 ];\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points cs7;\n            }\n            forwarding-class LOW {\n                loss-priority low code-points [ cs1 af11 ];\n            }\n            forwarding-class MEDIUM {\n                loss-priority high code-points [ cs2 af21 ];\n            }\n            forwarding-class NETWORK {\n                loss-priority low code-points cs6;\n            }\n            forwarding-class REALTIME {\n                loss-priority low code-points [ cs5 ef ];\n            }\n            forwarding-class SIG-OAM {\n                loss-priority low code-points [ cs3 af31 ];\n            }\n        }\n        exp EXP {\n            forwarding-class BEST-EFFORT {\n                loss-priority high code-points 000;\n            }\n            forwarding-class BUSINESS {\n                loss-priority high code-points 100;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points 111;\n            }\n            forwarding-class LOW {\n                loss-priority low code-points 001;\n            }\n            forwarding-class MEDIUM {\n                loss-priority high code-points 010;\n            }\n            forwarding-class NETWORK {\n                loss-priority low code-points 110;\n            }\n            forwarding-class REALTIME {\n                loss-priority low code-points 101;\n            }\n            forwarding-class SIG-OAM {\n                loss-priority high code-points 011;\n            }\n        }\n        ieee-802.1 8021P {\n            forwarding-class BEST-EFFORT {\n                loss-priority high code-points 000;\n            }\n            forwarding-class BUSINESS {\n                loss-priority high code-points 100;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points 111;\n            }\n            forwarding-class LOW {\n                loss-priority low code-points 001;\n            }\n            forwarding-class MEDIUM {\n                loss-priority high code-points 010;\n            }\n            forwarding-class NETWORK {\n                loss-priority low code-points 110;\n            }\n            forwarding-class REALTIME {\n                loss-priority low code-points 101;\n            }\n            forwarding-class SIG-OAM {\n                loss-priority high code-points 011;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        dscp DSCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs4 af41 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs1 af11 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points [ cs2 af21 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class NETWORK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs5 ef ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs3 af31 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        exp EXP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class NETWORK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> 8021P {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class NETWORK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2689,
+      "lineCount": 82,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/cos/forwarding-class-map",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "forwarding-class-map",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/cos/forwarding-class-map.conf",
+      "topic": "Forwarding-class to queue-number mapping (8-class CoS model)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Identical 8-class mapping as Junos — same queue-num assignments",
+        "drop-profiles dp1/dp2 implement WRED for congestion management",
+        "dp1: conservative (fill 40→50, drop 0→70%) — for important traffic overflow",
+        "dp2: aggressive (fill 10→30, drop 0→30%) — for best-effort early discard"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifier-dscp-exp-8021p.conf  (classifiers that feed these queues)",
+          "id": null
+        },
+        {
+          "raw": "evo/cos/rewrite-rules-exp.conf          (marking on egress)",
+          "id": null
+        },
+        {
+          "raw": "junos/cos/forwarding-class-map.conf     (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "class-of-service {\n    drop-profiles {\n        dp1 {\n            fill-level 40 drop-probability 0;\n            fill-level 50 drop-probability 70;\n        }\n        dp2 {\n            fill-level 10 drop-probability 0;\n            fill-level 30 drop-probability 30;\n        }\n    }\n    forwarding-classes {\n        class BEST-EFFORT queue-num 0;\n        class BUSINESS queue-num 4;\n        class CONTROL queue-num 7;\n        class LOW queue-num 1;\n        class MEDIUM queue-num 2;\n        class NETWORK queue-num 6;\n        class REALTIME queue-num 5;\n        class SIG-OAM queue-num 3;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    drop-profiles {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        dp1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">70</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        dp2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BUSINESS queue-num </span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class CONTROL queue-num </span><span style=\"color:#79C0FF\">7</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class LOW queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class MEDIUM queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class NETWORK queue-num </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class REALTIME queue-num </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class SIG-OAM queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 592,
+      "lineCount": 22,
+      "techFamily": "QoS / CoS",
+      "subfamily": "Cos",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/cos/rewrite-rules-exp",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "rewrite-rules-exp",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/cos/rewrite-rules-exp.conf",
+      "topic": "EXP rewrite rule and per-interface CoS binding (core egress marking)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Same interface CoS binding model as Junos",
+        "EXP rewrite applied to core-facing interfaces",
+        "802.1p classifiers applied to access-facing interface units",
+        "EVO interface naming uses et-0/0/X format (same as Junos MX/PTX)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifier-dscp-exp-8021p.conf  (classifiers referenced in bindings)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/physical-uplink-mpls.conf (core interfaces these rewrites apply to)",
+          "id": null
+        },
+        {
+          "raw": "junos/cos/rewrite-rules-exp.conf        (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_INTF",
+          "example": "et-0/0/0"
+        },
+        {
+          "name": "$ACCESS_INTF",
+          "example": "et-0/0/2"
+        },
+        {
+          "name": "$REWRITE_NAME",
+          "example": "EXP-REWRITE"
+        },
+        {
+          "name": "$CLASSIFIER_NAME",
+          "example": "EXP / 8021P"
+        }
+      ],
+      "body": "class-of-service {\n    interfaces {\n        $CORE_INTF {\n            unit 0 {\n                classifiers {\n                    exp $CLASSIFIER_NAME;\n                }\n                rewrite-rules {\n                    exp $REWRITE_NAME;\n                }\n            }\n        }\n        $ACCESS_INTF {\n            unit $UNIT {\n                classifiers {\n                    ieee-802.1 8021P;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $CORE_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp $CLASSIFIER_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp $REWRITE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $ACCESS_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> 8021P;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 446,
+      "lineCount": 21,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/ddos-mitigation/flowspec-routes",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "ddos-mitigation",
+      "name": "flowspec-routes",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/ddos-mitigation/flowspec-routes.conf",
+      "topic": "BGP FlowSpec enablement for dynamic DDoS mitigation",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Same enablement model as Junos — family inet flow in iBGP group",
+        "Allows RFC 5575 FlowSpec route reception from RR/controller",
+        "Dynamic firewall filter installation in hardware (no CLI config required)",
+        "Real-time DDoS mitigation via match-and-drop/rate-limit actions"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/bgp-ibgp-evpn.conf         (BGP group with family inet flow enabled)",
+          "id": null
+        },
+        {
+          "raw": "evo/firewall/filter-ipv4-stateless.conf   (static equivalent for manual PBR)",
+          "id": null
+        },
+        {
+          "raw": "junos/ddos-mitigation/flowspec-routes.conf (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "/* FlowSpec is enabled in the BGP group: */\n\nprotocols {\n    bgp {\n        group ibgp {\n            family inet {\n                unicast;\n                flow;   /* ← This enables FlowSpec route reception */\n            }\n        }\n    }\n}\n\n/* FlowSpec routes are injected by an external controller or RR peer.\n * Verify with: show route table inetflow.0\n */",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">/* FlowSpec is enabled in the BGP group: */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        group ibgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow;   /* ← This enables FlowSpec route reception */</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* FlowSpec routes are injected by an external controller or RR peer.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * Verify with: show route table inetflow.</span><span style=\"color:#79C0FF\">0</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> */</span></span></code></pre>",
+      "bytes": 361,
+      "lineCount": 16,
+      "techFamily": "Other",
+      "subfamily": "Ddos Mitigation",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/firewall/filter-ipv4-stateless",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-ipv4-stateless",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/firewall/filter-ipv4-stateless.conf",
+      "topic": "IPv4 stateless firewall filter (PBR with next-ip/next-interface)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Same stateless filter syntax as Junos — identical match/action semantics",
+        "Matches on L3/L4 fields (src/dst address, src/dst port, protocol)",
+        "next-ip and next-interface actions for policy-based routing",
+        "count action for per-filter hit statistics"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/ddos-mitigation/flowspec-routes.conf  (dynamic version via BGP FlowSpec)",
+          "id": null
+        },
+        {
+          "raw": "junos/firewall/filter-ipv4-stateless.conf (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "filter_ip_dport1"
+        },
+        {
+          "name": "$PROTOCOL",
+          "example": "tcp"
+        },
+        {
+          "name": "$MATCH_FIELD",
+          "example": "destination-port 80 / source-address 222.222.2.100/32"
+        },
+        {
+          "name": "$NEXT_HOP",
+          "example": "192.168.56.2/32"
+        },
+        {
+          "name": "$NEXT_INTF",
+          "example": "et-0/0/1"
+        }
+      ],
+      "body": "firewall {\n    family inet {\n        filter $FILTER_NAME {\n            term 1 {\n                from {\n                    protocol $PROTOCOL;\n                    destination-port $DST_PORT;\n                }\n                then {\n                    count $FILTER_NAME;\n                    next-ip $NEXT_HOP;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protocol $PROTOCOL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-port $DST_PORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count $FILTER_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    next-ip $NEXT_HOP;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 360,
+      "lineCount": 16,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/interfaces/ccc-vpws-mux",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "ccc-vpws-mux",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/interfaces/ccc-vpws-mux.conf",
+      "topic": "VPWS and ELAN attachment-circuit units (vlan-ccc with ESI, vlan-bridge)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "Same ESI format and all-active multi-homing semantics",
+        "EVO uses ether-options { 802.3ad } for member links (vs gigether-options on MX)",
+        "vlan-bridge units on EVO feed mac-vrf instances (not instance-type evpn)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/lag-flexible-services.conf  (the parent ae interface)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-vpws-simple.conf         (instances binding these vlan-ccc units)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/mac-vrf-elan.conf             (instances binding these vlan-bridge units)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LAG_INTF",
+          "example": "ae0"
+        },
+        {
+          "name": "$UNIT",
+          "example": "1"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$ESI",
+          "example": "00:34:34:34:34:34:34:34:11:01"
+        }
+      ],
+      "body": "/* --- VPWS AC (vlan-ccc with ESI, multi-homed) --- */\n\ninterfaces {\n    $LAG_INTF {\n        unit $UNIT {\n            encapsulation vlan-ccc;\n            vlan-id $VLAN_ID;\n            esi {\n                $ESI;\n                all-active;\n            }\n            family ccc;\n        }\n    }\n}\n\n/* --- ELAN AC (vlan-bridge, no ESI needed for bridge units) --- */\n\ninterfaces {\n    $LAG_INTF {\n        unit $UNIT {\n            encapsulation vlan-bridge;\n            vlan-id $VLAN_ID;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">/* --- VPWS AC (vlan-ccc with ESI, multi-homed) --- */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $LAG_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                $ESI;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* --- ELAN AC (vlan-bridge, no ESI needed for bridge units) --- */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $LAG_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 502,
+      "lineCount": 26,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/interfaces/irb-gateway",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "irb-gateway",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/interfaces/irb-gateway.conf",
+      "topic": "IRB gateway interface (per-VRF L3 address for EVPN Type-5 routing)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is byte-identical to the Junos sibling",
+        "IRB unit provides the default gateway for one mac-vrf VLAN (vlan-based service-type)",
+        "Referenced via l3-interface in the mac-vrf vlans stanza (vs routing-interface on Junos)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/mac-vrf-elan.conf         (mac-vrf with l3-interface irb.$UNIT)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-vrf-ip-prefix.conf   (VRF binding interface irb.$UNIT)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$UNIT",
+          "example": "476"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "100.100.76.1/24"
+        }
+      ],
+      "body": "interfaces {\n    irb {\n        unit $UNIT {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    irb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 140,
+      "lineCount": 9,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/interfaces/lag-flexible-services",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "lag-flexible-services",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/interfaces/lag-flexible-services.conf",
+      "topic": "LAG with flexible VLAN services (multi-service bundle for VPWS/ELAN ACs)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "EVO version omits link-protection and fast-failover (not supported on ACX7509 LACP in 23.4R2)",
+        "flexible-vlan-tagging + encapsulation flexible-ethernet-services same as Junos",
+        "LACP system-id must match the multi-homing peer PE's system-id for ESI to function",
+        "Member links use ether-options { 802.3ad ae0; } (vs gigether-options on Junos MX)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/ccc-vpws-mux.conf    (per-unit VPWS/ELAN AC config on this LAG)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-vpws-fxc.conf      (instances referencing ae0.* units)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LAG_INTF",
+          "example": "ae0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "PE3 to CE2"
+        },
+        {
+          "name": "$LACP_SYSTEM_ID",
+          "example": "00:00:00:00:01:01"
+        }
+      ],
+      "body": "interfaces {\n    $LAG_INTF {\n        description \"$DESCRIPTION\";\n        flexible-vlan-tagging;\n        encapsulation flexible-ethernet-services;\n        aggregated-ether-options {\n            lacp {\n                active;\n                periodic fast;\n                system-id $LACP_SYSTEM_ID;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $LAG_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                periodic fast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                system-id $LACP_SYSTEM_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 329,
+      "lineCount": 14,
+      "techFamily": "Interfaces",
+      "subfamily": "LAG / LACP",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/interfaces/loopback",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "loopback",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/interfaces/loopback.conf",
+      "topic": "Loopback interface (router-id, BGP source, MPLS label binding)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Body is byte-identical to the Junos sibling",
+        "/32 loopback is the SR node-segment target (OSPF advertises prefix-SID for this address)",
+        "Used as BGP local-address, OSPF router-id, and LDP transport address"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf     (lo0.0 as passive OSPF interface)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/bgp-ibgp-evpn.conf   (lo0.0 IP as BGP local-address)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LOOPBACK_V4",
+          "example": "4.4.4.4/32"
+        }
+      ],
+      "body": "interfaces {\n    lo0 {\n        unit 0 {\n            family inet {\n                address $LOOPBACK_V4;\n            }\n            family mpls;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    lo0 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $LOOPBACK_V4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 160,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/interfaces/physical-uplink-mpls",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "physical-uplink-mpls",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/interfaces/physical-uplink-mpls.conf",
+      "topic": "Physical core uplink with MPLS and IPv4 (WAN backbone interface)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling (direct port variant)",
+        "EVO WAN edges use et-* interfaces directly (no LAG on core links in this topology)",
+        "P routers (PTX) also use direct et-* or ae interfaces for core mesh",
+        "speed 100g may be explicitly set on EVO platforms (not present on Junos MX)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf          (OSPF config referencing these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/mpls-lsp.conf             (MPLS enablement on these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ldp-sr-coexistence.conf   (LDP also enabled on these interfaces)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTF",
+          "example": "et-1/0/0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "WANEdge3 to P1"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "192.168.34.2/24"
+        }
+      ],
+      "body": "interfaces {\n    $INTF {\n        description \"$DESCRIPTION\";\n        unit 0 {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n            family mpls;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 199,
+      "lineCount": 11,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/oam/cfm-maintenance-domain",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "oam",
+      "name": "cfm-maintenance-domain",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/oam/cfm-maintenance-domain.conf",
+      "topic": "CFM maintenance domain with continuity-check MEP (802.1ag OAM)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Same 802.1ag CFM syntax and semantics as Junos",
+        "Level 3 maintenance-domain for PE-to-PE monitoring",
+        "Continuity-check at 1s interval (failure detect ~3.5s)",
+        "MEP direction \"up\" monitors MPLS/EVPN path toward remote PE",
+        "auto-discovery for automatic remote-MEP detection"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/oam/cfm-sla-iterator.conf           (performance measurement on these MEPs)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/ccc-vpws-mux.conf        (AC interfaces referenced by MEPs)",
+          "id": null
+        },
+        {
+          "raw": "junos/oam/cfm-maintenance-domain.conf   (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$MD_NAME",
+          "example": "m-d301"
+        },
+        {
+          "name": "$MD_LEVEL",
+          "example": "3"
+        },
+        {
+          "name": "$MA_NAME",
+          "example": "m-a301"
+        },
+        {
+          "name": "$MEP_ID",
+          "example": "1"
+        },
+        {
+          "name": "$MEP_INTF",
+          "example": "et-0/0/2.301"
+        },
+        {
+          "name": "$CC_INTERVAL",
+          "example": "1s"
+        }
+      ],
+      "body": "protocols {\n    oam {\n        ethernet {\n            connectivity-fault-management {\n                maintenance-domain $MD_NAME {\n                    level $MD_LEVEL;\n                    name-format character-string;\n                    maintenance-association $MA_NAME {\n                        short-name-format character-string;\n                        continuity-check {\n                            interval $CC_INTERVAL;\n                        }\n                        mep $MEP_ID {\n                            interface $MEP_INTF;\n                            direction up;\n                            auto-discovery;\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    oam {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            connectivity-fault-management {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                maintenance-domain $MD_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    level $MD_LEVEL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    name-format character-string;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    maintenance-association $MA_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        short-name-format character-string;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        continuity-check {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            interval $CC_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        mep $MEP_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            interface $MEP_INTF;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            direction up;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            auto-discovery;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 723,
+      "lineCount": 23,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/oam/cfm-sla-iterator",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "oam",
+      "name": "cfm-sla-iterator",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/oam/cfm-sla-iterator.conf",
+      "topic": "CFM enhanced SLA iterator (two-way delay and synthetic loss measurement)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Same enhanced-sla-iterator model as Junos",
+        "Hardware-timestamped performance measurement",
+        "two-way-delay profile for round-trip latency measurement",
+        "slm (Synthetic Loss Measurement) for non-intrusive frame loss detection",
+        "measurement-interval sets the reporting/aggregation window"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/oam/cfm-maintenance-domain.conf   (MEPs these measurements run against)",
+          "id": null
+        },
+        {
+          "raw": "junos/oam/cfm-sla-iterator.conf       (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$PROFILE_DELAY",
+          "example": "i1"
+        },
+        {
+          "name": "$PROFILE_SLM",
+          "example": "i2"
+        },
+        {
+          "name": "$INTERVAL",
+          "example": "5"
+        }
+      ],
+      "body": "protocols {\n    oam {\n        ethernet {\n            connectivity-fault-management {\n                performance-monitoring {\n                    enhanced-sla-iterator;\n                    measurement-interval $INTERVAL;\n                    sla-iterator-profiles {\n                        $PROFILE_DELAY {\n                            measurement-type two-way-delay;\n                        }\n                        $PROFILE_SLM {\n                            measurement-type slm;\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    oam {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            connectivity-fault-management {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                performance-monitoring {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    enhanced-sla-iterator;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    measurement-interval $INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    sla-iterator-profiles {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        $PROFILE_DELAY {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            measurement-type two-way-delay;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        $PROFILE_SLM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            measurement-type slm;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 578,
+      "lineCount": 20,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/policy/per-packet-load-balance",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "per-packet-load-balance",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/policy/per-packet-load-balance.conf",
+      "topic": "Per-packet load-balance and BGP redistribution policies",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Same policy-options syntax as Junos — no EVO-specific differences",
+        "pplb enables per-flow ECMP; Term 1 specifically handles family evpn",
+        "send-direct redistributes connected routes into BGP (loopback reachability)",
+        "bgp-to-ospf redistributes BGP→OSPF for multi-area designs",
+        "Applied via routing-options forwarding-table export pplb"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/bgp-ibgp-evpn.conf           (BGP sessions using send-direct export)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/forwarding-options-hash.conf  (hash-key that pplb distributes across)",
+          "id": null
+        },
+        {
+          "raw": "junos/policy/per-packet-load-balance.conf   (Junos sibling — identical config)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "policy-options {\n    policy-statement pplb {\n        term 1 {\n            from family evpn;\n            then {\n                load-balance per-packet;\n                accept;\n            }\n        }\n        then {\n            load-balance per-packet;\n            accept;\n        }\n    }\n    policy-statement send-direct {\n        term 1 {\n            from protocol direct;\n            then accept;\n        }\n    }\n    policy-statement bgp-to-ospf {\n        from protocol bgp;\n        then accept;\n    }\n}\n\n/* Applied in routing-options: */\n\nrouting-options {\n    forwarding-table {\n        export pplb;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement pplb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> family evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                load-balance per-packet;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            load-balance per-packet;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement send-direct {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> protocol direct;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement bgp-to-ospf {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol bgp;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* Applied in routing-options: */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-table {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        export</span><span style=\"color:#E6EDF3\"> pplb;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 611,
+      "lineCount": 33,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/services/evpn-vpws-fxc",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vpws-fxc",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/services/evpn-vpws-fxc.conf",
+      "topic": "EVPN-VPWS with Flexible Cross-Connect (multi-AC VLAN-aware)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling (only local/remote IDs differ per-site)",
+        "Multi-homed VPWS carrying 2+ VLANs per instance via flexible-cross-connect-vlan-aware",
+        "Each AC interface gets its own vpws-service-id pair (local/remote must be swapped on the far end)",
+        "All ACs share a single RD and RT; the service-id disambiguates circuits within the instance",
+        "Scale: ~500 FXC instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/lag-flexible-services.conf  (the ae0 bundle carrying these ACs)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/ccc-vpws-mux.conf           (per-AC unit config on ae0)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vfxc_group_40_1001"
+        },
+        {
+          "name": "$AC_INTF_1",
+          "example": "ae0.1001"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "ae0.1002"
+        },
+        {
+          "name": "$LOCAL_ID_1",
+          "example": "1"
+        },
+        {
+          "name": "$REMOTE_ID_1",
+          "example": "2"
+        },
+        {
+          "name": "$LOCAL_ID_2",
+          "example": "11"
+        },
+        {
+          "name": "$REMOTE_ID_2",
+          "example": "21"
+        },
+        {
+          "name": "$RD",
+          "example": "44.44.44.44:1001"
+        },
+        {
+          "name": "$RT",
+          "example": "target:65000:1001"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF_1 {\n                    vpws-service-id {\n                        local $LOCAL_ID_1;\n                        remote $REMOTE_ID_1;\n                    }\n                }\n                interface $AC_INTF_2 {\n                    vpws-service-id {\n                        local $LOCAL_ID_2;\n                        remote $REMOTE_ID_2;\n                    }\n                }\n                flexible-cross-connect-vlan-aware;\n            }\n        }\n        interface $AC_INTF_1;\n        interface $AC_INTF_2;\n        route-distinguisher $RD;\n        vrf-target $RT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_ID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_ID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_ID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_ID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-cross-connect-vlan-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 722,
+      "lineCount": 26,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/services/evpn-vpws-simple",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vpws-simple",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/services/evpn-vpws-simple.conf",
+      "topic": "EVPN-VPWS point-to-point pseudowire (single AC, control-word)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "Simplest VPWS: one AC interface, one vpws-service-id pair, control-word enabled",
+        "control-word ensures correct sequencing and prevents fat-pipe reordering issues",
+        "local/remote IDs must be mirror-swapped on the PE peer (local 30 ↔ remote 20)",
+        "Scale: ~1000 simple VPWS instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/ccc-vpws-mux.conf  (the per-unit AC config on the physical/LAG interface)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vpws_group_23_1"
+        },
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/2.1"
+        },
+        {
+          "name": "$LOCAL_ID",
+          "example": "30"
+        },
+        {
+          "name": "$REMOTE_ID",
+          "example": "20"
+        },
+        {
+          "name": "$RD",
+          "example": "4.4.4.4:231"
+        },
+        {
+          "name": "$RT",
+          "example": "target:63535:231"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF {\n                    vpws-service-id {\n                        local $LOCAL_ID;\n                        remote $REMOTE_ID;\n                    }\n                }\n                control-word;\n            }\n        }\n        interface $AC_INTF;\n        route-distinguisher $RD;\n        vrf-target $RT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 458,
+      "lineCount": 19,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/services/evpn-vrf-ip-prefix",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vrf-ip-prefix",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/services/evpn-vrf-ip-prefix.conf",
+      "topic": "EVPN IP-prefix route VRF (L3 VPN with EVPN Type-5 advertisement)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is byte-identical to the Junos sibling",
+        "L3 VRF that advertises connected IRB subnets as EVPN Type-5 ip-prefix routes",
+        "advertise direct-nexthop enables direct PE-to-PE forwarding (no recursive resolution)",
+        "encapsulation mpls sets the data-plane encap for inter-PE traffic",
+        "vrf-table-label allocates a per-VRF MPLS label for ingress lookup",
+        "Scale: ~350 VRF instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/mac-vrf-elan.conf       (the bridge domain whose IRB feeds this VRF)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/irb-gateway.conf      (IRB unit addressing)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_1851"
+        },
+        {
+          "name": "$ROUTER_ID",
+          "example": "4.4.4.4"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.1851"
+        },
+        {
+          "name": "$RD",
+          "example": "63434:1851"
+        },
+        {
+          "name": "$RT",
+          "example": "target:60555:1851"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type vrf;\n        routing-options {\n            router-id $ROUTER_ID;\n        }\n        protocols {\n            evpn {\n                ip-prefix-routes {\n                    advertise direct-nexthop;\n                    encapsulation mpls;\n                }\n            }\n        }\n        interface $IRB_UNIT;\n        route-distinguisher $RD;\n        vrf-target $RT;\n        vrf-table-label;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            router-id $ROUTER_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ip-prefix-routes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise direct-nexthop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 458,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/services/mac-vrf-elan",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "mac-vrf-elan",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/services/mac-vrf-elan.conf",
+      "topic": "MAC-VRF ELAN bridge domain (L2 multipoint, with optional IRB)",
+      "seenOn": {
+        "junos": [
+          "(none)"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "EVO equivalent of Junos instance-type evpn; uses instance-type mac-vrf instead",
+        "Two service-type modes shown: vlan-bundle (simple L2) and vlan-based (with IRB gateway)",
+        "vlan-bundle: ACs grouped under a single vlans stanza, no per-VLAN L3",
+        "vlan-based: each VLAN gets explicit vlan-id + l3-interface for IRB routing",
+        "no-control-word is explicit on EVO (Junos omits it when not needed)",
+        "default-gateway do-not-advertise suppresses Type-5 default (bridged+IRB variant only)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/evpn-vrf-ip-prefix.conf  (the L3 VRF binding irb.$UNIT — vlan-based only)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/irb-gateway.conf       (IRB unit config)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "elan_group_500_2001 / elan_group_95_476"
+        },
+        {
+          "name": "$SERVICE_TYPE",
+          "example": "vlan-bundle / vlan-based"
+        },
+        {
+          "name": "$AC_INTF_1",
+          "example": "ae0.2001"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "ae0.2002"
+        },
+        {
+          "name": "$VLAN_NAME",
+          "example": "mvbundle_2001 / svbased_476"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "476"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.476"
+        },
+        {
+          "name": "$RD",
+          "example": "44.44.44.44:2001"
+        },
+        {
+          "name": "$RT",
+          "example": "target:62525:2001"
+        }
+      ],
+      "body": "/* --- Variant A: vlan-bundle (simple L2, no IRB) --- */\n\nrouting-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                no-control-word;\n            }\n        }\n        service-type vlan-bundle;\n        route-distinguisher $RD;\n        vrf-target $RT;\n        vlans {\n            $VLAN_NAME {\n                interface $AC_INTF_1;\n                interface $AC_INTF_2;\n            }\n        }\n    }\n}\n\n/* --- Variant B: vlan-based (with IRB gateway) --- */\n\nrouting-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n                no-control-word;\n            }\n        }\n        service-type vlan-based;\n        route-distinguisher $RD;\n        vrf-target $RT;\n        vlans {\n            $VLAN_NAME {\n                vlan-id $VLAN_ID;\n                interface $AC_INTF_1;\n                l3-interface $IRB_UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">/* --- Variant A: vlan-bundle (simple L2, no IRB) --- */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-bundle;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $VLAN_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* --- Variant B: vlan-based (with IRB gateway) --- */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-based;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $VLAN_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                l3-interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1051,
+      "lineCount": 46,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/transport/bgp-ibgp-evpn",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "bgp-ibgp-evpn",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/transport/bgp-ibgp-evpn.conf",
+      "topic": "iBGP overlay with EVPN signaling (route-reflector client config)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "EVO places multipath outside the group block (vs Junos which has it inside)",
+        "family route-target enables RT-constrain (RFC 4684) — not present on Junos PEs in this JVD",
+        "No advertise-external knob (EVO peers only with RRs, not external)",
+        "No top-level family inet { unicast { loops 2; } } — EVO omits this",
+        "P routers (RRs) add cluster and graceful-restart; PE config shown here"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/policy/per-packet-load-balance.conf  (the pplb policy applied via forwarding-table export)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf           (the IGP underlay these sessions ride over)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LOCAL_ADDRESS",
+          "example": "4.4.4.4"
+        },
+        {
+          "name": "$LOCAL_AS",
+          "example": "64512"
+        },
+        {
+          "name": "$RR_PEER_1",
+          "example": "3.3.3.3"
+        },
+        {
+          "name": "$RR_PEER_2",
+          "example": "6.6.6.6"
+        }
+      ],
+      "body": "protocols {\n    bgp {\n        group ibgp {\n            type internal;\n            local-address $LOCAL_ADDRESS;\n            family inet {\n                unicast;\n                flow;\n            }\n            family evpn {\n                signaling;\n            }\n            family route-target;\n            export send-direct;\n            local-as $LOCAL_AS;\n            bfd-liveness-detection {\n                minimum-interval 100;\n                multiplier 3;\n            }\n            neighbor $RR_PEER_1;\n            neighbor $RR_PEER_2;\n        }\n        multipath;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        group ibgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-address $LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                signaling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family route-target;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            export</span><span style=\"color:#E6EDF3\"> send-direct;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-as $LOCAL_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                minimum-interval </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $RR_PEER_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $RR_PEER_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        multipath;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 584,
+      "lineCount": 25,
+      "techFamily": "Transport",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/transport/forwarding-options-hash",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "forwarding-options-hash",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/transport/forwarding-options-hash.conf",
+      "topic": "Forwarding hash-key configuration for ECMP and LAG load distribution",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "EVO version adds family mpls with all-labels + payload ip for deep MPLS hash inspection",
+        "all-labels hashes across the full label stack (not just top label) for better SR/LDP ECMP",
+        "payload ip peeks past the MPLS stack into the IP header for per-flow distribution",
+        "inet/inet6/multiservice families are identical to the Junos sibling",
+        "Essential for LDP/SR coexistence where label stacks can be 3+ deep"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/lag-flexible-services.conf  (the LAG benefiting from this hash)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf             (ECMP paths this hash distributes across)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ldp-sr-coexistence.conf      (deep label stacks from LDP+SR stitching)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "forwarding-options {\n    hash-key {\n        family inet {\n            layer-3;\n            layer-4;\n        }\n        family inet6 {\n            layer-3;\n            layer-4;\n        }\n        family mpls {\n            all-labels;\n            payload {\n                ip;\n            }\n        }\n        family multiservice {\n            source-mac;\n            destination-mac;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">forwarding-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    hash-key {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-labels;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            payload {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ip;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family multiservice {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            source-mac;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            destination-mac;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 397,
+      "lineCount": 22,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/transport/ldp-sr-coexistence",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "ldp-sr-coexistence",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/transport/ldp-sr-coexistence.conf",
+      "topic": "LDP with SR coexistence (sr-mapping-client + ldp-synchronization)",
+      "seenOn": {
+        "junos": [
+          "(none)"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "LDP runs alongside Segment Routing on the same interfaces for interop with legacy nodes",
+        "sr-mapping-client (on P routers) tells LDP to consume prefix-SID mappings from the SR mapping server",
+        "OSPF interfaces have ldp-synchronization to hold traffic until LDP adjacency is up",
+        "This enables seamless SR/LDP stitching: LDP-only nodes can reach SR-only nodes via the P router",
+        "WAN edge EVO nodes run LDP on all core interfaces; Junos WAN edges do NOT run LDP (SR-only)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf       (OSPF with ldp-synchronization per interface)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/sr-mapping-server.conf  (mapping-server-entry on P routers)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_INTF_1",
+          "example": "et-1/0/0.0"
+        },
+        {
+          "name": "$CORE_INTF_2",
+          "example": "et-1/0/1.0"
+        },
+        {
+          "name": "$CORE_INTF_3",
+          "example": "et-1/0/2.0"
+        }
+      ],
+      "body": "protocols {\n    ldp {\n        interface $CORE_INTF_1;\n        interface $CORE_INTF_2;\n        interface $CORE_INTF_3;\n        interface lo0.0;\n    }\n}\n\n/* P routers additionally enable sr-mapping-client: */\n\nprotocols {\n    ldp {\n        interface $CORE_INTF_1;\n        interface lo0.0;\n        sr-mapping-client;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ldp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* P routers additionally enable sr-mapping-client: */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ldp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        sr-mapping-client;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 321,
+      "lineCount": 18,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/transport/mpls-lsp",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "mpls-lsp",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/transport/mpls-lsp.conf",
+      "topic": "MPLS label-switched paths and interface enablement",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "EVO nodes list all core-facing interfaces (no LAG aggregation on P routers)",
+        "LSP targets are the Junos PE loopbacks (cross-OS peering over same MPLS core)",
+        "traffic-engineering enables TE-DB for CSPF even with SR forwarding"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf          (IGP providing the label stack)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ldp-sr-coexistence.conf   (LDP runs on same interfaces for interop)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LSP_NAME_1",
+          "example": "lsp_to_pe1"
+        },
+        {
+          "name": "$LSP_DEST_1",
+          "example": "2.2.2.2"
+        },
+        {
+          "name": "$LSP_NAME_2",
+          "example": "lsp_to_pe2"
+        },
+        {
+          "name": "$LSP_DEST_2",
+          "example": "5.5.5.5"
+        },
+        {
+          "name": "$CORE_INTF_1",
+          "example": "et-1/0/0.0"
+        },
+        {
+          "name": "$CORE_INTF_2",
+          "example": "et-1/0/1.0"
+        },
+        {
+          "name": "$CORE_INTF_3",
+          "example": "et-1/0/2.0"
+        }
+      ],
+      "body": "protocols {\n    mpls {\n        traffic-engineering;\n        label-switched-path $LSP_NAME_1 {\n            to $LSP_DEST_1;\n        }\n        label-switched-path $LSP_NAME_2 {\n            to $LSP_DEST_2;\n        }\n        interface $CORE_INTF_1;\n        interface $CORE_INTF_2;\n        interface $CORE_INTF_3;\n        interface lo0.0;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        traffic-engineering;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 340,
+      "lineCount": 15,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/transport/ospf-sr-lfa",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "ospf-sr-lfa",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/transport/ospf-sr-lfa.conf",
+      "topic": "OSPF with Segment Routing and TI-LFA (post-convergence node protection)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "P routers additionally carry mapping-server + ldp-stitching (see ldp-sr-coexistence.conf)",
+        "install-prefix-sid-for-best-route present on P routers to install SIDs in FIB",
+        "Same SRGB (16000 base, 8000 range) must be consistent domain-wide"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ldp-sr-coexistence.conf      (LDP stitching knobs on P routers)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/sr-mapping-server.conf       (prefix-to-SID database)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/bgp-ibgp-evpn.conf           (iBGP sessions using this IGP's loopbacks)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$NODE_SEGMENT_INDEX",
+          "example": "103"
+        },
+        {
+          "name": "$SRGB_START",
+          "example": "16000"
+        },
+        {
+          "name": "$SRGB_RANGE",
+          "example": "8000"
+        },
+        {
+          "name": "$CORE_INTF_1",
+          "example": "ae2.0"
+        },
+        {
+          "name": "$CORE_INTF_2",
+          "example": "et-1/0/5.0"
+        },
+        {
+          "name": "$CORE_INTF_3",
+          "example": "et-1/0/1.0"
+        }
+      ],
+      "body": "protocols {\n    ospf {\n        backup-spf-options {\n            use-post-convergence-lfa {\n                maximum-labels 8;\n                maximum-backup-paths 5;\n            }\n            use-source-packet-routing;\n        }\n        traffic-engineering;\n        source-packet-routing {\n            node-segment ipv4-index $NODE_SEGMENT_INDEX;\n            srgb start-label $SRGB_START index-range $SRGB_RANGE;\n            mapping-server $MAPPING_SERVER_NAME;\n            install-prefix-sid-for-best-route;\n            ldp-stitching;\n        }\n        area 0.0.0.0 {\n            interface $CORE_INTF_1 {\n                interface-type p2p;\n                bfd-liveness-detection {\n                    minimum-interval 10;\n                    multiplier 3;\n                    full-neighbors-only;\n                }\n                post-convergence-lfa {\n                    node-protection;\n                }\n                ipv4-adjacency-segment {\n                    protected dynamic;\n                }\n            }\n            interface $CORE_INTF_2 {\n                interface-type p2p;\n                bfd-liveness-detection {\n                    minimum-interval 10;\n                    multiplier 3;\n                    full-neighbors-only;\n                }\n                post-convergence-lfa {\n                    node-protection;\n                }\n                ipv4-adjacency-segment {\n                    protected dynamic;\n                }\n            }\n            interface lo0.0 {\n                passive;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        backup-spf-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            use-post-convergence-lfa {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                maximum-labels </span><span style=\"color:#79C0FF\">8</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                maximum-backup-paths </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            use-source-packet-routing;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        traffic-engineering;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        source-packet-routing {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            node-segment ipv4-index $NODE_SEGMENT_INDEX;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            srgb start-label $SRGB_START index-range $SRGB_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            mapping-server $MAPPING_SERVER_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            install-prefix-sid-for-best-route;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            ldp-stitching;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        area </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_INTF_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface-type p2p;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    full-neighbors-only;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                post-convergence-lfa {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    node-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ipv4-adjacency-segment {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protected dynamic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_INTF_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface-type p2p;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    full-neighbors-only;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                post-convergence-lfa {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    node-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ipv4-adjacency-segment {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protected dynamic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                passive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1562,
+      "lineCount": 52,
+      "techFamily": "Transport",
+      "subfamily": "OSPF",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/evo/transport/sr-mapping-server",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "sr-mapping-server",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/evo/transport/sr-mapping-server.conf",
+      "topic": "SR prefix-SID mapping server (LDP-to-SR stitching on P routers)",
+      "seenOn": {
+        "junos": [
+          "(none)"
+        ],
+        "evo": [
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Mapping server advertises prefix-SID bindings for LDP-only nodes into the SR domain",
+        "prefix-segment-range maps a contiguous prefix block to a contiguous SID index range",
+        "install-prefix-sid-for-best-route installs mapped SIDs into the forwarding table",
+        "ldp-stitching enables seamless label swap between LDP and SR label spaces",
+        "Only P routers (route-reflectors) run the mapping server; PEs consume via sr-mapping-client in LDP",
+        "This enables a gradual SR migration: add SR nodes without breaking LDP-only forwarding"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ldp-sr-coexistence.conf  (LDP with sr-mapping-client on the consumer side)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ospf-sr-lfa.conf         (OSPF SR config referencing mapping-server name)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$MAPPING_NAME",
+          "example": "ospf-mapping-server"
+        },
+        {
+          "name": "$RANGE_NAME",
+          "example": "ldp-lo1"
+        },
+        {
+          "name": "$START_PREFIX",
+          "example": "4.4.4.4/32"
+        },
+        {
+          "name": "$START_INDEX",
+          "example": "1000"
+        },
+        {
+          "name": "$SIZE",
+          "example": "10"
+        }
+      ],
+      "body": "routing-options {\n    source-packet-routing {\n        mapping-server-entry $MAPPING_NAME {\n            prefix-segment-range $RANGE_NAME {\n                start-prefix $START_PREFIX;\n                start-index $START_INDEX;\n                size $SIZE;\n            }\n        }\n    }\n}\n\n/* Reference in OSPF source-packet-routing (same device): */\n\nprotocols {\n    ospf {\n        source-packet-routing {\n            mapping-server $MAPPING_NAME;\n            install-prefix-sid-for-best-route;\n            ldp-stitching;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    source-packet-routing {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        mapping-server-entry $MAPPING_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            prefix-segment-range $RANGE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                start-prefix $START_PREFIX;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                start-index $START_INDEX;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                size $SIZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* Reference in OSPF source-packet-routing (same device): */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        source-packet-routing {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            mapping-server $MAPPING_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            install-prefix-sid-for-best-route;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            ldp-stitching;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 535,
+      "lineCount": 23,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/bootstrap/chassis-network-services",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "bootstrap",
+      "name": "chassis-network-services",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/bootstrap/chassis-network-services.conf",
+      "topic": "Chassis network-services and aggregated-device count (platform bootstrap)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "aggregated-devices ethernet device-count sets the maximum number of ae interfaces",
+        "Must be configured before any ae interface can be created (platform pre-requisite)",
+        "network-services enhanced-ip (EVO only) enables the enhanced-IP forwarding mode",
+        "enhanced-ip required for EVPN/MPLS services on EVO platforms (vs default ethernet mode)",
+        "Junos MX platforms use per-FPC pic-mode flexible-ethernet-services instead (not shown here)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$DEVICE_COUNT",
+          "example": "25"
+        }
+      ],
+      "body": "/* EVO variant (includes network-services enhanced-ip): */\n\nchassis {\n    aggregated-devices {\n        ethernet {\n            device-count $DEVICE_COUNT;\n        }\n    }\n    network-services enhanced-ip;\n}\n\n/* Junos variant (no network-services line needed): */\n\nchassis {\n    aggregated-devices {\n        ethernet {\n            device-count $DEVICE_COUNT;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">/* EVO variant (includes network-services enhanced-ip): */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">chassis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    aggregated-devices {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            device-count $DEVICE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    network-services enhanced-ip;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* Junos variant (no network-services line needed): */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">chassis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    aggregated-devices {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            device-count $DEVICE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 374,
+      "lineCount": 20,
+      "techFamily": "Chassis",
+      "subfamily": "Chassis",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/cos/classifier-dscp-exp-8021p",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "classifier-dscp-exp-8021p",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/cos/classifier-dscp-exp-8021p.conf",
+      "topic": "Multi-field BA classifiers (DSCP, MPLS EXP, 802.1p → 8-class forwarding)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "8 forwarding classes: BEST-EFFORT, LOW, MEDIUM, SIG-OAM, BUSINESS, REALTIME, NETWORK, CONTROL",
+        "DSCP classifier used on customer-facing access interfaces (ingress from CE)",
+        "EXP classifier used on core-facing MPLS interfaces (trust MPLS marking from peer PE)",
+        "802.1p (ieee-802.1) classifier used on VLAN-tagged service AC units",
+        "loss-priority high on some code-points triggers WRED (drop-profile dp2) earlier under congestion"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/forwarding-class-map.conf  (the queue-num mapping these classifiers feed into)",
+          "id": null
+        },
+        {
+          "raw": "junos/cos/rewrite-rules-exp.conf     (EXP rewrite on egress core interfaces)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "class-of-service {\n    classifiers {\n        dscp DSCP {\n            forwarding-class BEST-EFFORT {\n                loss-priority low code-points be;\n            }\n            forwarding-class BUSINESS {\n                loss-priority low code-points [ cs4 af41 ];\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points cs7;\n            }\n            forwarding-class LOW {\n                loss-priority low code-points [ cs1 af11 ];\n            }\n            forwarding-class MEDIUM {\n                loss-priority high code-points [ cs2 af21 ];\n            }\n            forwarding-class NETWORK {\n                loss-priority low code-points cs6;\n            }\n            forwarding-class REALTIME {\n                loss-priority low code-points [ cs5 ef ];\n            }\n            forwarding-class SIG-OAM {\n                loss-priority low code-points [ cs3 af31 ];\n            }\n        }\n        exp EXP {\n            forwarding-class BEST-EFFORT {\n                loss-priority high code-points 000;\n            }\n            forwarding-class BUSINESS {\n                loss-priority high code-points 100;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points 111;\n            }\n            forwarding-class LOW {\n                loss-priority low code-points 001;\n            }\n            forwarding-class MEDIUM {\n                loss-priority high code-points 010;\n            }\n            forwarding-class NETWORK {\n                loss-priority low code-points 110;\n            }\n            forwarding-class REALTIME {\n                loss-priority low code-points 101;\n            }\n            forwarding-class SIG-OAM {\n                loss-priority high code-points 011;\n            }\n        }\n        ieee-802.1 8021P {\n            forwarding-class BEST-EFFORT {\n                loss-priority high code-points 000;\n            }\n            forwarding-class BUSINESS {\n                loss-priority high code-points 100;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points 111;\n            }\n            forwarding-class LOW {\n                loss-priority low code-points 001;\n            }\n            forwarding-class MEDIUM {\n                loss-priority high code-points 010;\n            }\n            forwarding-class NETWORK {\n                loss-priority low code-points 110;\n            }\n            forwarding-class REALTIME {\n                loss-priority low code-points 101;\n            }\n            forwarding-class SIG-OAM {\n                loss-priority high code-points 011;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        dscp DSCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs4 af41 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs1 af11 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points [ cs2 af21 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class NETWORK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs5 ef ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points [ cs3 af31 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        exp EXP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class NETWORK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> 8021P {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class NETWORK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority high code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2689,
+      "lineCount": 82,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/cos/forwarding-class-map",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "forwarding-class-map",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/cos/forwarding-class-map.conf",
+      "topic": "Forwarding-class to queue-number mapping (8-class CoS model)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Maps 8 named forwarding classes to hardware queue numbers 0-7",
+        "CONTROL (q7) and NETWORK (q6) are typically strict-priority (not shown here)",
+        "REALTIME (q5) is usually strict-priority or low-latency for voice/video",
+        "BEST-EFFORT (q0) gets remaining bandwidth after priority queues are served",
+        "drop-profiles dp1/dp2 implement WRED at different aggressiveness for congestion management"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifier-dscp-exp-8021p.conf  (classifiers that feed these queues)",
+          "id": null
+        },
+        {
+          "raw": "junos/cos/rewrite-rules-exp.conf          (marking on egress)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "class-of-service {\n    drop-profiles {\n        dp1 {\n            fill-level 40 drop-probability 0;\n            fill-level 50 drop-probability 70;\n        }\n        dp2 {\n            fill-level 10 drop-probability 0;\n            fill-level 30 drop-probability 30;\n        }\n    }\n    forwarding-classes {\n        class BEST-EFFORT queue-num 0;\n        class BUSINESS queue-num 4;\n        class CONTROL queue-num 7;\n        class LOW queue-num 1;\n        class MEDIUM queue-num 2;\n        class NETWORK queue-num 6;\n        class REALTIME queue-num 5;\n        class SIG-OAM queue-num 3;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    drop-profiles {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        dp1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">70</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        dp2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            fill-level </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\"> drop-probability </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BUSINESS queue-num </span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class CONTROL queue-num </span><span style=\"color:#79C0FF\">7</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class LOW queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class MEDIUM queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class NETWORK queue-num </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class REALTIME queue-num </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class SIG-OAM queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 592,
+      "lineCount": 22,
+      "techFamily": "QoS / CoS",
+      "subfamily": "Cos",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/cos/rewrite-rules-exp",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "rewrite-rules-exp",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/cos/rewrite-rules-exp.conf",
+      "topic": "EXP rewrite rule and per-interface CoS binding (core egress marking)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "EXP rewrite marks MPLS packets on core egress with the correct EXP value per queue",
+        "Applied to core-facing interfaces (et-*, ae2) so peer P/PE routers trust the marking",
+        "Access-facing interfaces (xe-*, ae0) get 802.1p classifiers on ingress instead",
+        "Interface-level CoS binding ties classifier (ingress) and rewrite (egress) to specific units"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifier-dscp-exp-8021p.conf  (the classifiers referenced in interface bindings)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/physical-uplink-mpls.conf (the core interfaces these rewrites apply to)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_INTF",
+          "example": "et-0/0/1"
+        },
+        {
+          "name": "$ACCESS_INTF",
+          "example": "xe-0/0/9:0"
+        },
+        {
+          "name": "$REWRITE_NAME",
+          "example": "EXP-REWRITE"
+        },
+        {
+          "name": "$CLASSIFIER_NAME",
+          "example": "EXP / 8021P"
+        }
+      ],
+      "body": "class-of-service {\n    interfaces {\n        $CORE_INTF {\n            unit 0 {\n                classifiers {\n                    exp $CLASSIFIER_NAME;\n                }\n                rewrite-rules {\n                    exp $REWRITE_NAME;\n                }\n            }\n        }\n        $ACCESS_INTF {\n            unit $UNIT {\n                classifiers {\n                    ieee-802.1 8021P;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $CORE_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp $CLASSIFIER_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp $REWRITE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $ACCESS_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> 8021P;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 446,
+      "lineCount": 21,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/ddos-mitigation/flowspec-routes",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "ddos-mitigation",
+      "name": "flowspec-routes",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/ddos-mitigation/flowspec-routes.conf",
+      "topic": "BGP FlowSpec enablement for dynamic DDoS mitigation",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Enabled via family inet { flow; } in the iBGP group configuration",
+        "Allows a controller/RR to inject RFC 5575 FlowSpec routes dynamically",
+        "FlowSpec routes install firewall filters in hardware without CLI configuration",
+        "Provides real-time DDoS mitigation by matching and dropping/rate-limiting attack traffic",
+        "The static firewall filters (filter-ipv4-stateless) are the manual equivalent",
+        "No static flowspec-routes are configured; all injection is via BGP from the RR"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/bgp-ibgp-evpn.conf         (BGP group with family inet flow enabled)",
+          "id": null
+        },
+        {
+          "raw": "junos/firewall/filter-ipv4-stateless.conf   (static equivalent for manual PBR)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "/* FlowSpec is enabled in the BGP group: */\n\nprotocols {\n    bgp {\n        group ibgp {\n            family inet {\n                unicast;\n                flow;   /* ← This enables FlowSpec route reception */\n            }\n        }\n    }\n}\n\n/* FlowSpec routes are injected by an external controller or RR peer.\n * When received, they automatically install as:\n *   - firewall filter terms matching the flow-spec NLRI fields\n *   - actions per the extended-community (rate-limit, discard, redirect, mark)\n *\n * Verify with: show route table inetflow.0\n */",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">/* FlowSpec is enabled in the BGP group: */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        group ibgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow;   /* ← This enables FlowSpec route reception */</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* FlowSpec routes are injected by an external controller or RR peer.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * When received, they automatically install as:</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *   - firewall filter terms matching the flow-spec NLRI fields</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *   - actions per the extended-community (rate-limit, discard, redirect, mark)</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * Verify with: show route table inetflow.</span><span style=\"color:#79C0FF\">0</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> */</span></span></code></pre>",
+      "bytes": 557,
+      "lineCount": 20,
+      "techFamily": "Other",
+      "subfamily": "Ddos Mitigation",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/firewall/filter-ipv4-stateless",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-ipv4-stateless",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/firewall/filter-ipv4-stateless.conf",
+      "topic": "IPv4 stateless firewall filter (PBR with next-ip/next-interface)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Stateless filters match on L3/L4 fields (src/dst address, src/dst port, protocol)",
+        "Actions redirect traffic via next-ip (policy-based routing to specific next-hop)",
+        "Or next-interface (steer to a specific egress interface regardless of FIB)",
+        "count action provides per-filter hit statistics for monitoring/debugging",
+        "These filters are applied to interfaces for traffic steering / DDoS mitigation"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/ddos-mitigation/flowspec-routes.conf  (dynamic version via BGP FlowSpec)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "filter_ip_dport1"
+        },
+        {
+          "name": "$PROTOCOL",
+          "example": "tcp"
+        },
+        {
+          "name": "$MATCH_FIELD",
+          "example": "destination-port 80 / source-address 222.222.2.100/32"
+        },
+        {
+          "name": "$NEXT_HOP",
+          "example": "192.168.56.2/32"
+        },
+        {
+          "name": "$NEXT_INTF",
+          "example": "et-0/0/1"
+        }
+      ],
+      "body": "firewall {\n    family inet {\n        filter $FILTER_NAME {\n            term 1 {\n                from {\n                    protocol $PROTOCOL;\n                    destination-port $DST_PORT;\n                }\n                then {\n                    count $FILTER_NAME;\n                    next-ip $NEXT_HOP;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protocol $PROTOCOL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-port $DST_PORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count $FILTER_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    next-ip $NEXT_HOP;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 360,
+      "lineCount": 16,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/interfaces/ccc-vpws-mux",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "ccc-vpws-mux",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/interfaces/ccc-vpws-mux.conf",
+      "topic": "VPWS and ELAN attachment-circuit units (vlan-ccc with ESI, vlan-bridge)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "vlan-ccc units carry point-to-point VPWS traffic; vlan-bridge units carry ELAN L2 frames",
+        "ESI with all-active enables per-flow multi-homing across PE pairs sharing the same LAG",
+        "ESI is a 10-byte identifier — must be identical on both multi-homed PEs for the same AC",
+        "Units without ESI are single-homed (e.g. traffic-generator facing ports)",
+        "vlan-bridge units have no family statement — bridging is implied by the encapsulation",
+        "Scale: ~1500 vlan-ccc units + ~1000 vlan-bridge units per ae0 in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/lag-flexible-services.conf  (the parent ae interface)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/evpn-vpws-simple.conf         (instances binding these vlan-ccc units)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/evpn-elan-simple.conf         (instances binding these vlan-bridge units)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LAG_INTF",
+          "example": "ae0"
+        },
+        {
+          "name": "$UNIT",
+          "example": "1"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$ESI",
+          "example": "00:12:12:12:12:12:12:12:11:01"
+        }
+      ],
+      "body": "/* --- VPWS AC (vlan-ccc with ESI, multi-homed) --- */\n\ninterfaces {\n    $LAG_INTF {\n        unit $UNIT {\n            encapsulation vlan-ccc;\n            vlan-id $VLAN_ID;\n            esi {\n                $ESI;\n                all-active;\n            }\n            family ccc;\n        }\n    }\n}\n\n/* --- ELAN AC (vlan-bridge, no ESI needed for bridge units) --- */\n\ninterfaces {\n    $LAG_INTF {\n        unit $UNIT {\n            encapsulation vlan-bridge;\n            vlan-id $VLAN_ID;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">/* --- VPWS AC (vlan-ccc with ESI, multi-homed) --- */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $LAG_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                $ESI;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* --- ELAN AC (vlan-bridge, no ESI needed for bridge units) --- */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $LAG_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 502,
+      "lineCount": 26,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/interfaces/irb-gateway",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "irb-gateway",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/interfaces/irb-gateway.conf",
+      "topic": "IRB gateway interface (per-VRF L3 address for EVPN Type-5 routing)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Each IRB unit provides the default gateway for one bridge domain / MAC-VRF VLAN",
+        "Unit number typically matches the VLAN-ID and routing-instance index for traceability",
+        "Bound to both an EVPN ELAN instance (L2) and a VRF instance (L3 ip-prefix-routes)",
+        "Address is the anycast gateway or per-PE unique address depending on design",
+        "Scale: ~350 IRB units per WAN edge in this JVD (one per VRF)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/evpn-elan-bridged.conf  (ELAN instance referencing routing-interface irb.$UNIT)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/evpn-vrf-ip-prefix.conf (VRF instance referencing interface irb.$UNIT)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$UNIT",
+          "example": "100"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "100.100.100.1/24"
+        }
+      ],
+      "body": "interfaces {\n    irb {\n        unit $UNIT {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    irb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 140,
+      "lineCount": 9,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/interfaces/lag-flexible-services",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "lag-flexible-services",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/interfaces/lag-flexible-services.conf",
+      "topic": "LAG with flexible VLAN services (multi-service bundle for VPWS/ELAN ACs)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "flexible-vlan-tagging + encapsulation flexible-ethernet-services allows mixed AC types per unit",
+        "Units can be vlan-ccc (VPWS), vlan-bridge (ELAN), or standard IP on the same ae interface",
+        "LACP active with fast periodic (1s) and fast-failover for sub-second link recovery",
+        "link-protection revertive provides automatic revert after member-link failure clears",
+        "system-id must match across multi-homed PEs sharing the same ESI for the LAG",
+        "Scale: ae0 carries ~2500+ units (VPWS + ELAN) in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/ccc-vpws-mux.conf    (per-unit VPWS/ELAN AC config on this LAG)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/evpn-vpws-fxc.conf      (instances referencing ae0.* units)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LAG_INTF",
+          "example": "ae0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "PE1 to CE1"
+        },
+        {
+          "name": "$LACP_SYSTEM_ID",
+          "example": "00:00:00:01:01:01"
+        }
+      ],
+      "body": "interfaces {\n    $LAG_INTF {\n        description \"$DESCRIPTION\";\n        flexible-vlan-tagging;\n        encapsulation flexible-ethernet-services;\n        aggregated-ether-options {\n            lacp {\n                active;\n                periodic fast;\n                fast-failover;\n                link-protection {\n                    revertive;\n                }\n                system-id $LACP_SYSTEM_ID;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $LAG_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                periodic fast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                fast-failover;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                link-protection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    revertive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                system-id $LACP_SYSTEM_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 443,
+      "lineCount": 18,
+      "techFamily": "Interfaces",
+      "subfamily": "LAG / LACP",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/interfaces/loopback",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "loopback",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/interfaces/loopback.conf",
+      "topic": "Loopback interface (router-id, BGP source, MPLS label binding)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "/32 address serves as router-id, OSPF passive interface, and BGP local-address",
+        "family mpls required for the loopback to be a valid MPLS endpoint (SR node-SID target)",
+        "lo0.0 appears in OSPF area 0 as passive, MPLS interface list, and LDP interface list",
+        "The loopback IP is used as the route-distinguisher prefix for all service instances"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ospf-sr-lfa.conf     (lo0.0 as passive OSPF interface)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/bgp-ibgp-evpn.conf   (lo0.0 IP as BGP local-address)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LOOPBACK_V4",
+          "example": "2.2.2.2/32"
+        }
+      ],
+      "body": "interfaces {\n    lo0 {\n        unit 0 {\n            family inet {\n                address $LOOPBACK_V4;\n            }\n            family mpls;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    lo0 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $LOOPBACK_V4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 160,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/interfaces/physical-uplink-mpls",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "physical-uplink-mpls",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/interfaces/physical-uplink-mpls.conf",
+      "topic": "Physical core uplink with MPLS and IPv4 (WAN backbone interface)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Core-facing interfaces carry both family inet (OSPF hello/routing) and family mpls (label switching)",
+        "May be a direct physical port (et-*) or a LAG (ae2) depending on topology",
+        "Point-to-point link addressing (/24 or /30) — no VLAN tagging on core links",
+        "These interfaces appear in OSPF area 0, MPLS interface list, and optionally LDP/RSVP",
+        "On Junos MX, member links use gigether-options { 802.3ad }; on EVO they use ether-options"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ospf-sr-lfa.conf  (OSPF config referencing these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/mpls-lsp.conf     (MPLS enablement on these interfaces)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTF",
+          "example": "ae2 / et-0/0/1"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "CE1 to PE1/2 / Link from WAN Edge1 to WAN Edge2"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "192.168.12.1/24"
+        }
+      ],
+      "body": "interfaces {\n    $INTF {\n        description \"$DESCRIPTION\";\n        unit 0 {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n            family mpls;\n        }\n    }\n}\n\n/* LAG variant with LACP (ae2 on wanedge1): */\n\ninterfaces {\n    $INTF {\n        description \"$DESCRIPTION\";\n        aggregated-ether-options {\n            lacp {\n                active;\n                periodic fast;\n            }\n        }\n        unit 0 {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n            family mpls;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* LAG variant with LACP (ae2 </span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\"> wanedge1): */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                periodic fast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 581,
+      "lineCount": 31,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/oam/cfm-maintenance-domain",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "oam",
+      "name": "cfm-maintenance-domain",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/oam/cfm-maintenance-domain.conf",
+      "topic": "CFM maintenance domain with continuity-check MEP (802.1ag OAM)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "IEEE 802.1ag Connectivity Fault Management for per-service MPLS/EVPN path monitoring",
+        "Level 3 maintenance-domain — typical for provider-edge to provider-edge monitoring",
+        "Continuity-check at 1s interval detects forwarding failures within ~3.5s (3.5× interval)",
+        "MEP direction \"up\" monitors the MPLS/EVPN path toward the remote PE (not the local CE)",
+        "auto-discovery enables automatic remote-MEP detection without static peer configuration",
+        "Scale: one maintenance-domain per monitored service instance (hundreds in this JVD)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/oam/cfm-sla-iterator.conf          (performance measurement on these MEPs)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/ccc-vpws-mux.conf        (the AC interfaces referenced by MEPs)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$MD_NAME",
+          "example": "m-d301"
+        },
+        {
+          "name": "$MD_LEVEL",
+          "example": "3"
+        },
+        {
+          "name": "$MA_NAME",
+          "example": "m-a301"
+        },
+        {
+          "name": "$MEP_ID",
+          "example": "1"
+        },
+        {
+          "name": "$MEP_INTF",
+          "example": "xe-0/0/9:0.301"
+        },
+        {
+          "name": "$CC_INTERVAL",
+          "example": "1s"
+        }
+      ],
+      "body": "protocols {\n    oam {\n        ethernet {\n            connectivity-fault-management {\n                maintenance-domain $MD_NAME {\n                    level $MD_LEVEL;\n                    name-format character-string;\n                    maintenance-association $MA_NAME {\n                        short-name-format character-string;\n                        continuity-check {\n                            interval $CC_INTERVAL;\n                        }\n                        mep $MEP_ID {\n                            interface $MEP_INTF;\n                            direction up;\n                            auto-discovery;\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    oam {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            connectivity-fault-management {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                maintenance-domain $MD_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    level $MD_LEVEL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    name-format character-string;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    maintenance-association $MA_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        short-name-format character-string;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        continuity-check {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            interval $CC_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        mep $MEP_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            interface $MEP_INTF;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            direction up;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            auto-discovery;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 723,
+      "lineCount": 23,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/oam/cfm-sla-iterator",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "oam",
+      "name": "cfm-sla-iterator",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/oam/cfm-sla-iterator.conf",
+      "topic": "CFM enhanced SLA iterator (two-way delay and synthetic loss measurement)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "enhanced-sla-iterator enables hardware-timestamped performance measurement",
+        "measurement-interval 5 (minutes) sets the reporting/aggregation window",
+        "two-way-delay profile measures round-trip latency between MEP pairs",
+        "slm (Synthetic Loss Measurement) profile detects frame loss without service disruption",
+        "Profiles are referenced by iterator configurations bound to specific MEPs (not shown)",
+        "Requires CFM maintenance-domains to be configured first"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/oam/cfm-maintenance-domain.conf  (the MEPs these measurements run against)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$PROFILE_DELAY",
+          "example": "i1"
+        },
+        {
+          "name": "$PROFILE_SLM",
+          "example": "i2"
+        },
+        {
+          "name": "$INTERVAL",
+          "example": "5"
+        }
+      ],
+      "body": "protocols {\n    oam {\n        ethernet {\n            connectivity-fault-management {\n                performance-monitoring {\n                    enhanced-sla-iterator;\n                    measurement-interval $INTERVAL;\n                    sla-iterator-profiles {\n                        $PROFILE_DELAY {\n                            measurement-type two-way-delay;\n                        }\n                        $PROFILE_SLM {\n                            measurement-type slm;\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    oam {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            connectivity-fault-management {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                performance-monitoring {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    enhanced-sla-iterator;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    measurement-interval $INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    sla-iterator-profiles {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        $PROFILE_DELAY {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            measurement-type two-way-delay;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        $PROFILE_SLM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            measurement-type slm;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 578,
+      "lineCount": 20,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/policy/per-packet-load-balance",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "policy",
+      "name": "per-packet-load-balance",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/policy/per-packet-load-balance.conf",
+      "topic": "Per-packet load-balance and BGP redistribution policies",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "pplb policy enables per-flow ECMP across equal-cost BGP/IGP paths",
+        "Applied via routing-options { forwarding-table { export pplb; } }",
+        "Term 1 specifically matches family evpn for EVPN multipath load-balancing",
+        "Default term applies per-packet to all other families (inet, mpls, etc.)",
+        "send-direct redistributes directly-connected routes into BGP for loopback reachability",
+        "bgp-to-ospf redistributes BGP routes into OSPF (used in multi-area designs)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/bgp-ibgp-evpn.conf           (BGP sessions using send-direct export)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/forwarding-options-hash.conf  (hash-key that pplb distributes across)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "policy-options {\n    policy-statement pplb {\n        term 1 {\n            from family evpn;\n            then {\n                load-balance per-packet;\n                accept;\n            }\n        }\n        then {\n            load-balance per-packet;\n            accept;\n        }\n    }\n    policy-statement send-direct {\n        term 1 {\n            from protocol direct;\n            then accept;\n        }\n    }\n    policy-statement bgp-to-ospf {\n        from protocol bgp;\n        then accept;\n    }\n}\n\n/* Applied in routing-options: */\n\nrouting-options {\n    forwarding-table {\n        export pplb;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement pplb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> family evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                load-balance per-packet;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            load-balance per-packet;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement send-direct {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> protocol direct;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement bgp-to-ospf {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol bgp;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">/* Applied in routing-options: */</span></span>\n<span class=\"line\"></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-table {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        export</span><span style=\"color:#E6EDF3\"> pplb;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 611,
+      "lineCount": 33,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/services/evpn-elan-bridged",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-elan-bridged",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/services/evpn-elan-bridged.conf",
+      "topic": "EVPN ELAN bridge domain with IRB gateway (L2+L3 integrated)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "Junos-specific: uses instance-type evpn with routing-interface (EVO uses mac-vrf + l3-interface)",
+        "no-normalization preserves original VLAN tags through the bridge domain",
+        "encapsulation mpls explicitly sets EVPN/MPLS data-plane (vs VXLAN)",
+        "default-gateway do-not-advertise suppresses Type-5 default from this instance",
+        "vlan-id none allows multiple VLANs or untagged frames into the same bridge domain",
+        "The IRB interface is associated with a VRF instance for ip-prefix-route advertisement"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/evpn-vrf-ip-prefix.conf  (the L3 VRF that binds to irb.$UNIT)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/irb-gateway.conf       (IRB unit with anycast or per-PE addressing)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "emh_group_400_1999"
+        },
+        {
+          "name": "$AC_INTF",
+          "example": "ae0.1999"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.1999"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "none"
+        },
+        {
+          "name": "$RD",
+          "example": "22.22.22.22:1999"
+        },
+        {
+          "name": "$RT",
+          "example": "target:60525:1999"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn {\n                no-normalization;\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n            }\n        }\n        vlan-id $VLAN_ID;\n        routing-interface $IRB_UNIT;\n        interface $AC_INTF;\n        route-distinguisher $RD;\n        vrf-target $RT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-normalization;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 407,
+      "lineCount": 17,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/services/evpn-elan-simple",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-elan-simple",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/services/evpn-elan-simple.conf",
+      "topic": "EVPN ELAN bridge domain — simple L2 multipoint (no IRB)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "Junos-specific: uses instance-type evpn (EVO uses mac-vrf instead)",
+        "Minimal ELAN: just protocols { evpn; } — no encapsulation or gateway knobs needed",
+        "Multiple ACs per instance for multi-homing or multi-site bridging",
+        "No IRB interface — pure L2 switching across the MPLS/EVPN fabric",
+        "Scale: ~500 simple ELAN instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/ccc-vpws-mux.conf   (per-unit VLAN-bridge AC config)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/evpn-elan-bridged.conf (variant with IRB for L3 gateway)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "elan_group_500_2001"
+        },
+        {
+          "name": "$AC_INTF_1",
+          "example": "ae0.2001"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "ae0.2002"
+        },
+        {
+          "name": "$RD",
+          "example": "22.22.22.22:2001"
+        },
+        {
+          "name": "$RT",
+          "example": "target:62525:2001"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn;\n        }\n        interface $AC_INTF_1;\n        interface $AC_INTF_2;\n        route-distinguisher $RD;\n        vrf-target $RT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 241,
+      "lineCount": 12,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/services/evpn-vpws-fxc",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-vpws-fxc",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/services/evpn-vpws-fxc.conf",
+      "topic": "EVPN-VPWS with Flexible Cross-Connect (multi-AC VLAN-aware)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Multi-homed VPWS carrying 2+ VLANs per instance via flexible-cross-connect-vlan-aware",
+        "Each AC interface gets its own vpws-service-id pair (local/remote must be swapped on the far end)",
+        "All ACs share a single RD and RT; the service-id disambiguates circuits within the instance",
+        "Scale: ~500 FXC instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/lag-flexible-services.conf  (the ae0 bundle carrying these ACs)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/ccc-vpws-mux.conf           (per-AC unit config on ae0)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vfxc_group_40_1001"
+        },
+        {
+          "name": "$AC_INTF_1",
+          "example": "ae0.1001"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "ae0.1002"
+        },
+        {
+          "name": "$LOCAL_ID_1",
+          "example": "2"
+        },
+        {
+          "name": "$REMOTE_ID_1",
+          "example": "1"
+        },
+        {
+          "name": "$LOCAL_ID_2",
+          "example": "21"
+        },
+        {
+          "name": "$REMOTE_ID_2",
+          "example": "11"
+        },
+        {
+          "name": "$RD",
+          "example": "22.22.22.22:1001"
+        },
+        {
+          "name": "$RT",
+          "example": "target:65000:1001"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF_1 {\n                    vpws-service-id {\n                        local $LOCAL_ID_1;\n                        remote $REMOTE_ID_1;\n                    }\n                }\n                interface $AC_INTF_2 {\n                    vpws-service-id {\n                        local $LOCAL_ID_2;\n                        remote $REMOTE_ID_2;\n                    }\n                }\n                flexible-cross-connect-vlan-aware;\n            }\n        }\n        interface $AC_INTF_1;\n        interface $AC_INTF_2;\n        route-distinguisher $RD;\n        vrf-target $RT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_ID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_ID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_ID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_ID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-cross-connect-vlan-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 722,
+      "lineCount": 26,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/services/evpn-vpws-simple",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-vpws-simple",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/services/evpn-vpws-simple.conf",
+      "topic": "EVPN-VPWS point-to-point pseudowire (single AC, control-word)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Simplest VPWS: one AC interface, one vpws-service-id pair, control-word enabled",
+        "control-word ensures correct sequencing and prevents fat-pipe reordering issues",
+        "local/remote IDs must be mirror-swapped on the PE peer (local 10 ↔ remote 40)",
+        "Scale: ~1000 simple VPWS instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/ccc-vpws-mux.conf  (the per-unit AC config on the physical/LAG interface)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vpws_group_14_1"
+        },
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/0/9:0.1"
+        },
+        {
+          "name": "$LOCAL_ID",
+          "example": "10"
+        },
+        {
+          "name": "$REMOTE_ID",
+          "example": "40"
+        },
+        {
+          "name": "$RD",
+          "example": "2.2.2.2:141"
+        },
+        {
+          "name": "$RT",
+          "example": "target:63535:141"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF {\n                    vpws-service-id {\n                        local $LOCAL_ID;\n                        remote $REMOTE_ID;\n                    }\n                }\n                control-word;\n            }\n        }\n        interface $AC_INTF;\n        route-distinguisher $RD;\n        vrf-target $RT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 458,
+      "lineCount": 19,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/services/evpn-vrf-ip-prefix",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-vrf-ip-prefix",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/services/evpn-vrf-ip-prefix.conf",
+      "topic": "EVPN IP-prefix route VRF (L3 VPN with EVPN Type-5 advertisement)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "L3 VRF that advertises connected IRB subnets as EVPN Type-5 ip-prefix routes",
+        "advertise direct-nexthop enables direct PE-to-PE forwarding (no recursive resolution)",
+        "encapsulation mpls sets the data-plane encap for inter-PE traffic",
+        "vrf-table-label allocates a per-VRF MPLS label for ingress lookup",
+        "Each VRF binds one IRB interface — the IRB lives in a corresponding ELAN bridge domain",
+        "Scale: ~350 VRF instances per WAN edge in this JVD"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/evpn-elan-bridged.conf  (the bridge domain whose IRB feeds this VRF)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/irb-gateway.conf      (IRB unit addressing)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_100"
+        },
+        {
+          "name": "$ROUTER_ID",
+          "example": "2.2.2.2"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.100"
+        },
+        {
+          "name": "$RD",
+          "example": "60202:100"
+        },
+        {
+          "name": "$RT",
+          "example": "target:60303:100"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type vrf;\n        routing-options {\n            router-id $ROUTER_ID;\n        }\n        protocols {\n            evpn {\n                ip-prefix-routes {\n                    advertise direct-nexthop;\n                    encapsulation mpls;\n                }\n            }\n        }\n        interface $IRB_UNIT;\n        route-distinguisher $RD;\n        vrf-target $RT;\n        vrf-table-label;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            router-id $ROUTER_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ip-prefix-routes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise direct-nexthop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 458,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/transport/bgp-ibgp-evpn",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "bgp-ibgp-evpn",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/transport/bgp-ibgp-evpn.conf",
+      "topic": "iBGP overlay with EVPN signaling (route-reflector client config)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Full-mesh iBGP to route-reflectors (3.3.3.3 / 6.6.6.6 are RRs in this JVD)",
+        "family evpn signaling enables EVPN Type-1 through Type-5 route exchange",
+        "family inet flow enables BGP FlowSpec for DDoS mitigation",
+        "advertise-external (Junos) allows external routes to be re-advertised to iBGP peers",
+        "BFD at 100ms × 3 for sub-second peer failure detection",
+        "multipath enables BGP multipath for ECMP across RRs"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/policy/per-packet-load-balance.conf  (the pplb policy applied via forwarding-table export)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ospf-sr-lfa.conf           (the IGP underlay these sessions ride over)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LOCAL_ADDRESS",
+          "example": "2.2.2.2"
+        },
+        {
+          "name": "$LOCAL_AS",
+          "example": "64512"
+        },
+        {
+          "name": "$RR_PEER_1",
+          "example": "3.3.3.3"
+        },
+        {
+          "name": "$RR_PEER_2",
+          "example": "6.6.6.6"
+        }
+      ],
+      "body": "protocols {\n    bgp {\n        family inet {\n            unicast {\n                loops 2;\n            }\n        }\n        group ibgp {\n            type internal;\n            local-address $LOCAL_ADDRESS;\n            advertise-external;\n            family inet {\n                unicast;\n                flow;\n            }\n            family evpn {\n                signaling;\n            }\n            export send-direct;\n            local-as $LOCAL_AS;\n            multipath;\n            bfd-liveness-detection {\n                minimum-interval 100;\n                multiplier 3;\n            }\n            neighbor $RR_PEER_1;\n            neighbor $RR_PEER_2;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unicast {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loops </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        group ibgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-address $LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            advertise-external;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                signaling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            export</span><span style=\"color:#E6EDF3\"> send-direct;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-as $LOCAL_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            multipath;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                minimum-interval </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $RR_PEER_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $RR_PEER_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 680,
+      "lineCount": 30,
+      "techFamily": "Transport",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/transport/forwarding-options-hash",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "forwarding-options-hash",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/transport/forwarding-options-hash.conf",
+      "topic": "Forwarding hash-key configuration for ECMP and LAG load distribution",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Controls which header fields the forwarding plane uses for ECMP/LAG hashing",
+        "inet/inet6: layer-3 + layer-4 includes src/dst IP AND TCP/UDP ports for finer distribution",
+        "multiservice: source-mac + destination-mac for L2 frames without IP headers",
+        "Without this, default hash may only use L3 headers, causing polarization on LAG/ECMP",
+        "Critical for WAN edges carrying thousands of pseudowires over a small number of ECMP paths"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/lag-flexible-services.conf  (the LAG benefiting from this hash)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ospf-sr-lfa.conf             (ECMP paths this hash distributes across)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "forwarding-options {\n    hash-key {\n        family inet {\n            layer-3;\n            layer-4;\n        }\n        family inet6 {\n            layer-3;\n            layer-4;\n        }\n        family multiservice {\n            source-mac;\n            destination-mac;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">forwarding-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    hash-key {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            layer-</span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family multiservice {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            source-mac;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            destination-mac;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 285,
+      "lineCount": 16,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/transport/mpls-lsp",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "mpls-lsp",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/transport/mpls-lsp.conf",
+      "topic": "MPLS label-switched paths (RSVP-less static LSP definitions)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "wanedge3_acx7509",
+          "wanedge4_acx7100-48l",
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "traffic-engineering enables MPLS-TE database population from IGP",
+        "label-switched-path entries define egress PE targets for RSVP or SR-TE tunnels",
+        "In this JVD, LSPs are minimal (to destination only) — no explicit-path or bandwidth",
+        "All core-facing interfaces and lo0.0 must be MPLS-enabled",
+        "These LSPs serve as the transport tunnel for EVPN overlay traffic"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ospf-sr-lfa.conf    (the SR underlay that resolves these LSPs)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/rsvp-te.conf        (RSVP signaling if used — wanedge2 only)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LSP_NAME_1",
+          "example": "lsp_to_pe3"
+        },
+        {
+          "name": "$LSP_DEST_1",
+          "example": "4.4.4.4"
+        },
+        {
+          "name": "$LSP_NAME_2",
+          "example": "lsp_to_pe4"
+        },
+        {
+          "name": "$LSP_DEST_2",
+          "example": "7.7.7.7"
+        },
+        {
+          "name": "$CORE_INTF_1",
+          "example": "ae2.0"
+        }
+      ],
+      "body": "protocols {\n    mpls {\n        traffic-engineering;\n        label-switched-path $LSP_NAME_1 {\n            to $LSP_DEST_1;\n        }\n        label-switched-path $LSP_NAME_2 {\n            to $LSP_DEST_2;\n        }\n        interface $CORE_INTF_1;\n        interface lo0.0;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        traffic-engineering;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_INTF_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 276,
+      "lineCount": 13,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/transport/ospf-sr-lfa",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "ospf-sr-lfa",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/transport/ospf-sr-lfa.conf",
+      "topic": "OSPF with Segment Routing and TI-LFA (post-convergence node protection)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "source-packet-routing enables OSPF Segment Routing with node-segment index allocation",
+        "SRGB 16000–24000 must be consistent across all SR-capable nodes in the domain",
+        "backup-spf-options with use-post-convergence-lfa enables TI-LFA (Topology-Independent LFA)",
+        "maximum-labels 8 allows up to 8 segment labels in the backup path (deep protection)",
+        "per-interface post-convergence-lfa { node-protection } activates node-protecting backup",
+        "ipv4-adjacency-segment { protected dynamic } assigns protected adj-SIDs for TE use",
+        "BFD at 10ms × 3 on core links for fast failure detection"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/mpls-lsp.conf              (LSPs that ride over this SR underlay)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/bgp-ibgp-evpn.conf         (iBGP sessions using this IGP's loopbacks)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$NODE_SEGMENT_INDEX",
+          "example": "102"
+        },
+        {
+          "name": "$SRGB_START",
+          "example": "16000"
+        },
+        {
+          "name": "$SRGB_RANGE",
+          "example": "8000"
+        },
+        {
+          "name": "$CORE_INTF_1",
+          "example": "ae2.0"
+        },
+        {
+          "name": "$CORE_INTF_2",
+          "example": "et-0/0/1.0"
+        }
+      ],
+      "body": "protocols {\n    ospf {\n        backup-spf-options {\n            use-post-convergence-lfa {\n                maximum-labels 8;\n                maximum-backup-paths 5;\n            }\n            use-source-packet-routing;\n        }\n        traffic-engineering;\n        source-packet-routing {\n            node-segment ipv4-index $NODE_SEGMENT_INDEX;\n            srgb start-label $SRGB_START index-range $SRGB_RANGE;\n        }\n        area 0.0.0.0 {\n            interface $CORE_INTF_1 {\n                interface-type p2p;\n                bfd-liveness-detection {\n                    minimum-interval 10;\n                    multiplier 3;\n                    full-neighbors-only;\n                }\n                post-convergence-lfa {\n                    node-protection;\n                }\n                ipv4-adjacency-segment {\n                    protected dynamic;\n                }\n            }\n            interface $CORE_INTF_2 {\n                interface-type p2p;\n                bfd-liveness-detection {\n                    minimum-interval 10;\n                    multiplier 3;\n                    full-neighbors-only;\n                }\n                post-convergence-lfa {\n                    node-protection;\n                }\n                ipv4-adjacency-segment {\n                    protected dynamic;\n                }\n            }\n            interface lo0.0 {\n                passive;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        backup-spf-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            use-post-convergence-lfa {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                maximum-labels </span><span style=\"color:#79C0FF\">8</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                maximum-backup-paths </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            use-source-packet-routing;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        traffic-engineering;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        source-packet-routing {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            node-segment ipv4-index $NODE_SEGMENT_INDEX;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            srgb start-label $SRGB_START index-range $SRGB_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        area </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_INTF_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface-type p2p;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    full-neighbors-only;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                post-convergence-lfa {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    node-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ipv4-adjacency-segment {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protected dynamic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_INTF_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface-type p2p;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    full-neighbors-only;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                post-convergence-lfa {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    node-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ipv4-adjacency-segment {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protected dynamic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                passive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1439,
+      "lineCount": 49,
+      "techFamily": "Transport",
+      "subfamily": "OSPF",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_adv_core_edge/junos/transport/rsvp-te",
+      "jvd": "ewan_adv_core_edge",
+      "jvdLabel": "Enterprise WAN: Advanced Core/Edge",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "rsvp-te",
+      "path": "enterprise_wan/ewan_adv_core_edge/configuration/snips/junos/transport/rsvp-te.conf",
+      "topic": "RSVP-TE interface enablement (signaled LSP protection)",
+      "seenOn": {
+        "junos": [
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "Only wanedge2 uses RSVP in this JVD; other PEs rely purely on SR for label distribution",
+        "\"interface all\" enables RSVP on every MPLS-capable interface (simple, broad enablement)",
+        "Combined with the mpls label-switched-path entries, provides RSVP-signaled backup paths",
+        "In mixed SR+RSVP deployments, RSVP LSPs can serve as explicit FRR bypass tunnels"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/mpls-lsp.conf     (the LSPs that RSVP signals)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ospf-sr-lfa.conf  (SR coexists on the same OSPF domain)",
+          "id": null
+        }
+      ],
+      "variables": [],
+      "body": "protocols {\n    rsvp {\n        interface all;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rsvp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface all;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 53,
+      "lineCount": 5,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/bootstrap/chassis-config",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "bootstrap",
+      "name": "chassis-config",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/bootstrap/chassis-config.conf",
+      "topic": "Chassis hardware initialization — aggregated devices and FPC/PIC port speeds",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr",
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "aggregated-devices ethernet device-count reserves LAG interface namespace",
+        "Per-port speed and sub-port breakout configured at PIC level",
+        "dump-on-panic enables core dumps for hardware troubleshooting"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/physical-p2p-mpls.conf  (interfaces bound to these ports)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/lag-lacp.conf           (LAG interfaces using aggregated-devices)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$DEVICE_COUNT",
+          "example": "25"
+        },
+        {
+          "name": "$FPC_SLOT",
+          "example": "0"
+        },
+        {
+          "name": "$PIC_SLOT",
+          "example": "0"
+        },
+        {
+          "name": "$PORT_ID",
+          "example": "0"
+        },
+        {
+          "name": "$PORT_SPEED",
+          "example": "100g"
+        },
+        {
+          "name": "$BREAKOUT_PORT_ID",
+          "example": "2"
+        },
+        {
+          "name": "$BREAKOUT_SPEED",
+          "example": "10g"
+        },
+        {
+          "name": "$BREAKOUT_SUB_PORTS",
+          "example": "4"
+        }
+      ],
+      "body": "chassis {\n    dump-on-panic;\n    aggregated-devices {\n        ethernet {\n            device-count $DEVICE_COUNT;\n        }\n    }\n    fpc $FPC_SLOT {\n        pic $PIC_SLOT {\n            port $PORT_ID {\n                speed $PORT_SPEED;\n            }\n            port $BREAKOUT_PORT_ID {\n                number-of-sub-ports $BREAKOUT_SUB_PORTS;\n                speed $BREAKOUT_SPEED;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">chassis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dump-</span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\">-panic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    aggregated-devices {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            device-count $DEVICE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    fpc $FPC_SLOT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        pic $PIC_SLOT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            port $PORT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                speed $PORT_SPEED;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            port $BREAKOUT_PORT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                number-of-sub-ports $BREAKOUT_SUB_PORTS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                speed $BREAKOUT_SPEED;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 414,
+      "lineCount": 19,
+      "techFamily": "Chassis",
+      "subfamily": "Chassis",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/cos/exp-classifiers-schedulers",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "exp-classifiers-schedulers",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/cos/exp-classifiers-schedulers.conf",
+      "topic": "MPLS EXP-based QoS — classifiers, forwarding classes, schedulers, and rewrite rules",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "4 forwarding classes: FC-LLQ (strict-high, queue 2) for low-latency finance traffic, FC-HIGH (queue 1), CONTROL (queue 3), BEST-EFFORT (queue 0)",
+        "EXP classifier maps 3-bit MPLS EXP values to forwarding classes",
+        "EXP rewrite rule re-marks egress frames to preserve QoS across hops",
+        "scheduler-map applied per-interface with classifier + rewrite on each unit",
+        "FC-LLQ uses strict-high priority for deterministic low-latency forwarding"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/physical-p2p-mpls.conf  (interfaces where CoS is applied)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/mpls-interfaces.conf     (MPLS transport carrying marked traffic)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTERFACE_1",
+          "example": "et-0/0/0"
+        },
+        {
+          "name": "$INTERFACE_2",
+          "example": "et-0/0/1"
+        },
+        {
+          "name": "$INTERFACE_3",
+          "example": "et-0/0/3"
+        },
+        {
+          "name": "$INTERFACE_4",
+          "example": "et-0/0/4"
+        }
+      ],
+      "body": "class-of-service {\n    classifiers {\n        exp EXP {\n            forwarding-class FC-HIGH {\n                loss-priority low code-points 001;\n            }\n            forwarding-class BEST-EFFORT {\n                loss-priority low code-points 000;\n            }\n            forwarding-class FC-LLQ {\n                loss-priority low code-points 010;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points 011;\n            }\n        }\n    }\n    forwarding-classes {\n        class FC-HIGH queue-num 1;\n        class BEST-EFFORT queue-num 0;\n        class CONTROL queue-num 3;\n        class FC-LLQ queue-num 2;\n    }\n    interfaces {\n        $INTERFACE_1 {\n            scheduler-map sched-map;\n            unit 0 {\n                classifiers {\n                    exp EXP;\n                }\n                rewrite-rules {\n                    exp EXP_REWRITE;\n                }\n            }\n        }\n        $INTERFACE_2 {\n            scheduler-map sched-map;\n            unit 0 {\n                classifiers {\n                    exp EXP;\n                }\n                rewrite-rules {\n                    exp EXP_REWRITE;\n                }\n            }\n        }\n    }\n    rewrite-rules {\n        exp EXP_REWRITE {\n            forwarding-class FC-HIGH {\n                loss-priority low code-point 001;\n            }\n            forwarding-class BEST-EFFORT {\n                loss-priority low code-point 000;\n            }\n            forwarding-class FC-LLQ {\n                loss-priority low code-point 010;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-point 011;\n            }\n        }\n    }\n    scheduler-maps {\n        sched-map {\n            forwarding-class BEST-EFFORT scheduler s0;\n            forwarding-class FC-HIGH scheduler s1;\n            forwarding-class FC-LLQ scheduler s2;\n            forwarding-class CONTROL scheduler s3;\n        }\n    }\n    schedulers {\n        s0 {\n            priority low;\n        }\n        s1 {\n            priority low;\n        }\n        s2 {\n            priority strict-high;\n        }\n        s3 {\n            priority low;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        exp EXP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class FC-HIGH queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class CONTROL queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class FC-LLQ queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $INTERFACE_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            scheduler-map sched-map;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP_REWRITE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $INTERFACE_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            scheduler-map sched-map;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP_REWRITE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        exp EXP_REWRITE {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    scheduler-maps {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        sched-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT scheduler s0;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-HIGH scheduler s1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-LLQ scheduler s2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL scheduler s3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s0 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s3 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2194,
+      "lineCount": 86,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/interfaces/flexible-vlan-subinterface",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "flexible-vlan-subinterface",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/flexible-vlan-subinterface.conf",
+      "topic": "Flexible VLAN-tagged subinterfaces with per-unit addressing",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "flexible-vlan-tagging + flexible-ethernet-services enables mixed encapsulation per-unit",
+        "Each unit carries a distinct VLAN-ID and IPv4 /30 or /24 address for PE-CE connectivity",
+        "Used for per-virtual-router PE-CE links on CR devices",
+        "Multiple units (13+) on a single physical interface to scale VPN instances"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/virtual-router-instance.conf  (VR instances bind these subinterfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/oam/twamp-client.conf                  (TWAMP probes use these as source)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTERFACE_NAME",
+          "example": "et-0/0/47"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "CR1_AP1"
+        },
+        {
+          "name": "$UNIT_ID",
+          "example": "1"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "10.101.48.2/30"
+        }
+      ],
+      "body": "interfaces {\n    $INTERFACE_NAME {\n        description \"$DESCRIPTION\";\n        flexible-vlan-tagging;\n        encapsulation flexible-ethernet-services;\n        unit $UNIT_ID {\n            vlan-id $VLAN_ID;\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTERFACE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 302,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/interfaces/lag-lacp",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "lag-lacp",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/lag-lacp.conf",
+      "topic": "LAG with LACP active and vlan-bridge encapsulated units",
+      "seenOn": {
+        "junos": [
+          "(none)"
+        ],
+        "evo": [
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "Aggregated Ethernet with LACP active for link bundling to dual-homed WAN edges",
+        "flexible-vlan-tagging + flexible-ethernet-services for multi-VLAN trunk",
+        "Per-unit vlan-bridge encapsulation ties into vlans{} bridge-domain membership",
+        "MTU 1522 accommodates VLAN tag overhead"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/vlan-bridge-domain.conf       (VLANs referencing ae0 units)",
+          "id": null
+        },
+        {
+          "raw": "evo/bootstrap/chassis-config.conf            (aggregated-devices device-count)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AE_NAME",
+          "example": "ae0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "L2/L3 to WANEDGE1/2"
+        },
+        {
+          "name": "$MTU",
+          "example": "1522"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        }
+      ],
+      "body": "interfaces {\n    $AE_NAME {\n        description \"$DESCRIPTION\";\n        flexible-vlan-tagging;\n        mtu $MTU;\n        encapsulation flexible-ethernet-services;\n        aggregated-ether-options {\n            lacp {\n                active;\n            }\n        }\n        unit $VLAN_ID {\n            encapsulation vlan-bridge;\n            vlan-id $VLAN_ID;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $VLAN_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 375,
+      "lineCount": 17,
+      "techFamily": "Interfaces",
+      "subfamily": "LAG / LACP",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/interfaces/loopback-multi-af",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "loopback-multi-af",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/loopback-multi-af.conf",
+      "topic": "Loopback interface with IPv4, ISO, and IPv6 address families",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004",
+          "cr2_mx480"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr",
+          "cr1_acx7100-48l",
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "Primary/preferred IPv4 used as router-id and BGP local-address",
+        "ISO address required for OSPF/IS-IS CLNS adjacency",
+        "IPv6 primary enables dual-stack management and IPv6 BGP peering",
+        "127.0.0.x addresses used for internal loopback functions"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ibgp-core-mesh.conf  (local-address sourced from lo0)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ospf-te-protection.conf  (lo0 passive interface in area 0)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$ROUTER_ID_ADDRESS",
+          "example": "10.200.50.13/32"
+        },
+        {
+          "name": "$MGMT_LOOPBACK",
+          "example": "10.255.163.148/32"
+        },
+        {
+          "name": "$ISO_ADDRESS",
+          "example": "47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00"
+        },
+        {
+          "name": "$IPV6_ADDRESS",
+          "example": "2001:db8::10:255:163:148/128"
+        }
+      ],
+      "body": "interfaces {\n    lo0 {\n        unit 0 {\n            family inet {\n                address $ROUTER_ID_ADDRESS {\n                    primary;\n                    preferred;\n                }\n                address 127.0.0.1/32;\n                address 127.0.0.64/32;\n                address $MGMT_LOOPBACK {\n                    primary;\n                }\n            }\n            family iso {\n                address $ISO_ADDRESS;\n            }\n            family inet6 {\n                address $IPV6_ADDRESS {\n                    primary;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    lo0 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $ROUTER_ID_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    primary;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    preferred;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address </span><span style=\"color:#79C0FF\">127</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">32</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address </span><span style=\"color:#79C0FF\">127</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">64</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">32</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $MGMT_LOOPBACK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    primary;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family iso {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $ISO_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV6_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    primary;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 590,
+      "lineCount": 25,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/interfaces/physical-p2p-mpls",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "physical-p2p-mpls",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/physical-p2p-mpls.conf",
+      "topic": "Core point-to-point interfaces with inet/ISO/MPLS families",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Multi-protocol family (inet + ISO + MPLS) on every core-facing link",
+        "ISO enables IS-IS/CLNS routing; MPLS enables label switching",
+        "/24 point-to-point addressing convention for inter-router links"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/mpls-interfaces.conf     (MPLS enabled on these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/rsvp-signaling.conf      (RSVP signaling on these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/bootstrap/chassis-config.conf      (port speed defined at chassis level)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTERFACE_NAME",
+          "example": "et-0/0/0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "Link to P1Node to WANEdge1"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "10.101.23.2/24"
+        }
+      ],
+      "body": "interfaces {\n    $INTERFACE_NAME {\n        description \"$DESCRIPTION\";\n        unit 0 {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n            family iso;\n            family mpls;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTERFACE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family iso;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 233,
+      "lineCount": 12,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/interfaces/vlan-bridge-domain",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-domain",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/vlan-bridge-domain.conf",
+      "topic": "Single-tag VLAN bridge-domains with interface membership binding",
+      "seenOn": {
+        "junos": [
+          "(none)"
+        ],
+        "evo": [
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "Each VLAN defined with explicit vlan-id and interface membership",
+        "Interfaces bound to VLANs via their vlan-bridge encapsulated units",
+        "Dual-homed: ae0 (LAG to WAN edges) + et-0/0/47 (local access port)",
+        "Simple L2-only switching — no IRB, no routing, no STP in this config"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/lag-lacp.conf                   (ae0 LAG carrying these VLANs)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/flexible-vlan-bridge.conf       (interface vlan-bridge units)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$VLAN_NAME",
+          "example": "vlan1"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$LAG_UNIT",
+          "example": "ae0.1"
+        },
+        {
+          "name": "$ACCESS_UNIT",
+          "example": "et-0/0/47.1"
+        }
+      ],
+      "body": "vlans {\n    $VLAN_NAME {\n        vlan-id $VLAN_ID;\n        interface $LAG_UNIT;\n        interface $ACCESS_UNIT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VLAN_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $LAG_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $ACCESS_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 119,
+      "lineCount": 7,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/oam/lldp-discovery",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "oam",
+      "name": "lldp-discovery",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/oam/lldp-discovery.conf",
+      "topic": "LLDP protocol enabled on all interfaces for neighbor discovery",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004",
+          "cr2_mx480"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr",
+          "cr1_acx7100-48l",
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "\"interface all\" enables LLDP on every physical port",
+        "Essential for topology discovery and cable verification",
+        "No per-interface filtering or hold-time tuning in this JVD"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "protocols {\n    lldp {\n        interface all;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    lldp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface all;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 53,
+      "lineCount": 5,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/oam/twamp-client",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "oam",
+      "name": "twamp-client",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/oam/twamp-client.conf",
+      "topic": "TWAMP client with per-virtual-router control connections and test sessions",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "TWAMP client (RFC 5357) probes AP reflectors for per-VRF latency/jitter measurement",
+        "One control-connection per VR targeting each AP server (dual-homed: AP1 + AP2)",
+        "routing-instance scoping ensures probes originate from the correct VRF",
+        "probe-count 100 at probe-interval 1s for continuous 100-second measurement cycles",
+        "test-count 0 means infinite test iterations (continuous monitoring)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/virtual-router-instance.conf      (VR instances where probes originate)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/flexible-vlan-subinterface.conf (PE-CE links carrying probes)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CONNECTION_NAME",
+          "example": "CR14_1"
+        },
+        {
+          "name": "$DEST_PORT",
+          "example": "862"
+        },
+        {
+          "name": "$ROUTING_INSTANCE",
+          "example": "VIRTUAL-ROUTER-V1"
+        },
+        {
+          "name": "$TARGET_ADDRESS",
+          "example": "10.101.48.1"
+        },
+        {
+          "name": "$TEST_SESSION_NAME",
+          "example": "T14_1"
+        },
+        {
+          "name": "$PROBE_COUNT",
+          "example": "100"
+        },
+        {
+          "name": "$PROBE_INTERVAL",
+          "example": "1"
+        }
+      ],
+      "body": "services {\n    rpm {\n        twamp {\n            client {\n                control-connection $CONNECTION_NAME {\n                    control-type managed;\n                    destination-port $DEST_PORT;\n                    routing-instance $ROUTING_INSTANCE;\n                    target-address $TARGET_ADDRESS;\n                    test-count 0;\n                    test-session $TEST_SESSION_NAME {\n                        target-address $TARGET_ADDRESS;\n                        probe-count $PROBE_COUNT;\n                        probe-interval $PROBE_INTERVAL;\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">services {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rpm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        twamp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            client {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-connection $CONNECTION_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    control-type managed;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-port $DEST_PORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    routing-instance $ROUTING_INSTANCE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    target-address $TARGET_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    test-count </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    test-session $TEST_SESSION_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        target-address $TARGET_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        probe-count $PROBE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        probe-interval $PROBE_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 632,
+      "lineCount": 20,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/policy/protocol-redistribution",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "protocol-redistribution",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/policy/protocol-redistribution.conf",
+      "topic": "Routing policy statements for BGP/OSPF/direct protocol redistribution",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "PS-ADV_DIRECT: redistributes directly-connected routes into BGP",
+        "PS-BGP-TO-OSPF: leaks BGP-learned routes into OSPF (for CE reachability)",
+        "PS-send-ospf: exports OSPF routes into BGP for VPN distribution",
+        "Simple accept-all policies — no route-filtering or manipulation"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$DIRECT_POLICY_NAME",
+          "example": "PS-ADV_DIRECT"
+        },
+        {
+          "name": "$BGP_TO_OSPF_NAME",
+          "example": "PS-BGP-TO-OSPF"
+        },
+        {
+          "name": "$OSPF_TO_BGP_NAME",
+          "example": "PS-send-ospf"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $DIRECT_POLICY_NAME {\n        from protocol direct;\n        then accept;\n    }\n    policy-statement $BGP_TO_OSPF_NAME {\n        from protocol bgp;\n        then accept;\n    }\n    policy-statement $OSPF_TO_BGP_NAME {\n        from protocol ospf;\n        then accept;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $DIRECT_POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol direct;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $BGP_TO_OSPF_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol bgp;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $OSPF_TO_BGP_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol ospf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 309,
+      "lineCount": 14,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/policy/route-filter-med",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "route-filter-med",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/policy/route-filter-med.conf",
+      "topic": "Route-filter-based MED metric assignment for BGP export",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "PS-med-10: assigns MED 10 to specific infrastructure prefix (preferred path)",
+        "PS-med-30: assigns MED 30 to all other prefixes (less-preferred backup)",
+        "Used as export policy in virtual-router BGP groups to influence AP path selection"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/virtual-router-instance.conf  (BGP group references these as export)",
+          "id": null
+        },
+        {
+          "raw": "evo/policy/protocol-redistribution.conf    (other policies in same policy-options)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$MED_LOW_NAME",
+          "example": "PS-med-10"
+        },
+        {
+          "name": "$MED_LOW_PREFIX",
+          "example": "10.101.0.0/16"
+        },
+        {
+          "name": "$MED_LOW_VALUE",
+          "example": "10"
+        },
+        {
+          "name": "$MED_HIGH_NAME",
+          "example": "PS-med-30"
+        },
+        {
+          "name": "$MED_HIGH_VALUE",
+          "example": "30"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $MED_LOW_NAME {\n        from {\n            route-filter $MED_LOW_PREFIX exact;\n        }\n        then {\n            metric $MED_LOW_VALUE;\n            accept;\n        }\n    }\n    policy-statement $MED_HIGH_NAME {\n        from {\n            route-filter 0.0.0.0/0 longer;\n        }\n        then {\n            metric $MED_HIGH_VALUE;\n            accept;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $MED_LOW_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            route-filter $MED_LOW_PREFIX exact;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            metric $MED_LOW_VALUE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $MED_HIGH_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            route-filter </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> longer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            metric $MED_HIGH_VALUE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 407,
+      "lineCount": 20,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/services/virtual-router-instance",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "virtual-router-instance",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/services/virtual-router-instance.conf",
+      "topic": "Virtual-router instance with BGP, PIM sparse-mode, and multicast RP",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "Body is structurally identical to the Junos sibling",
+        "instance-type virtual-router: full routing table isolation without MPLS VPN signaling",
+        "eBGP group \"AP\" peers to both AP nodes with MED export policy for path preference",
+        "iBGP group \"IXIA\" for traffic-generator peering within the VR",
+        "PIM sparse-mode with static RP pointing to AP node's loopback (multicast receiver side)",
+        "Each VR gets unique multicast group-ranges matching the MVPN sender's PIM RP config"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/interfaces/flexible-vlan-subinterface.conf (PE-CE interfaces bound to VR)",
+          "id": null
+        },
+        {
+          "raw": "evo/oam/twamp-client.conf                     (TWAMP probes originate per-VR)",
+          "id": null
+        },
+        {
+          "raw": "evo/policy/route-filter-med.conf              (MED export policies referenced)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$VR_NAME",
+          "example": "VIRTUAL-ROUTER-V1"
+        },
+        {
+          "name": "$AP_PEER_AS",
+          "example": "64512"
+        },
+        {
+          "name": "$AP_NEIGHBOR_1",
+          "example": "10.101.48.1"
+        },
+        {
+          "name": "$AP_NEIGHBOR_2",
+          "example": "10.101.78.1"
+        },
+        {
+          "name": "$EXPORT_POLICIES",
+          "example": "[ med-10 med-30 ]"
+        },
+        {
+          "name": "$IXIA_PEER_AS",
+          "example": "64521"
+        },
+        {
+          "name": "$IXIA_NEIGHBOR",
+          "example": "10.101.81.2"
+        },
+        {
+          "name": "$RP_ADDRESS",
+          "example": "10.10.47.101"
+        },
+        {
+          "name": "$MCAST_GROUP_RANGE",
+          "example": "225.0.0.0/22"
+        },
+        {
+          "name": "$IFACE_AP1",
+          "example": "et-0/0/47.1"
+        },
+        {
+          "name": "$IFACE_AP2",
+          "example": "et-0/0/48.1"
+        },
+        {
+          "name": "$IFACE_TG",
+          "example": "et-0/0/46.1"
+        }
+      ],
+      "body": "routing-instances {\n    $VR_NAME {\n        instance-type virtual-router;\n        protocols {\n            bgp {\n                group AP {\n                    type external;\n                    export $EXPORT_POLICIES;\n                    peer-as $AP_PEER_AS;\n                    neighbor $AP_NEIGHBOR_1;\n                    neighbor $AP_NEIGHBOR_2;\n                }\n                group IXIA {\n                    type internal;\n                    peer-as $IXIA_PEER_AS;\n                    neighbor $IXIA_NEIGHBOR;\n                }\n            }\n            pim {\n                rp {\n                    static {\n                        address $RP_ADDRESS {\n                            group-ranges {\n                                $MCAST_GROUP_RANGE;\n                            }\n                        }\n                    }\n                }\n                interface $IFACE_AP1 {\n                    mode sparse;\n                }\n                interface $IFACE_AP2 {\n                    mode sparse;\n                }\n                interface $IFACE_TG {\n                    mode sparse;\n                }\n            }\n        }\n        interface $IFACE_TG;\n        interface $IFACE_AP1;\n        interface $IFACE_AP2;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VR_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-router;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group AP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICIES;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $AP_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group IXIA {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $IXIA_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $IXIA_NEIGHBOR;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            pim {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        address $RP_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            group-ranges {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                                $MCAST_GROUP_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_TG {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_TG;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1245,
+      "lineCount": 44,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/transport/ibgp-core-mesh",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "ibgp-core-mesh",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/ibgp-core-mesh.conf",
+      "topic": "iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "family inet-vpn unicast + any for L3VPN route exchange",
+        "family evpn signaling for EVPN Type-1 through Type-5",
+        "family inet-mvpn signaling for NG-MVPN (multicast VPN) control plane",
+        "family route-target enables RT-constrain to limit VPN route distribution",
+        "BFD at 100ms × 3 for sub-second peer failure detection",
+        "All peers in a single iBGP group (full mesh, no route-reflectors)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/mpls-interfaces.conf      (label transport for VPN families)",
+          "id": null
+        },
+        {
+          "raw": "evo/policy/protocol-redistribution.conf (export policies referenced in group)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LOCAL_ADDRESS",
+          "example": "10.200.50.13"
+        },
+        {
+          "name": "$LOCAL_AS",
+          "example": "64512"
+        },
+        {
+          "name": "$EXPORT_POLICY",
+          "example": "[ PS-send-ospf PS-BGP-TO-OSPF ]"
+        },
+        {
+          "name": "$NEIGHBOR_1",
+          "example": "10.200.50.15"
+        },
+        {
+          "name": "$NEIGHBOR_2",
+          "example": "10.200.50.14"
+        },
+        {
+          "name": "$NEIGHBOR_3",
+          "example": "10.200.50.12"
+        },
+        {
+          "name": "$NEIGHBOR_4",
+          "example": "10.200.50.11"
+        },
+        {
+          "name": "$NEIGHBOR_5",
+          "example": "10.200.50.16"
+        }
+      ],
+      "body": "protocols {\n    bgp {\n        group IBGP {\n            type internal;\n            local-address $LOCAL_ADDRESS;\n            family inet {\n                unicast;\n            }\n            family inet-vpn {\n                unicast;\n                any;\n            }\n            family evpn {\n                signaling;\n            }\n            family inet-mvpn {\n                signaling;\n            }\n            family route-target;\n            export $EXPORT_POLICY;\n            local-as $LOCAL_AS;\n            bfd-liveness-detection {\n                minimum-interval 100;\n                multiplier 3;\n            }\n            neighbor $NEIGHBOR_1;\n            neighbor $NEIGHBOR_2;\n            neighbor $NEIGHBOR_3;\n            neighbor $NEIGHBOR_4;\n            neighbor $NEIGHBOR_5;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        group IBGP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-address $LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet-vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                any;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                signaling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet-mvpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                signaling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family route-target;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICY;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-as $LOCAL_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                minimum-interval </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 812,
+      "lineCount": 33,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/transport/mpls-interfaces",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "mpls-interfaces",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/mpls-interfaces.conf",
+      "topic": "MPLS protocol enablement on core and loopback interfaces",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "MPLS enabled on every core-facing interface for label switching",
+        "lo0.0 included to support targeted LDP sessions and LSP origination",
+        "Combined with RSVP-TE for traffic-engineered label-switched paths"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/rsvp-signaling.conf       (RSVP signals LSPs over these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ibgp-core-mesh.conf       (BGP VPN families ride over MPLS)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/physical-p2p-mpls.conf   (family mpls configured on interfaces)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_IFACE_1",
+          "example": "et-0/0/0.0"
+        },
+        {
+          "name": "$CORE_IFACE_2",
+          "example": "et-0/0/3.0"
+        },
+        {
+          "name": "$CORE_IFACE_3",
+          "example": "et-0/0/1.0"
+        },
+        {
+          "name": "$CORE_IFACE_4",
+          "example": "et-0/0/4.0"
+        }
+      ],
+      "body": "protocols {\n    mpls {\n        interface $CORE_IFACE_1;\n        interface $CORE_IFACE_2;\n        interface $CORE_IFACE_3;\n        interface $CORE_IFACE_4;\n        interface lo0.0;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 187,
+      "lineCount": 9,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/transport/ospf-te-protection",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "ospf-te-protection",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/ospf-te-protection.conf",
+      "topic": "OSPF with traffic engineering, node-link-protection, and BFD",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "traffic-engineering enables OSPF-TE extensions (RFC 3630) for RSVP-TE CSPF",
+        "node-link-protection provides LFA backup for sub-50ms failover",
+        "BFD at 10ms × 3 for ultra-fast adjacency failure detection (finance/low-latency)",
+        "lo0.0 as passive ensures router-id reachability without forming adjacency",
+        "All interfaces in area 0.0.0.0 (single-area backbone)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/mpls-interfaces.conf      (MPLS co-exists on same interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/physical-p2p-mpls.conf   (the physical interfaces referenced)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_IFACE_1",
+          "example": "et-0/0/0.0"
+        },
+        {
+          "name": "$CORE_IFACE_2",
+          "example": "et-0/0/3.0"
+        },
+        {
+          "name": "$CORE_IFACE_3",
+          "example": "et-0/0/1.0"
+        },
+        {
+          "name": "$CORE_IFACE_4",
+          "example": "et-0/0/4.0"
+        },
+        {
+          "name": "$BFD_INTERVAL",
+          "example": "10"
+        },
+        {
+          "name": "$BFD_MULTIPLIER",
+          "example": "3"
+        }
+      ],
+      "body": "protocols {\n    ospf {\n        traffic-engineering;\n        area 0.0.0.0 {\n            interface $CORE_IFACE_1 {\n                node-link-protection;\n                bfd-liveness-detection {\n                    minimum-interval $BFD_INTERVAL;\n                    multiplier $BFD_MULTIPLIER;\n                }\n            }\n            interface $CORE_IFACE_2 {\n                node-link-protection;\n                bfd-liveness-detection {\n                    minimum-interval $BFD_INTERVAL;\n                    multiplier $BFD_MULTIPLIER;\n                }\n            }\n            interface $CORE_IFACE_3 {\n                node-link-protection;\n                bfd-liveness-detection {\n                    minimum-interval $BFD_INTERVAL;\n                    multiplier $BFD_MULTIPLIER;\n                }\n            }\n            interface $CORE_IFACE_4 {\n                node-link-protection;\n                bfd-liveness-detection {\n                    minimum-interval $BFD_INTERVAL;\n                    multiplier $BFD_MULTIPLIER;\n                }\n            }\n            interface lo0.0 {\n                passive;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        traffic-engineering;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        area </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_IFACE_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                node-link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval $BFD_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier $BFD_MULTIPLIER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_IFACE_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                node-link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval $BFD_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier $BFD_MULTIPLIER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_IFACE_3 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                node-link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval $BFD_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier $BFD_MULTIPLIER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_IFACE_4 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                node-link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval $BFD_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier $BFD_MULTIPLIER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                passive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1157,
+      "lineCount": 38,
+      "techFamily": "Transport",
+      "subfamily": "OSPF",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/evo/transport/rsvp-signaling",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "transport",
+      "name": "rsvp-signaling",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/rsvp-signaling.conf",
+      "topic": "RSVP-TE interface enablement for label-switched path signaling",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "RSVP enabled on all core transport interfaces and loopback",
+        "Provides RSVP-TE signaling for traffic-engineered LSPs",
+        "Works with OSPF-TE CSPF to compute constrained shortest paths",
+        "lo0.0 included for targeted RSVP sessions (graceful restart, etc.)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/transport/mpls-interfaces.conf      (MPLS forwarding on same interfaces)",
+          "id": null
+        },
+        {
+          "raw": "evo/transport/ospf-te-protection.conf   (OSPF-TE provides path computation)",
+          "id": null
+        },
+        {
+          "raw": "evo/interfaces/physical-p2p-mpls.conf   (physical interfaces referenced)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_IFACE_1",
+          "example": "et-0/0/0.0"
+        },
+        {
+          "name": "$CORE_IFACE_2",
+          "example": "et-0/0/3.0"
+        },
+        {
+          "name": "$CORE_IFACE_3",
+          "example": "et-0/0/1.0"
+        },
+        {
+          "name": "$CORE_IFACE_4",
+          "example": "et-0/0/4.0"
+        }
+      ],
+      "body": "protocols {\n    rsvp {\n        interface lo0.0;\n        interface $CORE_IFACE_1;\n        interface $CORE_IFACE_2;\n        interface $CORE_IFACE_3;\n        interface $CORE_IFACE_4;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rsvp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 187,
+      "lineCount": 9,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/bootstrap/chassis-config",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "bootstrap",
+      "name": "chassis-config",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/bootstrap/chassis-config.conf",
+      "topic": "Chassis hardware initialization — aggregated devices, FPC/PIC port speeds, tunnel-services",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr",
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "aggregated-devices ethernet device-count reserves LAG interface namespace",
+        "tunnel-services bandwidth enables GRE/IP-IP tunnel encapsulation for MVPN",
+        "Per-port speed and sub-port breakout at PIC level",
+        "network-services enhanced-ip required for inet-mvpn and multicast forwarding"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/physical-p2p-mpls.conf  (interfaces bound to these ports)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/lag-esi-lacp.conf       (LAG interfaces using aggregated-devices)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/mvpn-instance.conf        (MVPN uses tunnel-services)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$DEVICE_COUNT",
+          "example": "25"
+        },
+        {
+          "name": "$FPC_SLOT",
+          "example": "0"
+        },
+        {
+          "name": "$PIC_SLOT",
+          "example": "0"
+        },
+        {
+          "name": "$TUNNEL_BW",
+          "example": "10g"
+        },
+        {
+          "name": "$PORT_ID",
+          "example": "0"
+        },
+        {
+          "name": "$PORT_SPEED",
+          "example": "100g"
+        },
+        {
+          "name": "$BREAKOUT_PORT_ID",
+          "example": "9"
+        },
+        {
+          "name": "$BREAKOUT_SPEED",
+          "example": "10g"
+        },
+        {
+          "name": "$BREAKOUT_SUB_PORTS",
+          "example": "4"
+        }
+      ],
+      "body": "chassis {\n    dump-on-panic;\n    aggregated-devices {\n        ethernet {\n            device-count $DEVICE_COUNT;\n        }\n    }\n    fpc $FPC_SLOT {\n        pic $PIC_SLOT {\n            tunnel-services {\n                bandwidth $TUNNEL_BW;\n            }\n            port $PORT_ID {\n                speed $PORT_SPEED;\n            }\n            port $BREAKOUT_PORT_ID {\n                number-of-sub-ports $BREAKOUT_SUB_PORTS;\n                speed $BREAKOUT_SPEED;\n            }\n        }\n    }\n    network-services enhanced-ip;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">chassis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dump-</span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\">-panic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    aggregated-devices {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            device-count $DEVICE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    fpc $FPC_SLOT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        pic $PIC_SLOT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            tunnel-services {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bandwidth $TUNNEL_BW;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            port $PORT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                speed $PORT_SPEED;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            port $BREAKOUT_PORT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                number-of-sub-ports $BREAKOUT_SUB_PORTS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                speed $BREAKOUT_SPEED;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    network-services enhanced-ip;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 530,
+      "lineCount": 23,
+      "techFamily": "Chassis",
+      "subfamily": "Chassis",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/cos/exp-classifiers-schedulers",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "exp-classifiers-schedulers",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/cos/exp-classifiers-schedulers.conf",
+      "topic": "MPLS EXP-based QoS — classifiers, forwarding classes, schedulers, and rewrite rules",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "4 forwarding classes: FC-LLQ (strict-high, queue 2) for low-latency finance traffic, FC-HIGH (queue 1), CONTROL (queue 3), BEST-EFFORT (queue 0)",
+        "EXP classifier maps 3-bit MPLS EXP values to forwarding classes",
+        "EXP rewrite rule re-marks egress frames to preserve QoS across hops",
+        "scheduler-map applied per-interface with classifier + rewrite on each unit",
+        "FC-LLQ uses strict-high priority for deterministic low-latency forwarding"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/physical-p2p-mpls.conf  (interfaces where CoS is applied)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/mpls-lsp-p2mp.conf       (MPLS transport carrying marked traffic)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTERFACE_1",
+          "example": "et-0/0/1"
+        },
+        {
+          "name": "$INTERFACE_2",
+          "example": "et-0/0/3"
+        }
+      ],
+      "body": "class-of-service {\n    classifiers {\n        exp EXP {\n            forwarding-class FC-HIGH {\n                loss-priority low code-points 001;\n            }\n            forwarding-class BEST-EFFORT {\n                loss-priority low code-points 000;\n            }\n            forwarding-class FC-LLQ {\n                loss-priority low code-points 010;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-points 011;\n            }\n        }\n    }\n    forwarding-classes {\n        class FC-HIGH queue-num 1;\n        class BEST-EFFORT queue-num 0;\n        class CONTROL queue-num 3;\n        class FC-LLQ queue-num 2;\n    }\n    interfaces {\n        $INTERFACE_1 {\n            scheduler-map sched-map;\n            unit 0 {\n                classifiers {\n                    exp EXP;\n                }\n                rewrite-rules {\n                    exp EXP_REWRITE;\n                }\n            }\n        }\n        $INTERFACE_2 {\n            scheduler-map sched-map;\n            unit 0 {\n                classifiers {\n                    exp EXP;\n                }\n                rewrite-rules {\n                    exp EXP_REWRITE;\n                }\n            }\n        }\n    }\n    rewrite-rules {\n        exp EXP_REWRITE {\n            forwarding-class FC-HIGH {\n                loss-priority low code-point 001;\n            }\n            forwarding-class BEST-EFFORT {\n                loss-priority low code-point 000;\n            }\n            forwarding-class FC-LLQ {\n                loss-priority low code-point 010;\n            }\n            forwarding-class CONTROL {\n                loss-priority low code-point 011;\n            }\n        }\n    }\n    scheduler-maps {\n        sched-map {\n            forwarding-class BEST-EFFORT scheduler s0;\n            forwarding-class FC-HIGH scheduler s1;\n            forwarding-class FC-LLQ scheduler s2;\n            forwarding-class CONTROL scheduler s3;\n        }\n    }\n    schedulers {\n        s0 {\n            priority low;\n        }\n        s1 {\n            priority low;\n        }\n        s2 {\n            priority strict-high;\n        }\n        s3 {\n            priority low;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        exp EXP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class FC-HIGH queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class CONTROL queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class FC-LLQ queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $INTERFACE_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            scheduler-map sched-map;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP_REWRITE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $INTERFACE_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            scheduler-map sched-map;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    exp EXP_REWRITE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        exp EXP_REWRITE {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                loss-priority low code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    scheduler-maps {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        sched-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT scheduler s0;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-HIGH scheduler s1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class FC-LLQ scheduler s2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL scheduler s3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s0 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        s3 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2194,
+      "lineCount": 86,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/firewall/multicast-fwd-cache-filter",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "multicast-fwd-cache-filter",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/firewall/multicast-fwd-cache-filter.conf",
+      "topic": "Multicast forwarding-cache filters with destination-based CoS marking",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "interface-specific allows per-IRB filter counters and statistics",
+        "mfc-filter: classifies 225.0.0.0/16 multicast to FC-LLQ (strict-high) for stock exchange",
+        "mfc-filter1/2/3: classify unicast VRF traffic into FC-HIGH / BEST-EFFORT / CONTROL",
+        "Applied as input filter on IRB interfaces to mark at L3 ingress before MPLS encap",
+        "Ensures multicast stock-exchange data gets low-latency queue treatment end-to-end"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/irb-l3-gateway.conf      (filter applied on IRB input)",
+          "id": null
+        },
+        {
+          "raw": "junos/cos/exp-classifiers-schedulers.conf  (forwarding classes referenced here)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "mfc-filter"
+        },
+        {
+          "name": "$MCAST_DEST_PREFIX",
+          "example": "225.0.0.0/16"
+        },
+        {
+          "name": "$FORWARDING_CLASS",
+          "example": "FC-LLQ"
+        },
+        {
+          "name": "$UNICAST_DEST_1",
+          "example": "10.8.21.2/32"
+        },
+        {
+          "name": "$UNICAST_DEST_2",
+          "example": "10.9.21.2/32"
+        },
+        {
+          "name": "$UNICAST_FWD_CLASS",
+          "example": "FC-HIGH"
+        }
+      ],
+      "body": "firewall {\n    family inet {\n        filter $FILTER_NAME {\n            interface-specific;\n            term stock_exch {\n                from {\n                    destination-address {\n                        $MCAST_DEST_PREFIX;\n                    }\n                }\n                then {\n                    count c1;\n                    loss-priority low;\n                    forwarding-class $FORWARDING_CLASS;\n                }\n            }\n            term accept-all-else {\n                then accept;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term stock_exch {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-address {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        $MCAST_DEST_PREFIX;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count c1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    loss-priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    forwarding-class $FORWARDING_CLASS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term accept-all-else {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 545,
+      "lineCount": 22,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/interfaces/flexible-vlan-subinterface",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "flexible-vlan-subinterface",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/flexible-vlan-subinterface.conf",
+      "topic": "Flexible VLAN-tagged subinterfaces with per-unit addressing",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "flexible-vlan-tagging + flexible-ethernet-services enables mixed encapsulation per-unit",
+        "Each unit carries a distinct VLAN-ID and IPv4 /30 or /24 address for PE-CE connectivity",
+        "Used for per-VRF / per-virtual-router PE-CE links on CR devices",
+        "Multiple units (13+) on a single physical interface to scale VPN instances"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/virtual-router-instance.conf  (VR instances bind these subinterfaces)",
+          "id": null
+        },
+        {
+          "raw": "junos/oam/twamp-client.conf                  (TWAMP probes use these as source)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTERFACE_NAME",
+          "example": "et-5/0/0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "CR2_AP1"
+        },
+        {
+          "name": "$UNIT_ID",
+          "example": "1"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "10.101.49.2/30"
+        }
+      ],
+      "body": "interfaces {\n    $INTERFACE_NAME {\n        description \"$DESCRIPTION\";\n        flexible-vlan-tagging;\n        encapsulation flexible-ethernet-services;\n        unit $UNIT_ID {\n            vlan-id $VLAN_ID;\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTERFACE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 302,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/interfaces/irb-l3-gateway",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "irb-l3-gateway",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/irb-l3-gateway.conf",
+      "topic": "IRB L3 gateway with multicast forwarding-cache filter and static MAC",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "IRB provides L3 gateway for EVPN bridge-domains (routed multicast ingress)",
+        "Input filter (mfc-filter) classifies multicast traffic into QoS forwarding classes",
+        "Static MAC per unit ensures deterministic gateway MAC across EVPN active/standby",
+        "One IRB unit per MVPN instance / EVPN bridge-domain"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/evpn-virtual-switch-esi.conf  (bridge-domain routing-interface irb.N)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/mvpn-instance.conf            (MVPN instance binds interface irb.N)",
+          "id": null
+        },
+        {
+          "raw": "junos/firewall/multicast-fwd-cache-filter.conf (mfc-filter applied here)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$UNIT_ID",
+          "example": "1"
+        },
+        {
+          "name": "$FILTER_NAME",
+          "example": "mfc-filter"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "172.16.1.1/24"
+        },
+        {
+          "name": "$STATIC_MAC",
+          "example": "00:10:94:00:00:01"
+        }
+      ],
+      "body": "interfaces {\n    irb {\n        unit $UNIT_ID {\n            family inet {\n                filter {\n                    input $FILTER_NAME;\n                }\n                address $IPV4_ADDRESS;\n            }\n            mac $STATIC_MAC;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    irb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    input $FILTER_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            mac $STATIC_MAC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 255,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/interfaces/lag-esi-lacp",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "lag-esi-lacp",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/lag-esi-lacp.conf",
+      "topic": "ESI-based LAG with LACP, single-active DF election, and vlan-bridge units",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "Interface-level ESI with single-active redundancy for EVPN multihoming",
+        "df-election-granularity per-esi with lacp-oos-on-ndf takes non-DF link out-of-service",
+        "Per-unit ESI allows per-VLAN designated-forwarder assignment",
+        "LACP system-priority + system-id must match across ESI peers (wanedge1 + wanedge2)",
+        "vlan-bridge encapsulation on each unit ties into EVPN virtual-switch instances"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/evpn-virtual-switch-esi.conf  (EVPN instances reference ae0 units)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/irb-l3-gateway.conf         (IRB interfaces for L3 gateway)",
+          "id": null
+        },
+        {
+          "raw": "junos/bootstrap/chassis-config.conf          (aggregated-devices device-count)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AE_NAME",
+          "example": "ae0"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "Link to WANEdge1 to L2/L3Edge AE"
+        },
+        {
+          "name": "$MTU",
+          "example": "1522"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:11:11:11:11:11:12:12:12:12"
+        },
+        {
+          "name": "$DF_PREFERENCE",
+          "example": "150"
+        },
+        {
+          "name": "$LACP_PRIORITY",
+          "example": "100"
+        },
+        {
+          "name": "$LACP_SYSTEM_ID",
+          "example": "00:00:00:00:00:10"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$UNIT_ESI",
+          "example": "00:01:71:81:11:12:a1:00:00:01"
+        },
+        {
+          "name": "$UNIT_DF_PREFERENCE",
+          "example": "150"
+        }
+      ],
+      "body": "interfaces {\n    $AE_NAME {\n        description \"$DESCRIPTION\";\n        flexible-vlan-tagging;\n        mtu $MTU;\n        encapsulation flexible-ethernet-services;\n        esi {\n            $ESI_ID;\n            single-active;\n            df-election-granularity {\n                per-esi {\n                    lacp-oos-on-ndf;\n                }\n            }\n            df-election-type {\n                preference {\n                    value $DF_PREFERENCE;\n                }\n            }\n        }\n        aggregated-ether-options {\n            lacp {\n                active;\n                system-priority $LACP_PRIORITY;\n                system-id $LACP_SYSTEM_ID;\n            }\n        }\n        unit $VLAN_ID {\n            encapsulation vlan-bridge;\n            vlan-id $VLAN_ID;\n            esi {\n                $UNIT_ESI;\n                single-active;\n                df-election-type {\n                    preference {\n                        value $UNIT_DF_PREFERENCE;\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            single-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            df-election-granularity {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                per-esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lacp-oos-</span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\">-ndf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            df-election-type {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                preference {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    value $DF_PREFERENCE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                system-priority $LACP_PRIORITY;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                system-id $LACP_SYSTEM_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $VLAN_ID {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                $UNIT_ESI;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                single-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                df-election-type {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    preference {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        value $UNIT_DF_PREFERENCE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1054,
+      "lineCount": 42,
+      "techFamily": "Interfaces",
+      "subfamily": "LAG / LACP",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/interfaces/loopback-multi-af",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "loopback-multi-af",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/loopback-multi-af.conf",
+      "topic": "Loopback interface with IPv4, ISO, and IPv6 address families",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004",
+          "cr2_mx480"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr",
+          "cr1_acx7100-48l",
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "Primary/preferred IPv4 used as router-id and BGP local-address",
+        "ISO address required for OSPF/IS-IS CLNS adjacency",
+        "IPv6 primary enables dual-stack management and IPv6 BGP peering",
+        "127.0.0.x addresses used for internal loopback functions"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ibgp-core-mesh.conf       (local-address sourced from lo0)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ospf-te-protection.conf   (lo0 passive interface in area 0)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$ROUTER_ID_ADDRESS",
+          "example": "10.200.50.13/32"
+        },
+        {
+          "name": "$MGMT_LOOPBACK",
+          "example": "10.255.163.148/32"
+        },
+        {
+          "name": "$ISO_ADDRESS",
+          "example": "47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00"
+        },
+        {
+          "name": "$IPV6_ADDRESS",
+          "example": "2001:db8::10:255:163:148/128"
+        }
+      ],
+      "body": "interfaces {\n    lo0 {\n        unit 0 {\n            family inet {\n                address $ROUTER_ID_ADDRESS {\n                    primary;\n                    preferred;\n                }\n                address 127.0.0.1/32;\n                address 127.0.0.64/32;\n                address $MGMT_LOOPBACK {\n                    primary;\n                }\n            }\n            family iso {\n                address $ISO_ADDRESS;\n            }\n            family inet6 {\n                address $IPV6_ADDRESS {\n                    primary;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    lo0 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $ROUTER_ID_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    primary;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    preferred;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address </span><span style=\"color:#79C0FF\">127</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">32</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address </span><span style=\"color:#79C0FF\">127</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">64</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">32</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $MGMT_LOOPBACK {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    primary;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family iso {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $ISO_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV6_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    primary;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 590,
+      "lineCount": 25,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/interfaces/physical-p2p-mpls",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "physical-p2p-mpls",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/physical-p2p-mpls.conf",
+      "topic": "Core point-to-point interfaces with inet/ISO/MPLS families",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "Multi-protocol family (inet + ISO + MPLS) on every core-facing link",
+        "ISO enables IS-IS/CLNS routing; MPLS enables label switching",
+        "/24 point-to-point addressing convention for inter-router links"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/mpls-lsp-p2mp.conf       (MPLS LSPs traverse these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/rsvp-signaling.conf      (RSVP signaling on these interfaces)",
+          "id": null
+        },
+        {
+          "raw": "junos/bootstrap/chassis-config.conf      (port speed defined at chassis level)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INTERFACE_NAME",
+          "example": "et-0/0/1"
+        },
+        {
+          "name": "$DESCRIPTION",
+          "example": "Link to WANEdge1 to WANEdge2"
+        },
+        {
+          "name": "$IPV4_ADDRESS",
+          "example": "10.101.25.1/24"
+        }
+      ],
+      "body": "interfaces {\n    $INTERFACE_NAME {\n        description \"$DESCRIPTION\";\n        unit 0 {\n            family inet {\n                address $IPV4_ADDRESS;\n            }\n            family iso;\n            family mpls;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INTERFACE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        description \"$DESCRIPTION\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                address $IPV4_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family iso;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 233,
+      "lineCount": 12,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/multicast/forwarding-multicast-tuning",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "multicast",
+      "name": "forwarding-multicast-tuning",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/multicast/forwarding-multicast-tuning.conf",
+      "topic": "Multicast forwarding-options tuning — resolve-rate and mismatch-rate",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "resolve-rate 1000 pps: max rate for resolving new multicast (S,G) entries in the PFE",
+        "mismatch-rate 1000 pps: max rate for handling RPF mismatch packets to RE",
+        "Critical for finance/stock-exchange multicast to prevent PFE drops during burst joins",
+        "Default values (~100 pps) are insufficient for high-frequency multicast environments"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/mvpn-instance.conf              (MVPN drives multicast state creation)",
+          "id": null
+        },
+        {
+          "raw": "junos/firewall/multicast-fwd-cache-filter.conf (CoS marking for multicast traffic)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$RESOLVE_RATE",
+          "example": "1000"
+        },
+        {
+          "name": "$MISMATCH_RATE",
+          "example": "1000"
+        }
+      ],
+      "body": "forwarding-options {\n    multicast {\n        resolve-rate $RESOLVE_RATE;\n        mismatch-rate $MISMATCH_RATE;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">forwarding-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    multicast {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        resolve-rate $RESOLVE_RATE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        mismatch-rate $MISMATCH_RATE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 118,
+      "lineCount": 6,
+      "techFamily": "Other",
+      "subfamily": "Multicast",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/oam/lldp-discovery",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "oam",
+      "name": "lldp-discovery",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/oam/lldp-discovery.conf",
+      "topic": "LLDP protocol enabled on all interfaces for neighbor discovery",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004",
+          "cr2_mx480"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr",
+          "cr1_acx7100-48l",
+          "l2-l3_edge_acx7100"
+        ]
+      },
+      "highlights": [
+        "\"interface all\" enables LLDP on every physical port",
+        "Essential for topology discovery and cable verification",
+        "No per-interface filtering or hold-time tuning in this JVD"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "protocols {\n    lldp {\n        interface all;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    lldp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface all;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 53,
+      "lineCount": 5,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/oam/twamp-client",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "oam",
+      "name": "twamp-client",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/oam/twamp-client.conf",
+      "topic": "TWAMP client with per-virtual-router control connections and test sessions",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "TWAMP client (RFC 5357) probes AP reflectors for per-VRF latency/jitter measurement",
+        "One control-connection per VR targeting each AP server (dual-homed: AP1 + AP2)",
+        "routing-instance scoping ensures probes originate from the correct VRF",
+        "probe-count 100 at probe-interval 1s for continuous 100-second measurement cycles",
+        "test-count 0 means infinite test iterations (continuous monitoring)",
+        "destination-port per connection matches server routing-instance-list port mapping"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/oam/twamp-server.conf                    (AP nodes run the reflector)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/virtual-router-instance.conf    (VR instances where probes originate)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/flexible-vlan-subinterface.conf (PE-CE links carrying probes)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CONNECTION_NAME",
+          "example": "CR24_1"
+        },
+        {
+          "name": "$DEST_PORT",
+          "example": "862"
+        },
+        {
+          "name": "$ROUTING_INSTANCE",
+          "example": "VIRTUAL-ROUTER-V1"
+        },
+        {
+          "name": "$TARGET_ADDRESS",
+          "example": "10.101.49.1"
+        },
+        {
+          "name": "$TEST_SESSION_NAME",
+          "example": "T24_1"
+        },
+        {
+          "name": "$PROBE_COUNT",
+          "example": "100"
+        },
+        {
+          "name": "$PROBE_INTERVAL",
+          "example": "1"
+        }
+      ],
+      "body": "services {\n    rpm {\n        twamp {\n            client {\n                control-connection $CONNECTION_NAME {\n                    control-type managed;\n                    destination-port $DEST_PORT;\n                    routing-instance $ROUTING_INSTANCE;\n                    target-address $TARGET_ADDRESS;\n                    test-count 0;\n                    test-session $TEST_SESSION_NAME {\n                        target-address $TARGET_ADDRESS;\n                        probe-count $PROBE_COUNT;\n                        probe-interval $PROBE_INTERVAL;\n                    }\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">services {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rpm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        twamp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            client {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-connection $CONNECTION_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    control-type managed;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-port $DEST_PORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    routing-instance $ROUTING_INSTANCE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    target-address $TARGET_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    test-count </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    test-session $TEST_SESSION_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        target-address $TARGET_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        probe-count $PROBE_COUNT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        probe-interval $PROBE_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 632,
+      "lineCount": 20,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/oam/twamp-server",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "oam",
+      "name": "twamp-server",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/oam/twamp-server.conf",
+      "topic": "TWAMP server with per-VRF port mappings and client authentication lists",
+      "seenOn": {
+        "junos": [
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "TWAMP server (RFC 5357) provides reflector endpoints for latency/jitter measurement",
+        "routing-instance-list maps each MVPN/VRF to a unique port (862 + 49152-49163)",
+        "Per-client address lists (CR1_N, CR2_N) restrict which probers can connect",
+        "authentication-mode none for minimal overhead in controlled lab/DC environment",
+        "\"light\" mode enables lightweight TWAMP-Light without full control session",
+        "Port 1862 as global server port for non-VRF probes"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/oam/twamp-client.conf         (CR nodes probe this server)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/mvpn-instance.conf   (VRF instances whose latency is monitored)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$VRF_NAME_1",
+          "example": "MVPN_INSTANCE1"
+        },
+        {
+          "name": "$VRF_PORT_1",
+          "example": "862"
+        },
+        {
+          "name": "$VRF_NAME_2",
+          "example": "MVPN_INSTANCE2"
+        },
+        {
+          "name": "$VRF_PORT_2",
+          "example": "49152"
+        },
+        {
+          "name": "$GLOBAL_PORT",
+          "example": "1862"
+        },
+        {
+          "name": "$CLIENT_LIST_NAME",
+          "example": "CR1_1"
+        },
+        {
+          "name": "$CLIENT_ADDRESS",
+          "example": "10.101.48.2/32"
+        }
+      ],
+      "body": "services {\n    rpm {\n        twamp {\n            server {\n                routing-instance-list {\n                    $VRF_NAME_1 {\n                        port $VRF_PORT_1;\n                    }\n                    $VRF_NAME_2 {\n                        port $VRF_PORT_2;\n                    }\n                }\n                authentication-mode none;\n                port $GLOBAL_PORT;\n                client-list $CLIENT_LIST_NAME {\n                    address {\n                        $CLIENT_ADDRESS;\n                    }\n                }\n                light;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">services {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rpm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        twamp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            server {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                routing-instance-list {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    $VRF_NAME_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        port $VRF_PORT_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    $VRF_NAME_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        port $VRF_PORT_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                authentication-mode none;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                port $GLOBAL_PORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                client-list $CLIENT_LIST_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    address {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        $CLIENT_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                light;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 602,
+      "lineCount": 24,
+      "techFamily": "OAM",
+      "subfamily": "Oam",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/policy/protocol-redistribution",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "policy",
+      "name": "protocol-redistribution",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/policy/protocol-redistribution.conf",
+      "topic": "Routing policy statements for BGP/OSPF/direct protocol redistribution",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "PS-ADV_DIRECT: redistributes directly-connected routes into BGP",
+        "PS-BGP-TO-OSPF: leaks BGP-learned routes into OSPF (for CE reachability)",
+        "PS-send-ospf: exports OSPF routes into BGP for VPN distribution",
+        "Simple accept-all policies — no route-filtering or manipulation"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$DIRECT_POLICY_NAME",
+          "example": "PS-ADV_DIRECT"
+        },
+        {
+          "name": "$BGP_TO_OSPF_NAME",
+          "example": "PS-BGP-TO-OSPF"
+        },
+        {
+          "name": "$OSPF_TO_BGP_NAME",
+          "example": "PS-send-ospf"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $DIRECT_POLICY_NAME {\n        from protocol direct;\n        then accept;\n    }\n    policy-statement $BGP_TO_OSPF_NAME {\n        from protocol bgp;\n        then accept;\n    }\n    policy-statement $OSPF_TO_BGP_NAME {\n        from protocol ospf;\n        then accept;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $DIRECT_POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol direct;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $BGP_TO_OSPF_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol bgp;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $OSPF_TO_BGP_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> protocol ospf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 309,
+      "lineCount": 14,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/policy/route-filter-med",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "policy",
+      "name": "route-filter-med",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/policy/route-filter-med.conf",
+      "topic": "Route-filter-based MED metric assignment for BGP export",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "PS-med-10: assigns MED 10 to specific infrastructure prefix (preferred path)",
+        "PS-med-30: assigns MED 30 to all other prefixes (less-preferred backup)",
+        "Used as export policy in virtual-router BGP groups to influence AP path selection",
+        "route-filter with \"exact\" match for precise prefix control"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/virtual-router-instance.conf  (BGP group references these as export)",
+          "id": null
+        },
+        {
+          "raw": "junos/policy/protocol-redistribution.conf    (other policies in same policy-options)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$MED_LOW_NAME",
+          "example": "PS-med-10"
+        },
+        {
+          "name": "$MED_LOW_PREFIX",
+          "example": "10.101.0.0/16"
+        },
+        {
+          "name": "$MED_LOW_VALUE",
+          "example": "10"
+        },
+        {
+          "name": "$MED_HIGH_NAME",
+          "example": "PS-med-30"
+        },
+        {
+          "name": "$MED_HIGH_VALUE",
+          "example": "30"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $MED_LOW_NAME {\n        from {\n            route-filter $MED_LOW_PREFIX exact;\n        }\n        then {\n            metric $MED_LOW_VALUE;\n            accept;\n        }\n    }\n    policy-statement $MED_HIGH_NAME {\n        from {\n            route-filter 0.0.0.0/0 longer;\n        }\n        then {\n            metric $MED_HIGH_VALUE;\n            accept;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $MED_LOW_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            route-filter $MED_LOW_PREFIX exact;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            metric $MED_LOW_VALUE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $MED_HIGH_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">        from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            route-filter </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> longer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            metric $MED_HIGH_VALUE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 407,
+      "lineCount": 20,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/services/evpn-virtual-switch-esi",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-virtual-switch-esi",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/services/evpn-virtual-switch-esi.conf",
+      "topic": "EVPN virtual-switch instance with MPLS encapsulation and bridge-domain",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "instance-type virtual-switch: provides per-tenant MAC/VLAN isolation",
+        "EVPN with MPLS encapsulation for Type-2 MAC/IP and Type-3 IM route exchange",
+        "default-gateway do-not-advertise: suppresses gateway MAC advertisement (anycast not used)",
+        "no-control-word: omits 4-byte control word for compatibility with older MPLS nodes",
+        "bridge-domain binds ESI LAG unit + IRB routing-interface for integrated routing/bridging",
+        "One virtual-switch instance per VLAN/service (EVPN_ESI_LAG1 through LAG23)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/lag-esi-lacp.conf     (ae0 units referenced in bridge-domains)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/irb-l3-gateway.conf   (IRB routing-interface for L3 gateway)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/mvpn-instance.conf      (MVPN uses same IRB for multicast ingress)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "EVPN_ESI_LAG1"
+        },
+        {
+          "name": "$BD_NAME",
+          "example": "BD_EVPN_GROUP1"
+        },
+        {
+          "name": "$VLAN_ID",
+          "example": "1"
+        },
+        {
+          "name": "$AE_UNIT",
+          "example": "ae0.1"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.1"
+        },
+        {
+          "name": "$ROUTE_DISTINGUISHER",
+          "example": "10.200.50.12:1"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "target:61535:1"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type virtual-switch;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n                no-control-word;\n            }\n        }\n        bridge-domains {\n            $BD_NAME {\n                vlan-id $VLAN_ID;\n                interface $AE_UNIT;\n                routing-interface $IRB_UNIT;\n            }\n        }\n        route-distinguisher $ROUTE_DISTINGUISHER;\n        vrf-target $VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-switch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        bridge-domains {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $BD_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AE_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                routing-interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $ROUTE_DISTINGUISHER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 537,
+      "lineCount": 21,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/services/mvpn-instance",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "mvpn-instance",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/services/mvpn-instance.conf",
+      "topic": "NG-MVPN VRF instance with PIM, OSPF, BGP, and RSVP-TE provider-tunnel",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "instance-type vrf with mvpn protocol for NG-MVPN (RFC 6513/6514)",
+        "mvpn-mode spt-only: shortest-path-tree only (no shared-tree), optimal for finance",
+        "hot-root-standby with source-tree: pre-builds backup multicast tree for fast failover",
+        "min-rate 3m + revert-delay 5: traffic threshold and holdoff for standby activation",
+        "sender-based-rpf: validates multicast source via BGP MVPN routes (not RPF on IGP)",
+        "PIM local RP with per-instance multicast group-ranges (225.0.x.0/22 per VRF)",
+        "provider-tunnel rsvp-te with default-template: uses P2MP LSP for multicast transport",
+        "Per-VRF OSPF for CE route distribution + BGP eBGP for traffic-generator peering"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/mpls-lsp-p2mp.conf               (P2MP template referenced)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/irb-l3-gateway.conf             (IRB interface bound to this VRF)",
+          "id": null
+        },
+        {
+          "raw": "junos/multicast/forwarding-multicast-tuning.conf (multicast PFE rate-limiting)",
+          "id": null
+        },
+        {
+          "raw": "junos/firewall/multicast-fwd-cache-filter.conf   (CoS marking on multicast ingress)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MVPN_INSTANCE1"
+        },
+        {
+          "name": "$CE_LOCAL_ADDRESS",
+          "example": "172.16.1.1"
+        },
+        {
+          "name": "$CE_NEIGHBOR",
+          "example": "172.16.1.2"
+        },
+        {
+          "name": "$CE_PEER_AS",
+          "example": "64513"
+        },
+        {
+          "name": "$MVPN_RT_IMPORT",
+          "example": "target:64512:101"
+        },
+        {
+          "name": "$MVPN_RT_EXPORT",
+          "example": "target:64512:101"
+        },
+        {
+          "name": "$RP_ADDRESS",
+          "example": "10.10.47.101"
+        },
+        {
+          "name": "$MCAST_GROUP_RANGE",
+          "example": "225.0.0.0/22"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.1"
+        },
+        {
+          "name": "$LO_UNIT",
+          "example": "lo0.1"
+        },
+        {
+          "name": "$ROUTE_DISTINGUISHER",
+          "example": "10.200.50.12:61"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "target:64512:11"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type vrf;\n        protocols {\n            bgp {\n                group custA_TGN {\n                    type external;\n                    local-address $CE_LOCAL_ADDRESS;\n                    export PS-ADV_DIRECT;\n                    neighbor $CE_NEIGHBOR {\n                        peer-as $CE_PEER_AS;\n                    }\n                }\n            }\n            mvpn {\n                sender-site;\n                mvpn-mode {\n                    spt-only;\n                }\n                route-target {\n                    import-target {\n                        target $MVPN_RT_IMPORT;\n                    }\n                    export-target {\n                        target $MVPN_RT_EXPORT;\n                    }\n                }\n                sender-based-rpf;\n                hot-root-standby {\n                    source-tree;\n                    min-rate {\n                        rate 3m;\n                        revert-delay 5;\n                    }\n                }\n            }\n            ospf {\n                area 0.0.0.0 {\n                    interface $LO_UNIT;\n                }\n                export PS-send-ospf;\n            }\n            pim {\n                join-prune-timeout 420;\n                rp {\n                    local {\n                        address $RP_ADDRESS;\n                        group-ranges {\n                            $MCAST_GROUP_RANGE;\n                        }\n                    }\n                }\n                interface $IRB_UNIT;\n                interface $LO_UNIT;\n            }\n        }\n        interface $IRB_UNIT;\n        interface $LO_UNIT;\n        route-distinguisher $ROUTE_DISTINGUISHER;\n        vrf-target $VRF_TARGET;\n        vrf-table-label;\n        provider-tunnel {\n            rsvp-te {\n                label-switched-path-template {\n                    default-template;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group custA_TGN {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    local-address $CE_LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> PS-ADV_DIRECT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $CE_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        peer-as $CE_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            mvpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                sender-site;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                mvpn-mode {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    spt-only;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                route-target {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    import-target {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        target $MVPN_RT_IMPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\">-target {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        target $MVPN_RT_EXPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                sender-based-rpf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hot-root-standby {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    source-tree;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    min-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        rate 3m;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        revert-delay </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                area </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $LO_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                export</span><span style=\"color:#E6EDF3\"> PS-send-ospf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            pim {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                join-prune-timeout </span><span style=\"color:#79C0FF\">420</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    local {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        address $RP_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        group-ranges {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            $MCAST_GROUP_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $LO_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $LO_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $ROUTE_DISTINGUISHER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        provider-tunnel {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            rsvp-te {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                label-switched-path-template {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    default-template;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1965,
+      "lineCount": 70,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/services/virtual-router-instance",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "virtual-router-instance",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/services/virtual-router-instance.conf",
+      "topic": "Virtual-router instance with BGP, PIM sparse-mode, and multicast RP",
+      "seenOn": {
+        "junos": [
+          "cr2_mx480"
+        ],
+        "evo": [
+          "cr1_acx7100-48l"
+        ]
+      },
+      "highlights": [
+        "instance-type virtual-router: full routing table isolation without MPLS VPN signaling",
+        "eBGP group \"AP\" peers to both AP nodes with MED export policy for path preference",
+        "iBGP group \"IXIA\" for traffic-generator peering within the VR",
+        "PIM sparse-mode with static RP pointing to AP node's loopback (multicast receiver side)",
+        "Each VR gets unique multicast group-ranges matching the MVPN sender's PIM RP config",
+        "VRFs V21/V22/V23 omit PIM (unicast-only traffic classes)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/flexible-vlan-subinterface.conf (PE-CE interfaces bound to VR)",
+          "id": null
+        },
+        {
+          "raw": "junos/oam/twamp-client.conf                     (TWAMP probes originate per-VR)",
+          "id": null
+        },
+        {
+          "raw": "junos/policy/route-filter-med.conf              (MED export policies referenced)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$VR_NAME",
+          "example": "VIRTUAL-ROUTER-V1"
+        },
+        {
+          "name": "$AP_PEER_AS",
+          "example": "64512"
+        },
+        {
+          "name": "$AP_NEIGHBOR_1",
+          "example": "10.101.49.1"
+        },
+        {
+          "name": "$AP_NEIGHBOR_2",
+          "example": "10.101.79.1"
+        },
+        {
+          "name": "$EXPORT_POLICIES",
+          "example": "[ med-10 med-30 ]"
+        },
+        {
+          "name": "$IXIA_PEER_AS",
+          "example": "64521"
+        },
+        {
+          "name": "$IXIA_NEIGHBOR",
+          "example": "10.101.91.2"
+        },
+        {
+          "name": "$RP_ADDRESS",
+          "example": "10.10.47.101"
+        },
+        {
+          "name": "$MCAST_GROUP_RANGE",
+          "example": "225.0.0.0/22"
+        },
+        {
+          "name": "$IFACE_AP1",
+          "example": "et-5/0/0.1"
+        },
+        {
+          "name": "$IFACE_AP2",
+          "example": "et-5/0/1.1"
+        },
+        {
+          "name": "$IFACE_TG",
+          "example": "xe-3/0/6.1"
+        }
+      ],
+      "body": "routing-instances {\n    $VR_NAME {\n        instance-type virtual-router;\n        protocols {\n            bgp {\n                group AP {\n                    type external;\n                    export $EXPORT_POLICIES;\n                    peer-as $AP_PEER_AS;\n                    neighbor $AP_NEIGHBOR_1;\n                    neighbor $AP_NEIGHBOR_2;\n                }\n                group IXIA {\n                    type internal;\n                    peer-as $IXIA_PEER_AS;\n                    neighbor $IXIA_NEIGHBOR;\n                }\n            }\n            pim {\n                rp {\n                    static {\n                        address $RP_ADDRESS {\n                            group-ranges {\n                                $MCAST_GROUP_RANGE;\n                            }\n                        }\n                    }\n                }\n                interface $IFACE_AP1 {\n                    mode sparse;\n                }\n                interface $IFACE_AP2 {\n                    mode sparse;\n                }\n                interface $IFACE_TG {\n                    mode sparse;\n                }\n            }\n        }\n        interface $IFACE_TG;\n        interface $IFACE_AP1;\n        interface $IFACE_AP2;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VR_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-router;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group AP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICIES;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $AP_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group IXIA {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $IXIA_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $IXIA_NEIGHBOR;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            pim {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        address $RP_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            group-ranges {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                                $MCAST_GROUP_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_TG {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_TG;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1245,
+      "lineCount": 44,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/services/vrf-l3vpn",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "vrf-l3vpn",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/services/vrf-l3vpn.conf",
+      "topic": "L3VPN VRF instance with external BGP peer (traffic-generator / CE device)",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "instance-type vrf for L3VPN isolation (non-multicast VRFs: VRF21/22/23)",
+        "eBGP peering to traffic-generator or CE device in each VRF",
+        "vrf-table-label enables per-VRF MPLS label for penultimate-hop popping",
+        "route-distinguisher unique per-PE per-VRF for BGP path distinction",
+        "vrf-target with shared RT allows route import/export between PE nodes",
+        "IRB interface provides the VRF's L3 gateway"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/irb-l3-gateway.conf             (IRB bound to this VRF)",
+          "id": null
+        },
+        {
+          "raw": "junos/firewall/multicast-fwd-cache-filter.conf   (filter on IRB for these VRFs)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ibgp-core-mesh.conf              (inet-vpn family carries VRF routes)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$VRF_NAME",
+          "example": "VRF21"
+        },
+        {
+          "name": "$LOCAL_ADDRESS",
+          "example": "172.16.21.1"
+        },
+        {
+          "name": "$EXPORT_POLICY",
+          "example": "PS-ADV_DIRECT"
+        },
+        {
+          "name": "$CE_NEIGHBOR",
+          "example": "172.16.21.2"
+        },
+        {
+          "name": "$CE_PEER_AS",
+          "example": "64513"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "irb.21"
+        },
+        {
+          "name": "$ROUTE_DISTINGUISHER",
+          "example": "10.200.50.12:221"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "target:64512:21"
+        }
+      ],
+      "body": "routing-instances {\n    $VRF_NAME {\n        instance-type vrf;\n        protocols {\n            bgp {\n                group TGN_AF {\n                    type external;\n                    local-address $LOCAL_ADDRESS;\n                    export $EXPORT_POLICY;\n                    neighbor $CE_NEIGHBOR {\n                        peer-as $CE_PEER_AS;\n                    }\n                }\n            }\n        }\n        interface $IRB_UNIT;\n        route-distinguisher $ROUTE_DISTINGUISHER;\n        vrf-target $VRF_TARGET;\n        vrf-table-label;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VRF_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group TGN_AF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    local-address $LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICY;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $CE_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        peer-as $CE_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $ROUTE_DISTINGUISHER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 556,
+      "lineCount": 21,
+      "techFamily": "Service Overlay",
+      "subfamily": "L3VPN",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/transport/ibgp-core-mesh",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "ibgp-core-mesh",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/transport/ibgp-core-mesh.conf",
+      "topic": "iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "family inet-vpn unicast + any for L3VPN route exchange",
+        "family evpn signaling for EVPN Type-1 through Type-5",
+        "family inet-mvpn signaling for NG-MVPN (multicast VPN) control plane",
+        "family route-target enables RT-constrain to limit VPN route distribution",
+        "BFD at 100ms × 3 for sub-second peer failure detection",
+        "All peers in a single iBGP group (full mesh, no route-reflectors)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/mpls-lsp-p2mp.conf        (label transport for VPN families)",
+          "id": null
+        },
+        {
+          "raw": "junos/policy/protocol-redistribution.conf (export policies referenced in group)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$LOCAL_ADDRESS",
+          "example": "10.200.50.12"
+        },
+        {
+          "name": "$LOCAL_AS",
+          "example": "64512"
+        },
+        {
+          "name": "$EXPORT_POLICY",
+          "example": "[ PS-send-ospf PS-BGP-TO-OSPF ]"
+        },
+        {
+          "name": "$NEIGHBOR_1",
+          "example": "10.200.50.13"
+        },
+        {
+          "name": "$NEIGHBOR_2",
+          "example": "10.200.50.14"
+        },
+        {
+          "name": "$NEIGHBOR_3",
+          "example": "10.200.50.15"
+        },
+        {
+          "name": "$NEIGHBOR_4",
+          "example": "10.200.50.11"
+        },
+        {
+          "name": "$NEIGHBOR_5",
+          "example": "10.200.50.16"
+        }
+      ],
+      "body": "protocols {\n    bgp {\n        group IBGP {\n            type internal;\n            local-address $LOCAL_ADDRESS;\n            family inet {\n                unicast;\n            }\n            family inet-vpn {\n                unicast;\n                any;\n            }\n            family evpn {\n                signaling;\n            }\n            family inet-mvpn {\n                signaling;\n            }\n            family route-target;\n            export $EXPORT_POLICY;\n            local-as $LOCAL_AS;\n            bfd-liveness-detection {\n                minimum-interval 100;\n                multiplier 3;\n            }\n            neighbor $NEIGHBOR_1;\n            neighbor $NEIGHBOR_2;\n            neighbor $NEIGHBOR_3;\n            neighbor $NEIGHBOR_4;\n            neighbor $NEIGHBOR_5;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        group IBGP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-address $LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet-vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unicast;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                any;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                signaling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family inet-mvpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                signaling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family route-target;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICY;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            local-as $LOCAL_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                minimum-interval </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            neighbor $NEIGHBOR_5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 812,
+      "lineCount": 33,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/transport/mpls-lsp-p2mp",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "mpls-lsp-p2mp",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/transport/mpls-lsp-p2mp.conf",
+      "topic": "MPLS LSPs with P2MP template and named point-to-point paths",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "(none)"
+        ]
+      },
+      "highlights": [
+        "P2MP LSP template enables dynamic multipoint trees for NG-MVPN provider-tunnels",
+        "optimize-aggressive + optimize-timer 5 enables frequent CSPF reoptimization",
+        "link-protection on P2MP template provides FRR bypass tunnels",
+        "Named unicast LSPs (lsp_to_*) provide pre-established paths to PE/AP peers",
+        "retry-timer 5 for fast LSP re-establishment after failure"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/rsvp-signaling.conf     (RSVP signals these LSPs)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ospf-te-protection.conf (CSPF uses OSPF-TE TED)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/mvpn-instance.conf       (MVPN uses P2MP provider-tunnel)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$P2MP_LSP_NAME",
+          "example": "P2MP"
+        },
+        {
+          "name": "$LSP_NAME_1",
+          "example": "lsp_to_AP1"
+        },
+        {
+          "name": "$LSP_DEST_1",
+          "example": "10.200.50.14"
+        },
+        {
+          "name": "$LSP_NAME_2",
+          "example": "lsp_to_AP2"
+        },
+        {
+          "name": "$LSP_DEST_2",
+          "example": "10.200.50.16"
+        },
+        {
+          "name": "$LSP_NAME_3",
+          "example": "lsp_to_PE2"
+        },
+        {
+          "name": "$LSP_DEST_3",
+          "example": "10.200.50.15"
+        },
+        {
+          "name": "$CORE_IFACE_1",
+          "example": "et-0/0/1.0"
+        },
+        {
+          "name": "$CORE_IFACE_2",
+          "example": "et-0/0/3.0"
+        }
+      ],
+      "body": "protocols {\n    mpls {\n        optimize-aggressive;\n        label-switched-path $P2MP_LSP_NAME {\n            template;\n            retry-timer 5;\n            optimize-timer 5;\n            link-protection;\n            p2mp;\n        }\n        label-switched-path $LSP_NAME_1 {\n            to $LSP_DEST_1;\n        }\n        label-switched-path $LSP_NAME_2 {\n            to $LSP_DEST_2;\n        }\n        label-switched-path $LSP_NAME_3 {\n            to $LSP_DEST_3;\n        }\n        interface $CORE_IFACE_1;\n        interface $CORE_IFACE_2;\n        interface lo0.0;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        optimize-aggressive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $P2MP_LSP_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            template;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            retry-timer </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            optimize-timer </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            p2mp;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-switched-path $LSP_NAME_3 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            to $LSP_DEST_3;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 571,
+      "lineCount": 24,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/transport/ospf-te-protection",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "ospf-te-protection",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/transport/ospf-te-protection.conf",
+      "topic": "OSPF with traffic engineering, node-link-protection, and BFD",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "traffic-engineering enables OSPF-TE extensions (RFC 3630) for RSVP-TE CSPF",
+        "node-link-protection provides LFA backup for sub-50ms failover",
+        "BFD at 10ms × 3 for ultra-fast adjacency failure detection (finance/low-latency)",
+        "lo0.0 as passive ensures router-id reachability without forming adjacency",
+        "All interfaces in area 0.0.0.0 (single-area backbone)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/mpls-lsp-p2mp.conf        (MPLS LSPs use CSPF paths)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/physical-p2p-mpls.conf   (the physical interfaces referenced)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_IFACE_1",
+          "example": "et-0/0/1.0"
+        },
+        {
+          "name": "$CORE_IFACE_2",
+          "example": "et-0/0/3.0"
+        },
+        {
+          "name": "$BFD_INTERVAL",
+          "example": "10"
+        },
+        {
+          "name": "$BFD_MULTIPLIER",
+          "example": "3"
+        }
+      ],
+      "body": "protocols {\n    ospf {\n        traffic-engineering;\n        area 0.0.0.0 {\n            interface $CORE_IFACE_1 {\n                node-link-protection;\n                bfd-liveness-detection {\n                    minimum-interval $BFD_INTERVAL;\n                    multiplier $BFD_MULTIPLIER;\n                }\n            }\n            interface $CORE_IFACE_2 {\n                node-link-protection;\n                bfd-liveness-detection {\n                    minimum-interval $BFD_INTERVAL;\n                    multiplier $BFD_MULTIPLIER;\n                }\n            }\n            interface lo0.0 {\n                passive;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        traffic-engineering;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        area </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_IFACE_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                node-link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval $BFD_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier $BFD_MULTIPLIER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $CORE_IFACE_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                node-link-protection;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    minimum-interval $BFD_INTERVAL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multiplier $BFD_MULTIPLIER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                passive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 659,
+      "lineCount": 24,
+      "techFamily": "Transport",
+      "subfamily": "OSPF",
+      "usecases": [
+        "Enterprise WAN"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "ewan_finance/junos/transport/rsvp-signaling",
+      "jvd": "ewan_finance",
+      "jvdLabel": "Enterprise WAN: Finance",
+      "area": "Enterprise WAN",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "transport",
+      "name": "rsvp-signaling",
+      "path": "enterprise_wan/ewan_finance/configuration/snips/junos/transport/rsvp-signaling.conf",
+      "topic": "RSVP-TE interface enablement for label-switched path signaling",
+      "seenOn": {
+        "junos": [
+          "wanedge1_mx304",
+          "wanedge2_mx10004",
+          "ap1_mx304",
+          "ap2_mx10004"
+        ],
+        "evo": [
+          "p1_ptx10003-80c",
+          "p2_ptx10001-36mr"
+        ]
+      },
+      "highlights": [
+        "RSVP enabled on all core transport interfaces and loopback",
+        "Provides RSVP-TE signaling for traffic-engineered LSPs",
+        "Works with OSPF-TE CSPF to compute constrained shortest paths",
+        "lo0.0 included for targeted RSVP sessions (graceful restart, etc.)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/transport/mpls-lsp-p2mp.conf        (MPLS LSPs signaled via RSVP)",
+          "id": null
+        },
+        {
+          "raw": "junos/transport/ospf-te-protection.conf   (OSPF-TE provides path computation)",
+          "id": null
+        },
+        {
+          "raw": "junos/interfaces/physical-p2p-mpls.conf   (physical interfaces referenced)",
+          "id": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$CORE_IFACE_1",
+          "example": "et-0/0/1.0"
+        },
+        {
+          "name": "$CORE_IFACE_2",
+          "example": "et-0/0/3.0"
+        }
+      ],
+      "body": "protocols {\n    rsvp {\n        interface lo0.0;\n        interface $CORE_IFACE_1;\n        interface $CORE_IFACE_2;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    rsvp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface lo0.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $CORE_IFACE_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 121,
+      "lineCount": 7,
+      "techFamily": "Transport",
+      "subfamily": "Transport",
+      "usecases": [
+        "Enterprise WAN"
       ],
       "parseWarnings": []
     },
@@ -13203,6 +19192,14 @@
     {
       "jvd": "broadband_edge",
       "markdown": "# Snippet variable glossary\n\nAll `.conf` files under `junos/` and `evo/` are templates: identifiers\nthat vary between deployments are written as `$VAR`. Render with the\nsame `snips_render.py` tool used elsewhere in the JVD repo.\n\nConstants left as literals on purpose:\n- Apply-group / policy / community names (PS-ISIS-EXPORT, PS-PPLB,\n  PS-RADIUS-COMM, etc.) — they ARE the abstraction.\n- Forwarding-class names, scheduler-map names — JVD-wide.\n- Pool / dynamic-profile names (`pppv4-pool`, `auto-stacked-pwht`,\n  `prod-dhcp-base`, …) — wired by the BNG runtime by name.\n- All `$junos-*` placeholders inside dynamic-profiles — runtime-resolved\n  by smg-service, NOT user-templatable.\n\n## Identity / topology\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$ROUTER_ID` | Device router-id (== lo0.0 IPv4) | `192.168.0.7` | transport/* |\n| `$LOCAL_AS` | iBGP / overlay AS | `65001` | transport/* |\n| `$LOOPBACK_V4` | This PE's lo0.0 IPv4 | `192.168.0.7` | transport/*, policy/* |\n| `$LOOPBACK_V6` | This PE's lo0.0 IPv6 | `2001:db8::192:168:0:7` | policy/* |\n| `$NODE_SID_V4` | ISIS-SR IPv4 node-segment index (1000+lastoctet in this JVD) | `1007` | policy/isis-export-prefix-segment.conf |\n| `$NODE_SID_V6` | ISIS-SR IPv6 node-segment index (4000+lastoctet) | `4007` | policy/isis-export-prefix-segment.conf |\n| `$SRGB_START` / `$SRGB_END` | MPLS SRGB label range | `800000` / `890000` | transport/mpls-segment-routing.conf |\n\n## Neighbours / route reflectors\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$RR_AGN1_V4` / `$RR_AGN2_V4` | Fabric (AGN) RR loopbacks | `192.168.0.5` / `192.168.0.6` | transport/bgp-overlay-* |\n| `$RR_CR_V4` | Core (CR) RR loopback | `192.168.0.11` | transport/bgp-overlay-pe-bng.conf |\n| `$AN1_V4`..`$AN5_V4` | Access-node loopbacks (RR clients) | `192.168.0.0`..`192.168.0.4` | transport/bgp-overlay-rr-fabric.conf |\n| `$BNG1_V4`..`$BNG4_V4` | BNG loopbacks (RR clients) | `192.168.0.7`..`192.168.0.10` | transport/bgp-overlay-rr-* |\n| `$AGN1_V4` / `$AGN2_V4` | Aggregation-node loopbacks (cr1 view) | `192.168.0.5` / `192.168.0.6` | transport/bgp-overlay-rr-core.conf |\n| `$CR_V4` | Core RR loopback (AGN view) | `192.168.0.11` | transport/bgp-overlay-rr-fabric.conf |\n| `$CE_PEER_V4` / `$CE_PEER_V6` | Internet eBGP peer addresses | `10.11.110.2` / `2001:db8::11:11:110:2` | services/l3vpn-internet.conf |\n| `$CE_AS_V4` / `$CE_AS_V6` | Internet eBGP peer AS numbers | `200` / `300` | services/l3vpn-internet.conf |\n\n## Interfaces (underlay)\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$CORE_INTF` | Core-facing IS-IS unit | `et-0/0/2.0` | transport/isis-srmpls-tilfa.conf |\n| `$CORE_PHYS` | Core-facing physical interface | `et-0/0/2` | interfaces/core-isis-mpls.conf |\n| `$CORE_DESC` | JVD-style link description | `R7-BNG1-To-R6-AGN2` | interfaces/core-isis-mpls.conf |\n| `$CORE_V4` / `$CORE_V6` | Underlay link addresses | `10.10.67.2/24` / `2001:db8::10:10:67:1:2/120` | interfaces/core-isis-mpls.conf |\n| `$ISIS_LEVEL` | ISIS level on this interface | `1` (or `2` on cr1's L2 links) | transport/isis-srmpls-tilfa.conf |\n| `$L2_KNOB` | `level 2` mode | `disable` (or `wide-metrics-only` on cr1) | transport/isis-srmpls-tilfa.conf |\n| `$EXPORT_POLICY` | ISIS export policy reference | `PS-ISIS-EXPORT` (or `[ PS-ISIS-EXPORT stop_leak ]` on cr1) | transport/isis-srmpls-tilfa.conf |\n| `$V6_VRF_RIB` | VRF v6 rib leaked into inet6.0 | `PPPOE_SUBS_1.inet6.0` | transport/routing-options-pe.conf |\n\n## Interfaces (subscriber & access)\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$PS_DEV` | Pseudowire-headend ifd | `ps0`, `ps11` | interfaces/ps-pseudowire-* |\n| `$PS_AC` | psN.0 attachment-circuit unit | `ps1.0`, `ps11.0`, `ps31.0` | services/evpn-vpws-*-bng.conf |\n| `$ANCHOR_LT` | logical-tunnel anchor | `lt-0/0/0` | interfaces/ps-pseudowire-* |\n| `$DYN_PROFILE` | Dynamic-profile invoked by auto-configure | `auto-stacked-pwht`, `auto-stacked-pwht_dhcp` | interfaces/ps-pseudowire-* |\n| `$ESI_VALUE` | Per-ps ESI for EVPN multihoming | `00:10:12:12:12:12:12:00:00:31` | interfaces/ps-pseudowire-* |\n| `$DF_PREFERENCE` | df-election-type preference value | `1000` (preferred) / `995` (backup) | interfaces/ps-pseudowire-* |\n| `$STATIC_MAC` | Override MAC on ps interface (DHCP) | `aa:aa:aa:bb:bb:bb` | interfaces/ps-pseudowire-dhcp-ipoe.conf |\n| `$MTU` | ps interface MTU | `2022` | interfaces/ps-pseudowire-* |\n| `$AC_INTF` | AN-side EVPN-VPWS attachment-circuit unit | `ae1.1041` | services/evpn-vpws-an.conf |\n| `$AC1` / `$AC2` | FXC bundle members on the AN | `ae0.1061` / `ae0.1062` | services/evpn-vpws-fxc-an.conf |\n| `$LAG`, `$LAG_FXC`, `$LAG_PERSUB` | Aggregated-Ethernet device names | `ae0`, `ae1` | interfaces/ae-vlan-bridge-* |\n| `$LAG_VLAN_UNIT` / `$LAG_VLAN_ID` | per-subscriber VLAN unit/id | `1031` / `1031` | interfaces/ae-vlan-bridge-fxc-sw.conf |\n| `$CPE_PORT` | sw1/sw2 CPE-facing breakout port | `xe-0/0/0:3` | interfaces/ae-vlan-bridge-fxc-sw.conf |\n| `$BD_NAME` | sw1/sw2 bridge-domain name | `bd_group_1031` | interfaces/ae-vlan-bridge-fxc-sw.conf |\n| `$FXC_VLAN_UNIT` | AN FXC LAG unit/vlan | `1061` | interfaces/ae-vlan-bridge-an.conf |\n| `$PERSUB_VLAN_UNIT` | AN per-subscriber LAG unit/vlan | `1031` | interfaces/ae-vlan-bridge-an.conf |\n| `$FXC_ESI` | Shared LAG-level ESI for FXC | `00:15:15:15:00:00:00:15:15:15` | interfaces/ae-vlan-bridge-an.conf, services/evpn-vpws-fxc-an.conf |\n| `$PERSUB_ESI_VALUE` | Per-unit ESI for per-subscriber EVPN-VPWS | `00:10:11:11:11:11:11:00:00:31` | interfaces/ae-vlan-bridge-an.conf |\n| `$LACP_SYSID_FXC` / `$LACP_SYSID_PERSUB` | LACP system-id overrides on AN LAGs | `00:00:00:00:01:01` / `00:00:00:00:02:02` | interfaces/ae-vlan-bridge-an.conf |\n\n## Services (EVPN-VPWS / L3VPN)\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$INSTANCE_NAME` | routing-instance name | `METRO_BBE_EVPN_VPWS_PPPoE_GROUP_1` | services/evpn-vpws-* |\n| `$VRF_NAME` | L3VPN routing-instance name | `PPPOE_SUBS_1`, `dhcp-subs` | services/l3vpn-* |\n| `$RD_LOOPBACK_V4` | Loopback used as RD-prefix | `192.168.107.107` (BNG-side), `100.100.100.100` (AN-side) | services/* |\n| `$RD_ID` | RD tail integer | `1031` | services/* |\n| `$RT_AS` / `$RT_ID` | Route-target AS:ID pair | `60000`:`1031` | services/evpn-vpws-* |\n| `$VPWS_LOCAL_ID` / `$VPWS_REMOTE_ID` | EVPN-VPWS service-id pair | `21` / `1` | services/evpn-vpws-* |\n| `$SVC_LOCAL` / `$SVC_REMOTE` | FXC group service-id pair | `5001` / `6001` | services/evpn-vpws-fxc-an.conf |\n| `$LO_UNIT` | VRF loopback unit | `lo0.1`, `lo0.7`, `lo0.11`, `lo0.313` | services/l3vpn-* |\n| `$VRF_IMPORT_POL` / `$VRF_EXPORT_POL` | Per-VRF import/export policy refs | `PS-PPPOE-SUBS-1-VRF-IMPORT` / `-EXPORT` | services/l3vpn-* |\n| `$V4_AGGREGATE` / `$V6_AGGREGATE` | Subscriber-pool aggregate prefixes | `10.25.0.0/16` / `fc00:25:140::/48` | services/l3vpn-pppoe-subs.conf |\n| `$V4_POOL` / `$V6_POOL` | DHCP pool names | `dhcp_v4_pool` / `dhcp_v6_pool` | services/l3vpn-dhcp-subs.conf |\n| `$V4_NETWORK` | DHCP v4 pool network | `10.42.0.0/16` | services/l3vpn-dhcp-subs.conf |\n| `$V4_RANGE_LOW` / `$V4_RANGE_HIGH` | DHCP v4 lease range | `10.42.0.2` / `10.42.255.254` | services/l3vpn-dhcp-subs.conf |\n| `$V4_GATEWAY` | DHCP server-identifier + router option | `10.42.0.1` | services/l3vpn-dhcp-subs.conf |\n| `$V6_PREFIX` | DHCPv6 pool prefix | `fc00:125:140::/64` | services/l3vpn-dhcp-subs.conf |\n| `$V6_RANGE_LOW` / `$V6_RANGE_HIGH` | DHCPv6 range | `fc00:125:140::2/128` / `fc00:125:140::ffff/128` | services/l3vpn-dhcp-subs.conf |\n| `$LEASE_TIME` | dhcp-attributes maximum-lease-time (s) | `600` | services/l3vpn-dhcp-subs.conf |\n| `$V6_RIB` | rib for IPv6 aggregate inside VRF | `PPPOE_SUBS_1.inet6.0` | services/l3vpn-pppoe-subs.conf |\n| `$V4_POOL_NETWORK` / `$V6_POOL_PREFIX` | PPPoE pool prefixes | `10.25.0.0/16` / `fc00:25:140::/48` | services/l3vpn-pppoe-subs.conf, subscriber-management/address-assignment-pools.conf |\n| `$AUTH_PROFILE` | RADIUS access-profile reference | `vlan-auth-access1` | interfaces/ps-pseudowire-*, services/l3vpn-dhcp-subs.conf |\n| `$RADIUS_INTF` | RADIUS-VRF interface on cr1 | `et-0/0/20:0.0` | services/l3vpn-radius.conf |\n| `$CE_INTF` | VRF_Internet eBGP interface | `et-0/0/26:1.0` | services/l3vpn-internet.conf |\n\n## Chassis / boot / subscriber-management\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$PS_DEVICE_COUNT` | chassis pseudowire-service device-count | `100` | bootstrap/chassis-bng.conf |\n| `$TS_FPC` / `$TS_PIC` / `$TS_BW` | tunnel-services FPC/PIC/bandwidth | `0` / `0` / `100g` | bootstrap/chassis-bng.conf |\n| `$NAS_ID` | RADIUS NAS-Identifier | `R7-BNG1` | subscriber-management/access-profile-radius.conf |\n| `$RADIUS_SERVER_V4` | RADIUS server address | `10.189.189.2` | subscriber-management/* |\n| `$RADIUS_PORT` | RADIUS server UDP port | `1812` | subscriber-management/radius-server.conf |\n| `$RADIUS_SECRET` / `$RADIUS_SECRET_AUTH` / `$RADIUS_SECRET_ACCT` | Encrypted RADIUS secrets | `$9$...` (Junos type-9) | subscriber-management/* |\n| `$RADIUS_SOURCE_V4` | RADIUS source-address (in RADIUS VRF) | `192.168.17.17` | subscriber-management/* |\n| `$AUTOCONF_BW` / `$AUTOCONF_BURST` | ddos-protection autoconf rate-limits | `20000` / `20000` | subscriber-management/system-services-subscriber-mgmt.conf |\n| `$PPPOE_PADSE_BW` / `$PPPOE_PADSE_BURST` | ddos-protection PPPoE PADSE rate-limits | `2000` / `100` | subscriber-management/system-services-subscriber-mgmt.conf |\n| `$USER_PASS` | dynamic-profile RADIUS password | `joshua` | interfaces/ps-pseudowire-*, services/l3vpn-dhcp-subs.conf, subscriber-management/dp-auto-stacked-* |\n| `$USER_PREFIX` | dynamic-profile username prefix | `pwht_pppoe`, `pwht_dhcp` | (same as `$USER_PASS`) |\n| `$DOMAIN_NAME` | dynamic-profile username domain | `jnpr.net` | (same as `$USER_PASS`) |\n| `$RA_MIN` / `$RA_MAX` | router-advertisement intervals | `30` / `60` | subscriber-management/dp-auto-stacked-pwht-dhcp.conf |\n| `$VRF_LO_UNIT` | dhcp-subs VRF loopback unit | `lo0.313` | subscriber-management/dp-prod-dhcp-base.conf, dp-autosense-ipdemux.conf |\n\n## Policy\n\n| Variable | Meaning | Example | Used in |\n|---|---|---|---|\n| `$PL_AN_REGION_LIST` | Prefix-list of AN+BNG client loopbacks | `192.168.0.0..0.4 192.168.0.7 192.168.0.8` | policy/bgp-rr-export.conf |\n| `$PL_CORE_LIST` | Prefix-list of CORE loopbacks (per RR view) | `192.168.0.7 .8 .11` (AGN view); `192.168.0.9 .10` (cr1 view) | policy/bgp-rr-export.conf |\n"
+    },
+    {
+      "jvd": "ewan_adv_core_edge",
+      "markdown": "# Snip Variable Reference\n\nVariables used across the `ewan_adv_core_edge` snip library. Replace `$VARIABLE` placeholders\nwith site-specific values when adapting snips to a new deployment.\n\n## Interfaces\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$CORE_INTF` | `et-0/0/1` | physical-uplink-mpls, rewrite-rules-exp |\n| `$ACCESS_INTF` | `xe-0/0/9:0` | rewrite-rules-exp, ccc-vpws-mux |\n| `$LAG_INTF` | `ae0` | lag-flexible-services |\n| `$LAG_MEMBER` | `xe-0/0/9:0` | lag-flexible-services |\n| `$UNIT` | `301` | ccc-vpws-mux, irb-gateway, rewrite-rules-exp |\n| `$VLAN_ID` | `301` | ccc-vpws-mux, irb-gateway |\n| `$LOOPBACK_IPV4` | `192.168.0.1/32` | loopback |\n| `$LOOPBACK_IPV6` | `fd00::1/128` | loopback |\n| `$IRB_IPV4` | `10.0.1.1/24` | irb-gateway |\n| `$MTU` | `9192` | physical-uplink-mpls |\n\n## Transport / Routing\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$ROUTER_ID` | `192.168.0.1` | bgp-ibgp-evpn, ospf-sr-lfa |\n| `$AS_NUMBER` | `65001` | bgp-ibgp-evpn |\n| `$RR_PEER` | `192.168.0.100` | bgp-ibgp-evpn |\n| `$AREA` | `0.0.0.0` | ospf-sr-lfa |\n| `$SRGB_START` | `400000` | ospf-sr-lfa |\n| `$SRGB_SIZE` | `4096` | ospf-sr-lfa |\n| `$NODE_INDEX` | `1` | ospf-sr-lfa |\n| `$LSP_NAME` | `to-wanedge2` | mpls-lsp |\n| `$LSP_DESTINATION` | `192.168.0.2` | mpls-lsp |\n| `$BW_MBPS` | `1000m` | rsvp-te |\n\n## Services (EVPN / VPN)\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$VPN_INSTANCE` | `vpws_group_14_1` | evpn-vpws-fxc, evpn-vpws-simple |\n| `$RD` | `192.168.0.1:14001` | all services |\n| `$RT_IMPORT` | `target:65001:14001` | all services |\n| `$RT_EXPORT` | `target:65001:14001` | all services |\n| `$LOCAL_ID` | `1` | evpn-vpws-fxc, evpn-vpws-simple |\n| `$REMOTE_ID` | `2` | evpn-vpws-fxc, evpn-vpws-simple |\n| `$FXC_INTF` | `lsi.*` | evpn-vpws-fxc |\n| `$ELAN_VNI` | `5001` | evpn-elan-simple (if extended) |\n\n## CoS / QoS\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$REWRITE_NAME` | `EXP-REWRITE` | rewrite-rules-exp |\n| `$CLASSIFIER_NAME` | `EXP` / `8021P` | rewrite-rules-exp |\n\n## Firewall / Security\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$FILTER_NAME` | `filter_ip_dport1` | filter-ipv4-stateless |\n| `$PROTOCOL` | `tcp` | filter-ipv4-stateless |\n| `$DST_PORT` | `80` | filter-ipv4-stateless |\n| `$NEXT_HOP` | `192.168.56.2/32` | filter-ipv4-stateless |\n| `$NEXT_INTF` | `et-0/0/1` | filter-ipv4-stateless |\n\n## OAM (802.1ag CFM)\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$MD_NAME` | `m-d301` | cfm-maintenance-domain |\n| `$MD_LEVEL` | `3` | cfm-maintenance-domain |\n| `$MA_NAME` | `m-a301` | cfm-maintenance-domain |\n| `$MEP_ID` | `1` | cfm-maintenance-domain |\n| `$MEP_INTF` | `xe-0/0/9:0.301` | cfm-maintenance-domain |\n| `$CC_INTERVAL` | `1s` | cfm-maintenance-domain |\n| `$PROFILE_DELAY` | `i1` | cfm-sla-iterator |\n| `$PROFILE_SLM` | `i2` | cfm-sla-iterator |\n| `$INTERVAL` | `5` | cfm-sla-iterator |\n\n## Bootstrap / Platform\n\n| Variable | Example | Used in |\n|----------|---------|---------|\n| `$DEVICE_COUNT` | `25` | chassis-network-services |\n"
+    },
+    {
+      "jvd": "ewan_finance",
+      "markdown": "# Variables Glossary\n\nAll `$VARIABLE` placeholders used across the ewan_finance snip library.\nReplace these with site-specific values when deploying.\n\n## Identifiers & Addressing\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$LOCAL_ADDRESS` | BGP local-address (router-id loopback) | `10.200.50.12` |\n| `$LOCAL_AS` | BGP autonomous system number | `64512` |\n| `$ROUTER_ID_ADDRESS` | Primary loopback IPv4 with /32 mask | `10.200.50.13/32` |\n| `$MGMT_LOOPBACK` | Management loopback address | `10.255.163.148/32` |\n| `$ISO_ADDRESS` | IS-IS/CLNS NET address on lo0 | `47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00` |\n| `$IPV6_ADDRESS` | Primary IPv6 loopback address | `2001:db8::10:255:163:148/128` |\n| `$IPV4_ADDRESS` | Interface IPv4 address with mask | `10.101.23.2/24` |\n| `$ROUTE_DISTINGUISHER` | BGP route-distinguisher (router-id:id) | `10.200.50.12:61` |\n| `$VRF_TARGET` | VPN route-target community | `target:64512:11` |\n\n## Interfaces & LAG\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$INTERFACE_NAME` | Physical interface name | `et-0/0/0` |\n| `$AE_NAME` | Aggregated Ethernet (LAG) name | `ae0` |\n| `$DESCRIPTION` | Interface description string | `Link to P1Node to WANEdge1` |\n| `$MTU` | Interface MTU value | `1522` |\n| `$CORE_IFACE_1` .. `$CORE_IFACE_4` | Core transport interface.unit | `et-0/0/1.0` |\n| `$UNIT_ID` | Logical interface unit number | `1` |\n| `$VLAN_ID` | 802.1Q VLAN identifier | `1` |\n\n## LAG / ESI\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$ESI_ID` | Ethernet Segment Identifier (10 bytes) | `00:11:11:11:11:11:12:12:12:12` |\n| `$DF_PREFERENCE` | Designated-forwarder election preference | `150` |\n| `$LACP_PRIORITY` | LACP system priority | `100` |\n| `$LACP_SYSTEM_ID` | LACP system-id (must match across ESI peers) | `00:00:00:00:00:10` |\n| `$UNIT_ESI` | Per-unit ESI for per-VLAN DF election | `00:01:71:81:11:12:a1:00:00:01` |\n| `$UNIT_DF_PREFERENCE` | Per-unit DF preference value | `150` |\n\n## IRB\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$FILTER_NAME` | Firewall filter applied on IRB input | `mfc-filter` |\n| `$STATIC_MAC` | Static MAC for deterministic gateway | `00:10:94:00:00:01` |\n\n## Chassis\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$DEVICE_COUNT` | Aggregated Ethernet device-count | `25` |\n| `$FPC_SLOT` | FPC slot number | `0` |\n| `$PIC_SLOT` | PIC slot number | `0` |\n| `$TUNNEL_BW` | Tunnel-services bandwidth | `10g` |\n| `$PORT_ID` | Physical port number | `0` |\n| `$PORT_SPEED` | Port speed setting | `100g` |\n| `$BREAKOUT_PORT_ID` | Port to be broken out | `9` |\n| `$BREAKOUT_SPEED` | Per-lane speed after breakout | `10g` |\n| `$BREAKOUT_SUB_PORTS` | Number of breakout sub-ports | `4` |\n\n## BGP Peers\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$NEIGHBOR_1` .. `$NEIGHBOR_5` | iBGP peer addresses | `10.200.50.13` |\n| `$EXPORT_POLICY` | BGP group export policy list | `[ PS-send-ospf PS-BGP-TO-OSPF ]` |\n| `$CE_NEIGHBOR` | CE/TG BGP peer address | `172.16.1.2` |\n| `$CE_PEER_AS` | CE/TG peer autonomous system | `64513` |\n| `$AP_PEER_AS` | AP router peer AS (for CR VRs) | `64512` |\n| `$AP_NEIGHBOR_1` | AP1 peer address in virtual-router | `10.101.49.1` |\n| `$AP_NEIGHBOR_2` | AP2 peer address in virtual-router | `10.101.79.1` |\n| `$IXIA_PEER_AS` | Traffic generator peer AS | `64521` |\n| `$IXIA_NEIGHBOR` | Traffic generator peer address | `10.101.91.2` |\n\n## MPLS / RSVP\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$P2MP_LSP_NAME` | P2MP LSP template name | `P2MP` |\n| `$LSP_NAME_1` .. `$LSP_NAME_3` | Named unicast LSP | `lsp_to_AP1` |\n| `$LSP_DEST_1` .. `$LSP_DEST_3` | LSP destination (peer loopback) | `10.200.50.14` |\n\n## OSPF / BFD\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$BFD_INTERVAL` | BFD minimum-interval (ms) | `10` |\n| `$BFD_MULTIPLIER` | BFD detect-multiplier | `3` |\n\n## Policy\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$DIRECT_POLICY_NAME` | Direct-route redistribution policy | `PS-ADV_DIRECT` |\n| `$BGP_TO_OSPF_NAME` | BGP-to-OSPF leak policy | `PS-BGP-TO-OSPF` |\n| `$OSPF_TO_BGP_NAME` | OSPF-to-BGP export policy | `PS-send-ospf` |\n| `$MED_LOW_NAME` | Low-MED route-filter policy | `PS-med-10` |\n| `$MED_LOW_PREFIX` | Route-filter prefix for low MED | `10.101.0.0/16` |\n| `$MED_LOW_VALUE` | Low MED metric value | `10` |\n| `$MED_HIGH_NAME` | High-MED catch-all policy | `PS-med-30` |\n| `$MED_HIGH_VALUE` | High MED metric value | `30` |\n| `$EXPORT_POLICIES` | VR BGP export policy list | `[ med-10 med-30 ]` |\n\n## CoS\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$INTERFACE_1` .. `$INTERFACE_4` | CoS-applied interfaces | `et-0/0/1` |\n\n## Firewall\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$MCAST_DEST_PREFIX` | Multicast destination prefix to match | `225.0.0.0/16` |\n| `$FORWARDING_CLASS` | Target forwarding class for match | `FC-LLQ` |\n| `$UNICAST_DEST_1` | Unicast destination for VRF filter | `10.8.21.2/32` |\n| `$UNICAST_DEST_2` | Second unicast destination | `10.9.21.2/32` |\n| `$UNICAST_FWD_CLASS` | Forwarding class for unicast match | `FC-HIGH` |\n\n## Multicast / MVPN\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$RESOLVE_RATE` | Multicast PFE resolve-rate (pps) | `1000` |\n| `$MISMATCH_RATE` | RPF mismatch-rate (pps) | `1000` |\n| `$INSTANCE_NAME` | MVPN/VRF routing-instance name | `MVPN_INSTANCE1` |\n| `$CE_LOCAL_ADDRESS` | MVPN VRF local-address for CE peering | `172.16.1.1` |\n| `$MVPN_RT_IMPORT` | MVPN route-target import | `target:64512:101` |\n| `$MVPN_RT_EXPORT` | MVPN route-target export | `target:64512:101` |\n| `$RP_ADDRESS` | PIM Rendezvous Point address | `10.10.47.101` |\n| `$MCAST_GROUP_RANGE` | PIM multicast group-range prefix | `225.0.0.0/22` |\n| `$IRB_UNIT` | IRB interface bound to MVPN | `irb.1` |\n| `$LO_UNIT` | Loopback unit bound to MVPN | `lo0.1` |\n\n## EVPN\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$BD_NAME` | Bridge-domain name | `BD_EVPN_GROUP1` |\n| `$AE_UNIT` | LAG unit in bridge-domain | `ae0.1` |\n| `$IRB_UNIT` | Routing-interface in bridge-domain | `irb.1` |\n\n## L3VPN / Virtual-Router\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$VRF_NAME` | L3VPN VRF instance name | `VRF21` |\n| `$VR_NAME` | Virtual-router instance name | `VIRTUAL-ROUTER-V1` |\n| `$LOCAL_ADDRESS` | VRF eBGP local-address | `172.16.21.1` |\n| `$IFACE_AP1` | AP1-facing interface in VR | `et-5/0/0.1` |\n| `$IFACE_AP2` | AP2-facing interface in VR | `et-5/0/1.1` |\n| `$IFACE_TG` | Traffic-generator interface in VR | `xe-3/0/6.1` |\n\n## TWAMP / OAM\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$VRF_NAME_1` | TWAMP server VRF name | `MVPN_INSTANCE1` |\n| `$VRF_PORT_1` | TWAMP server port for VRF | `862` |\n| `$GLOBAL_PORT` | TWAMP server global port | `1862` |\n| `$CLIENT_LIST_NAME` | TWAMP client-list ACL name | `CR1_1` |\n| `$CLIENT_ADDRESS` | TWAMP client source address | `10.101.48.2/32` |\n| `$CONNECTION_NAME` | TWAMP client control-connection name | `CR24_1` |\n| `$DEST_PORT` | TWAMP client destination port | `862` |\n| `$ROUTING_INSTANCE` | TWAMP client routing-instance | `VIRTUAL-ROUTER-V1` |\n| `$TARGET_ADDRESS` | TWAMP probe target (server) address | `10.101.49.1` |\n| `$TEST_SESSION_NAME` | TWAMP test-session identifier | `T24_1` |\n| `$PROBE_COUNT` | Probes per test-session iteration | `100` |\n| `$PROBE_INTERVAL` | Probe interval in seconds | `1` |\n\n## VLAN Bridge-Domain (L2 Edge)\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$VLAN_NAME` | VLAN definition name | `vlan1` |\n| `$LAG_UNIT` | LAG unit in VLAN membership | `ae0.1` |\n| `$ACCESS_UNIT` | Access port unit in VLAN membership | `et-0/0/47.1` |\n"
     },
     {
       "jvd": "metro_ethernet_business_services",


### PR DESCRIPTION
## Why

The Enterprise WAN for Finance & Stock Exchange JVD (`ewan_finance`) has 9 device configs totaling ~10k lines but no reusable template library. Operators building NG-MVPN multicast deployments on MX/PTX/ACX must reverse-engineer the full device configs to extract individual patterns.

## What

**38 config-snippet templates** (22 Junos + 16 EVO) extracted and parameterized from `ewan_finance/configuration/conf/`, organized under `configuration/snips/{junos,evo}/` across 9 categories:

| Category | Junos | EVO | Key patterns |
|----------|:-----:|:---:|--------------|
| bootstrap | 1 | 1 | Chassis, aggregated-devices, tunnel-services |
| interfaces | 5 | 5 | ESI LAG, IRB gateway, flexible-vlan, loopback, VLAN bridge |
| transport | 4 | 4 | iBGP inet-mvpn, MPLS P2MP, OSPF-TE, RSVP |
| policy | 2 | 2 | Protocol redistribution, route-filter MED |
| cos | 1 | 1 | 4-class EXP with strict-high LLQ |
| firewall | 1 | — | Multicast fwd-cache filter with CoS marking |
| oam | 3 | 2 | LLDP, TWAMP server, TWAMP client |
| services | 4 | 1 | MVPN SPT-only, EVPN-VS ESI, VRF, virtual-router |
| multicast | 1 | — | Forwarding resolve/mismatch rate tuning |

**New category introduced: `multicast/`** — for multicast forwarding-options tuning knobs.

Supporting docs:
- `_variables.md` — glossary of ~80 $VARIABLES with examples
- `README.md` — platform table, sibling pairs, design pattern summary

CHANGELOG updated with 2026-05-21 entry.

## Expected impact

- Operators get ready-to-fill templates for the most complex patterns (MVPN hot-root-standby, ESI multihoming, TWAMP multi-VRF monitoring)
- 13 Junos↔EVO sibling pairs enable single-tree reference regardless of OS
- Portal picks up the library automatically on merge

## Test

- All 38 .conf files verified to contain valid hierarchical Junos syntax
- Variable placeholders confirmed consistent with `_variables.md`
- CHANGELOG boundary with previous 2026-05-15 entry verified intact