### PR TITLE
fix(portal): round snip count stat to nearest 50

### DIFF
--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -108,7 +108,7 @@ export default function JvdPortal() {
 
   const stats = [
     { label: "Validated Designs", value: "60+" },
-    { label: "Reusable Config Templates", value: `${snipBundle.counts.total}+` },
+    { label: "Reusable Config Templates", value: `${Math.floor(snipBundle.counts.total / 50) * 50}+` },
     { label: "Platforms Validated", value: "25+" },
   ];
 


### PR DESCRIPTION
## What's New
- Hero stat "Reusable Config Templates" now rounds down to the nearest 50 (shows "250+" instead of "267+"), consistent with the other two rounded stats ("60+", "25+").

## Why
The exact-number-plus-sign looked oddly precise next to the other rounded hero stats. Rounding to 50 gives a cleaner look and auto-bumps to "300+" once we cross that threshold.

## Details
- `portal/src/components/JvdPortal.tsx`: replaced `snipBundle.counts.total` with `Math.floor(snipBundle.counts.total / 50) * 50`