### PR TITLE
fix(metro-ebs): remove cross-OS pair-with refs, correct Seen-on claims

### DIFF
--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-24T16:01:52.845Z",
+  "generatedAt": "2026-05-27T22:11:23.222Z",
   "counts": {
     "total": 320,
     "junos": 160,
@@ -14670,10 +14670,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/apply-groups/gr-bgp-bcp.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-bgp-bcp"
-        },
-        {
           "raw": "evo/transport/bgp-overlay.conf",
           "id": "metro_ethernet_business_services/evo/transport/bgp-overlay"
         }
@@ -14719,10 +14715,6 @@
         "hold-time up 2000 down 0 — short up-damp on core links (give IGP a moment to come back) but no down-damp (let BFD/IGP withdraw)."
       ],
       "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-core-intf.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-core-intf"
-        },
         {
           "raw": "evo/transport/isis-srmpls-tilfa.conf",
           "id": "metro_ethernet_business_services/evo/transport/isis-srmpls-tilfa"
@@ -14773,10 +14765,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/apply-groups/gr-edge-intf-mh.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-edge-intf-mh"
-        },
-        {
           "raw": "evo/interfaces/lag-esi-multihoming.conf",
           "id": "metro_ethernet_business_services/evo/interfaces/lag-esi-multihoming"
         }
@@ -14823,10 +14811,6 @@
         "Optics low-light alarms tied to link-down for fast convergence."
       ],
       "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-edge-intf.conf (Junos counterpart)",
-          "id": null
-        },
         {
           "raw": "evo/apply-groups/gr-edge-intf-mh.conf (multihomed variant)",
           "id": null
@@ -14877,12 +14861,7 @@
         ]
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-fatpw-label.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-fatpw-label"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-FATPW-LABEL {\n        /* EVPN-VPWS will use static label EVPN-ELAN will use both */\n        routing-instances {\n            <l2vpn_*> {\n                protocols {\n                    l2vpn {\n                        flow-label-transmit;\n                        flow-label-receive;\n                    }\n                }\n            }\n            <vpls_*> {\n                protocols {\n                    vpls {\n                        flow-label-transmit;\n                        flow-label-receive;\n                    }\n                }\n            }\n            <evpn_group_80_*> {\n                protocols {\n                    evpn {\n                        flow-label;\n                        flow-label-static;\n                    }\n                }\n            }\n            <evpn_group_10_*> {\n                protocols {\n                    evpn {\n                        flow-label-transmit-static;\n                        flow-label-receive-static;\n                    }\n                }\n            }\n            <EVPN_VPWS_PORT_*> {\n                protocols {\n                    evpn {\n                        flow-label-transmit-static;\n                        flow-label-receive-static;\n                    }\n                }\n            }\n            L2VPN_PORT_BASED {\n                protocols {\n                    l2vpn {\n                        flow-label-transmit;\n                        flow-label-receive;\n                    }\n                }\n            }\n            <EVPN_ELAN_PORT_*> {\n                protocols {\n                    evpn {\n                        flow-label;\n                        flow-label-static;\n                    }\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-FATPW-LABEL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        /* EVPN-VPWS will use static label EVPN-ELAN will use both */</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;l2vpn_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    l2vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;vpls_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;evpn_group_80_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-static;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;evpn_group_10_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-transmit-static;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-receive-static;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;EVPN_VPWS_PORT_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-transmit-static;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-receive-static;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            L2VPN_PORT_BASED {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    l2vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;EVPN_ELAN_PORT_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        flow-label-static;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -14924,12 +14903,7 @@
         ]
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-fatpw-lb.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-fatpw-lb"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-FATPW-LB {\n        forwarding-options {\n            load-balance-label-capability;\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-FATPW-LB {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            load-balance-label-capability;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -14970,10 +14944,10 @@
       ],
       "pairWith": [],
       "variables": [],
-      "body": "et* lets ISIS hellos use the full\n *    jumbo MTU (verifies path MTU before the protocol commits).\n *  - lsp-interval 10 (ms) — fast LSP flooding on point-to-point links.\n *  - SPF: delay 50 ms / holddown 2000 ms / rapid-runs 5 → fast\n *    initial reaction with a backoff window, the textbook BCP.\n *  - overload bit timeout 300s + advertise-high-metrics → router\n *    comes up \"drained\" so traffic doesn't shift onto it before BGP\n *    converges.\n *\n * Pair with:\n *  - junos/apply-groups/gr-isis-bcp.conf\n *  - evo/transport/isis-srmpls-tilfa.conf\n *\n * Variables: none. Apply-groups in this JVD are entirely\n *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry\n *            only network-wide constants — there are no per-PE\n *            values to parameterise.\n */\ngroups {\n    GR-ISIS-BCP {\n        protocols {\n            isis {\n                interface <ae*> {\n                    max-hello-size 9106;\n                    lsp-interval 10;\n                }\n                interface <et-*> {\n                    max-hello-size 9106;\n                    lsp-interval 10;\n                }\n                spf-options {\n                    delay 50;\n                    holddown 2000;\n                    rapid-runs 5;\n                }\n                overload {\n                    timeout 300;\n                    advertise-high-metrics;\n                }\n            }\n        }\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">et* lets ISIS hellos use the full</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    jumbo MTU (verifies path MTU before the protocol commits).</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\"> (ms) — fast LSP flooding </span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\"> point-to-point links.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - SPF: delay </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\"> ms / holddown </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\"> ms / rapid-runs </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\"> → fast</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    initial reaction with a backoff window, the textbook BCP.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - overload bit timeout 300s + advertise-high-metrics → router</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    comes up \"drained\" so traffic doesn't shift onto it before BGP</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    converges.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * Pair with:</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - junos/apply-groups/gr-isis-bcp.conf</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - evo/transport/isis-srmpls-tilfa.conf</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * Variables: none. Apply-groups in this JVD are entirely</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *            wildcard-driven (e.g. &#x3C;ae*>, &#x3C;METRO_*>) and carry</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *            only network-wide constants — there are no per-PE</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *            values to parameterise.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> */</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-ISIS-BCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            isis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;ae*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    max-hello-size </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;et-*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    max-hello-size </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                spf-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    delay </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    holddown </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    rapid-runs </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                overload {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    timeout </span><span style=\"color:#79C0FF\">300</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise-high-metrics;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 1419,
-      "lineCount": 43,
+      "body": "et* lets ISIS hellos use the full\n *    jumbo MTU (verifies path MTU before the protocol commits).\n *  - lsp-interval 10 (ms) — fast LSP flooding on point-to-point links.\n *  - SPF: delay 50 ms / holddown 2000 ms / rapid-runs 5 → fast\n *    initial reaction with a backoff window, the textbook BCP.\n *  - overload bit timeout 300s + advertise-high-metrics → router\n *    comes up \"drained\" so traffic doesn't shift onto it before BGP\n *    converges.\n *\n * Pair with:\n *  - evo/transport/isis-srmpls-tilfa.conf\n *\n * Variables: none. Apply-groups in this JVD are entirely\n *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry\n *            only network-wide constants — there are no per-PE\n *            values to parameterise.\n */\ngroups {\n    GR-ISIS-BCP {\n        protocols {\n            isis {\n                interface <ae*> {\n                    max-hello-size 9106;\n                    lsp-interval 10;\n                }\n                interface <et-*> {\n                    max-hello-size 9106;\n                    lsp-interval 10;\n                }\n                spf-options {\n                    delay 50;\n                    holddown 2000;\n                    rapid-runs 5;\n                }\n                overload {\n                    timeout 300;\n                    advertise-high-metrics;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">et* lets ISIS hellos use the full</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    jumbo MTU (verifies path MTU before the protocol commits).</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\"> (ms) — fast LSP flooding </span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\"> point-to-point links.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - SPF: delay </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\"> ms / holddown </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\"> ms / rapid-runs </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\"> → fast</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    initial reaction with a backoff window, the textbook BCP.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - overload bit timeout 300s + advertise-high-metrics → router</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    comes up \"drained\" so traffic doesn't shift onto it before BGP</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *    converges.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * Pair with:</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *  - evo/transport/isis-srmpls-tilfa.conf</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> * Variables: none. Apply-groups in this JVD are entirely</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *            wildcard-driven (e.g. &#x3C;ae*>, &#x3C;METRO_*>) and carry</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *            only network-wide constants — there are no per-PE</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> *            values to parameterise.</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\"> */</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-ISIS-BCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            isis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;ae*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    max-hello-size </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;et-*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    max-hello-size </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                spf-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    delay </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    holddown </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    rapid-runs </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                overload {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    timeout </span><span style=\"color:#79C0FF\">300</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise-high-metrics;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1377,
+      "lineCount": 42,
       "techFamily": "Apply-groups",
       "subfamily": "IS-IS",
       "usecases": [
@@ -15000,12 +14974,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-isis-bfd.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-isis-bfd"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-ISIS-BFD {\n        protocols {\n            isis {\n                interface <ae*> {\n                    family inet {\n                        bfd-liveness-detection {\n                            minimum-interval 50;\n                            multiplier 3;\n                            no-adaptation;\n                        }\n                    }\n                }\n                interface <et*> {\n                    family inet {\n                        bfd-liveness-detection {\n                            minimum-interval 50;\n                            multiplier 3;\n                            no-adaptation;\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-ISIS-BFD {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            isis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;ae*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            minimum-interval </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            no-adaptation;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;et*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        bfd-liveness-detection {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            minimum-interval </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            multiplier </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            no-adaptation;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -15039,12 +15008,7 @@
         ]
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-l2ckt-hs.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-l2ckt-hs"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-L2CKT-HS {\n        protocols {\n            l2circuit {\n                neighbor <*> {\n                    interface <*> {\n                        pseudowire-status-tlv {\n                            hot-standby-vc-on;\n                        }\n                        switchover-delay 0;\n                    }\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-L2CKT-HS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                neighbor &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        pseudowire-status-tlv {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            hot-standby-vc-</span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        switchover-delay </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -15085,12 +15049,7 @@
         ]
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-l3vpn.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-l3vpn"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-L3VPN {\n        routing-instances {\n            <METRO_*> {\n                instance-type vrf;\n                routing-options {\n                    multipath {\n                        vpn-unequal-cost;\n                    }\n                    protect core;\n                }\n                vrf-table-label;\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-L3VPN {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;METRO_*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    multipath {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        vpn-unequal-cost;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    protect core;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -15122,12 +15081,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/apply-groups/gr-lag-member.conf",
-          "id": "metro_ethernet_business_services/junos/apply-groups/gr-lag-member"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-EDGE-INTF-LAG-MEMBER {\n        interfaces {\n            <*> {\n                traps;\n                hold-time up 180000 down 0;\n                optics-options {\n                    alarm low-light-alarm {\n                        link-down;\n                    }\n                    warning low-light-warning {\n                        syslog;\n                    }\n                }\n            }\n        }\n    }\n    GR-EDGE-INTF-LAG-MEMBER-MH {\n        interfaces {\n            <*> {\n                traps;\n                hold-time up 180000 down 0;\n                optics-options {\n                    alarm low-light-alarm {\n                        link-down;\n                    }\n                    warning low-light-warning {\n                        syslog;\n                    }\n                }\n            }\n        }\n    }\n    GR-CORE-INTF-LAG-MEMBER {\n        interfaces {\n            <*> {\n                description \"********GR-CORE-INTF-LAG-MEMBERS-SETTINGS-APPLIED ********\";\n                traps;\n                hold-time up 2000 down 0;\n                optics-options {\n                    alarm low-light-alarm {\n                        link-down;\n                    }\n                    warning low-light-warning {\n                        syslog;\n                    }\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-EDGE-INTF-LAG-MEMBER {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hold-time up </span><span style=\"color:#79C0FF\">180000</span><span style=\"color:#E6EDF3\"> down </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                optics-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    alarm low-light-alarm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        link-down;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    warning low-light-warning {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        syslog;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-EDGE-INTF-LAG-MEMBER-MH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hold-time up </span><span style=\"color:#79C0FF\">180000</span><span style=\"color:#E6EDF3\"> down </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                optics-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    alarm low-light-alarm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        link-down;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    warning low-light-warning {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        syslog;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-CORE-INTF-LAG-MEMBER {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                description \"********GR-CORE-INTF-LAG-MEMBERS-SETTINGS-APPLIED ********\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hold-time up </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\"> down </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                optics-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    alarm low-light-alarm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        link-down;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    warning low-light-warning {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        syslog;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -15168,10 +15122,6 @@
         "DSCP / EXP / 802.1p classifiers produce the same forwarding-class on both OS families (key for transparent CoS across multi-vendor pseudowires)."
       ],
       "pairWith": [
-        {
-          "raw": "junos/cos/forwarding-classes.conf",
-          "id": "metro_ethernet_business_services/junos/cos/forwarding-classes"
-        },
         {
           "raw": "evo/cos/schedulers.conf",
           "id": "metro_ethernet_business_services/evo/cos/schedulers"
@@ -15218,10 +15168,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/cos/schedulers.conf",
-          "id": "metro_ethernet_business_services/junos/cos/schedulers"
-        },
-        {
           "raw": "evo/cos/forwarding-classes.conf",
           "id": "metro_ethernet_business_services/evo/cos/forwarding-classes"
         }
@@ -15266,10 +15212,6 @@
         "Note: ma1-1_acx7024 in this JVD does NOT carry a generic \"any\" filter; policers are referenced directly per-unit via `unit X { filter { input 50MB_filter; } }` where 50MB_filter lives on filter-equipped peers (e.g. an3_acx7100-48l). On EVO devices that need a filter, build it as a family-any filter referencing these policers — same pattern as Junos."
       ],
       "pairWith": [
-        {
-          "raw": "junos/firewall/policers.conf",
-          "id": "metro_ethernet_business_services/junos/firewall/policers"
-        },
         {
           "raw": "evo/interfaces/edge-vlan-normalization.conf  (per-unit input filter ref)",
           "id": null
@@ -15316,10 +15258,6 @@
         "lo0.0 below carries the loopback address used by ISIS/iBGP."
       ],
       "pairWith": [
-        {
-          "raw": "junos/interfaces/core-isis-mpls.conf",
-          "id": "metro_ethernet_business_services/junos/interfaces/core-isis-mpls"
-        },
         {
           "raw": "evo/apply-groups/gr-core-intf.conf",
           "id": "metro_ethernet_business_services/evo/apply-groups/gr-core-intf"
@@ -15400,12 +15338,7 @@
         "Per-unit ingress filter (50MB_filter from firewall snippet) for rate-limiting at the UNI.",
         "unit 3000 is the L2Circuit attachment shown in evo/services/l2circuit-hot-standby.conf Edge baseline knobs (description, MTU, flex-vlan tagging, encapsulation, optics alarms) come from apply-groups GR-EDGE-INTF."
       ],
-      "pairWith": [
-        {
-          "raw": "junos/interfaces/edge-vlan-normalization.conf",
-          "id": "metro_ethernet_business_services/junos/interfaces/edge-vlan-normalization"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$AC_PHYS",
@@ -15460,10 +15393,6 @@
         "apply-groups GR-EDGE-INTF-MH (no port-level hold-time → EVPN DF election handles convergence)."
       ],
       "pairWith": [
-        {
-          "raw": "junos/interfaces/lag-esi-multihoming.conf",
-          "id": "metro_ethernet_business_services/junos/interfaces/lag-esi-multihoming"
-        },
         {
           "raw": "evo/services/evpn-vpws.conf",
           "id": "metro_ethernet_business_services/evo/services/evpn-vpws"
@@ -15526,12 +15455,7 @@
         "One maintenance-domain (level 5) holds many maintenance-associations (one per service / VLAN unit). Continuity-check 1s with loss-threshold 10 + hold-interval 1 detects PW liveness.",
         "One representative maintenance-association is shown; the source file repeats this template for each service-bound subinterface. Apply on a per-unit basis: each MEP binds to a vlan-ccc subinterface (e.g., et-0/0/0.2800) that is also the L2Circuit attachment-circuit."
       ],
-      "pairWith": [
-        {
-          "raw": "junos/oam/oam-cfm-perf-mon.conf",
-          "id": "metro_ethernet_business_services/junos/oam/oam-cfm-perf-mon"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$MD_NAME",
@@ -15584,12 +15508,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "junos/policy/communities.conf",
-          "id": "metro_ethernet_business_services/junos/policy/communities"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "policy-options {\n    community CM-ACCESS-FABRIC members 63535:2;\n    community CM-INET-BACKUP members target:63536:99999;\n    community CM-INET-DEFAULT members target:63536:11111;\n    community CM-INET-PRIMARY members target:63536:00000;\n    community CM-L3VPN-PUB members target:63536:22222;\n    community CM-LOOPBACK members 63535:10000;\n    community CM-METRO-FABRIC members 63535:1;\n    community CM-METRO-RING members 63536:20;\n    community CM-NO-ADVERTISE members no-advertise;\n    community CM-REGION-EDGE members 63536:30;\n    community CM-REGIONAL-BORDER members 63535:3;\n    community CM-SERVICE-EDGE members 63536:10;\n    community CM-TC-MAP2BRONZE members color:0:6000;\n    community CM-TC-MAP2GOLD members color:0:4000;\n    community METRO_BGPv4_L3VPN_2101 members target:63535:2101;\n    community METRO_BGPv4_L3VPN_2102 members target:63535:2102;\n    /* ... per-VRF community continues for every METRO_BGPv4_L3VPN_NNNN ... */\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-ACCESS-FABRIC members </span><span style=\"color:#79C0FF\">63535</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-INET-BACKUP members target:</span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">99999</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-INET-DEFAULT members target:</span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">11111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-INET-PRIMARY members target:</span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-L3VPN-PUB members target:</span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">22222</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-LOOPBACK members </span><span style=\"color:#79C0FF\">63535</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">10000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-METRO-FABRIC members </span><span style=\"color:#79C0FF\">63535</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-METRO-RING members </span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-NO-ADVERTISE members no-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-REGION-EDGE members </span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-REGIONAL-BORDER members </span><span style=\"color:#79C0FF\">63535</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-SERVICE-EDGE members </span><span style=\"color:#79C0FF\">63536</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2BRONZE members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">6000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2GOLD members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">4000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community METRO_BGPv4_L3VPN_2101 members target:</span><span style=\"color:#79C0FF\">63535</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">2101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community METRO_BGPv4_L3VPN_2102 members target:</span><span style=\"color:#79C0FF\">63535</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">2102</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    /* ... per-VRF community continues for every METRO_BGPv4_L3VPN_NNNN ... */</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -15635,12 +15554,7 @@
         "EXPORT also tags any \"public\" customer ranges with CM-L3VPN-PUB so they can be selectively redistributed for Internet breakout",
         "IMPORT accepts both the per-service RT and a default-route community CM-INET-DEFAULT (Internet default leaked into the VRF) The pattern repeats for every METRO_BGPv4_L3VPN_NNNN VRF; this single example is enough to understand the per-service template."
       ],
-      "pairWith": [
-        {
-          "raw": "junos/policy/l3vpn-export-import.conf",
-          "id": "metro_ethernet_business_services/junos/policy/l3vpn-export-import"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$INSTANCE_NAME",
@@ -15702,8 +15616,12 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/services/evpn-elan-mac-vrf-irb.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-elan-mac-vrf-irb"
+          "raw": "evo/services/evpn-type5.conf  (IRB co-occurrence)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-vpws.conf  (IRB co-occurrence)",
+          "id": null
         }
       ],
       "variables": [
@@ -15787,10 +15705,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/services/evpn-elan-mac-vrf.conf  (Junos MX virtual-switch flavour)",
-          "id": null
-        },
-        {
           "raw": "evo/transport/bgp-overlay.conf (family evpn signaling)",
           "id": null
         },
@@ -15873,12 +15787,7 @@
         "EVPN_VPWS_PORT_BASED: instance-type evpn-vpws + vpws-service-id local/remote pair (signalled via EVPN Type-1)",
         "EVPN_ELAN_PORT_BASED: instance-type mac-vrf with service-type vlan-bundle (multiple customer VLANs share one bridge-domain / one mac-vrf)"
       ],
-      "pairWith": [
-        {
-          "raw": "junos/services/evpn-port-based.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-port-based"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$AC_INTF_VPWS",
@@ -15970,10 +15879,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/services/evpn-type5.conf  (Junos end of the same VRF)",
-          "id": null
-        },
-        {
           "raw": "evo/services/evpn-elan-mac-vrf-irb.conf  (the L2 / IRB side",
           "id": null
         },
@@ -15987,6 +15892,10 @@
         },
         {
           "raw": "evo/transport/bgp-overlay.conf  (family evpn signaling)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-vpws.conf  (IRB co-occurrence)",
           "id": null
         }
       ],
@@ -16057,15 +15966,19 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/services/evpn-vpws.conf (remote single-homed end)",
-          "id": null
-        },
-        {
           "raw": "evo/interfaces/lag-esi-multihoming.conf (the AC interface)",
           "id": null
         },
         {
           "raw": "evo/transport/bgp-overlay.conf (family evpn signaling)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-type5.conf  (IRB co-occurrence)",
+          "id": null
+        },
+        {
+          "raw": "evo/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)",
           "id": null
         }
       ],
@@ -16153,10 +16066,6 @@
         {
           "raw": "evo/policy/communities.conf (CM-TC-MAP2GOLD definition)",
           "id": null
-        },
-        {
-          "raw": "junos/services/l2circuit-hot-standby.conf",
-          "id": "metro_ethernet_business_services/junos/services/l2circuit-hot-standby"
         }
       ],
       "variables": [
@@ -16223,16 +16132,8 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/transport/bgp-overlay.conf (family l2vpn signaling)",
-          "id": null
-        },
-        {
           "raw": "evo/apply-groups/gr-fatpw-label.conf (matches L2VPN_PORT_BASED)",
           "id": null
-        },
-        {
-          "raw": "junos/services/l2vpn-kompella.conf",
-          "id": "metro_ethernet_business_services/junos/services/l2vpn-kompella"
         }
       ],
       "variables": [
@@ -16314,14 +16215,6 @@
         {
           "raw": "evo/policy/l3vpn-export-import.conf",
           "id": "metro_ethernet_business_services/evo/policy/l3vpn-export-import"
-        },
-        {
-          "raw": "junos/transport/bgp-overlay.conf (family inet-vpn)",
-          "id": null
-        },
-        {
-          "raw": "junos/services/l3vpn-vrf.conf",
-          "id": "metro_ethernet_business_services/junos/services/l3vpn-vrf"
         }
       ],
       "variables": [
@@ -16391,12 +16284,7 @@
         "no-tunnel-services for ACX/MX hardware that does not require a tunnel PIC for VPLS",
         "Single VLAN (EPL-v0) bridges the attachment-circuit et-0/0/53.0 to all remote PEs in the VPLS domain For BGP-VPLS, replace `vpls-id`/`neighbor` with `site` / `route-target` (see KB-VPLS-TEST in the source file for that variant)."
       ],
-      "pairWith": [
-        {
-          "raw": "junos/services/bgp-vpls.conf  (BGP-VPLS sibling pattern, Junos only)",
-          "id": null
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$INSTANCE_NAME",
@@ -16467,10 +16355,6 @@
         "vpn-apply-export + advertise-from-main-vpn-tables — required so per-VRF export policies see VPN routes correctly when this box is also a service PE."
       ],
       "pairWith": [
-        {
-          "raw": "junos/transport/bgp-overlay.conf",
-          "id": "metro_ethernet_business_services/junos/transport/bgp-overlay"
-        },
         {
           "raw": "evo/apply-groups/gr-bgp-bcp.conf",
           "id": "metro_ethernet_business_services/evo/apply-groups/gr-bgp-bcp"
@@ -16549,10 +16433,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/transport/isis-srmpls-tilfa.conf",
-          "id": "metro_ethernet_business_services/junos/transport/isis-srmpls-tilfa"
-        },
-        {
           "raw": "evo/transport/mpls-segment-routing.conf",
           "id": "metro_ethernet_business_services/evo/transport/mpls-segment-routing"
         },
@@ -16628,10 +16508,6 @@
       ],
       "pairWith": [
         {
-          "raw": "junos/transport/mpls-segment-routing.conf",
-          "id": "metro_ethernet_business_services/junos/transport/mpls-segment-routing"
-        },
-        {
           "raw": "evo/transport/isis-srmpls-tilfa.conf",
           "id": "metro_ethernet_business_services/evo/transport/isis-srmpls-tilfa"
         }
@@ -16669,12 +16545,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-bgp-bcp.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-bgp-bcp"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-BGP-BCP {\n        protocols {\n            bgp {\n                path-selection external-router-id;\n                precision-timers;\n                hold-time 10;\n                bgp-error-tolerance;\n                tcp-mss 4096;\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-BGP-BCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                path-selection external-router-id;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                precision-timers;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hold-time </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bgp-error-tolerance;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                tcp-mss </span><span style=\"color:#79C0FF\">4096</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -16708,12 +16579,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-core-intf.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-core-intf"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-CORE-INTF {\n        interfaces {\n            <*> {\n                description \"********GR-CORE-INTF-SETTINGS-APPLIED ********\";\n                traps;\n                mtu 9192;\n                hold-time up 2000 down 0;\n                unit <*> {\n                    traps;\n                    family inet {\n                        mtu 9106;\n                    }\n                    family iso {\n                        mtu 9106;\n                    }\n                    family mpls {\n                        mtu 9170;\n                        maximum-labels 14;\n                    }\n                }\n            }\n            <ae*> {\n                aggregated-ether-options {\n                    lacp {\n                        active;\n                        hold-time up 2;\n                    }\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-CORE-INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                description \"********GR-CORE-INTF-SETTINGS-APPLIED ********\";</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                mtu </span><span style=\"color:#79C0FF\">9192</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hold-time up </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\"> down </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                unit &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        mtu </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    family iso {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        mtu </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    family mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        mtu </span><span style=\"color:#79C0FF\">9170</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        maximum-labels </span><span style=\"color:#79C0FF\">14</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;ae*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        hold-time up </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -16747,12 +16613,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-edge-intf-mh.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-edge-intf-mh"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-EDGE-INTF-MH {\n        interfaces {\n            <*> {\n                description ********GR-EDGE-INTF-Multihomed-SETTINGS-APPLIED-ADD-DESCRIPTION********;\n                traps;\n                flexible-vlan-tagging;\n                mtu 9102;\n                encapsulation flexible-ethernet-services;\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-EDGE-INTF-MH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                description ********GR-EDGE-INTF-Multihomed-SETTINGS-APPLIED-ADD-DESCRIPTION********;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                mtu </span><span style=\"color:#79C0FF\">9102</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -16786,12 +16647,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-edge-intf.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-edge-intf"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-EDGE-INTF {\n        interfaces {\n            <*> {\n                description ********GR-EDGE-INTF-SETTINGS-APPLIED-ADD-DESCRIPTION********;\n                traps;\n                flexible-vlan-tagging;\n                mtu 9102;\n                hold-time up 180000 down 0;\n                encapsulation flexible-ethernet-services;\n            }\n            <ae*> {\n                aggregated-ether-options {\n                    lacp {\n                        active;\n                        accept-data;\n                        hold-time up 2;\n                    }\n                }\n            }\n            \"<[egx][te]-*>\" {\n                optics-options {\n                    alarm low-light-alarm {\n                        link-down;\n                    }\n                    warning low-light-warning {\n                        syslog;\n                    }\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-EDGE-INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                description ********GR-EDGE-INTF-SETTINGS-APPLIED-ADD-DESCRIPTION********;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                traps;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                mtu </span><span style=\"color:#79C0FF\">9102</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hold-time up </span><span style=\"color:#79C0FF\">180000</span><span style=\"color:#E6EDF3\"> down </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            &#x3C;ae*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                aggregated-ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lacp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        accept-data;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        hold-time up </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            \"&#x3C;[egx][te]-*>\" {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                optics-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    alarm low-light-alarm {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        link-down;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    warning low-light-warning {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        syslog;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -16838,10 +16694,6 @@
         "Apply this group at the device level alongside GR-FATPW-LB."
       ],
       "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-fatpw-label.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-fatpw-label"
-        },
         {
           "raw": "junos/apply-groups/gr-fatpw-lb.conf",
           "id": "metro_ethernet_business_services/junos/apply-groups/gr-fatpw-lb"
@@ -16898,10 +16750,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/apply-groups/gr-fatpw-lb.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-fatpw-lb"
-        },
-        {
           "raw": "junos/apply-groups/gr-fatpw-label.conf",
           "id": "metro_ethernet_business_services/junos/apply-groups/gr-fatpw-label"
         }
@@ -16939,12 +16787,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-isis-bcp.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-isis-bcp"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "groups {\n    GR-ISIS-BCP {\n        protocols {\n            isis {\n                interface <ae*> {\n                    max-hello-size 9106;\n                    lsp-interval 10;\n                }\n                interface <et-*> {\n                    max-hello-size 9106;\n                    lsp-interval 10;\n                }\n                spf-options {\n                    delay 50;\n                    holddown 2000;\n                    rapid-runs 5;\n                }\n                overload {\n                    timeout 300;\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    GR-ISIS-BCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            isis {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;ae*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    max-hello-size </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface &#x3C;et-*> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    max-hello-size </span><span style=\"color:#79C0FF\">9106</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    lsp-interval </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                spf-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    delay </span><span style=\"color:#79C0FF\">50</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    holddown </span><span style=\"color:#79C0FF\">2000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    rapid-runs </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                overload {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    timeout </span><span style=\"color:#79C0FF\">300</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -16981,10 +16824,6 @@
         "On EVO (an3) the BFD timers are factored into a reusable"
       ],
       "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-isis-bfd.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-isis-bfd"
-        },
         {
           "raw": "junos/transport/isis-srmpls-tilfa.conf  (inline BFD example)",
           "id": null
@@ -17027,10 +16866,6 @@
         "This file is included for symmetry with evo/apply-groups/gr-l2ckt-hs.conf and to flag that the hot-standby pattern is NOT validated on Junos PEs in this JVD — use it as a reference template if you adopt L2Circuit hot-standby on a Junos box."
       ],
       "pairWith": [
-        {
-          "raw": "evo/apply-groups/gr-l2ckt-hs.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-l2ckt-hs"
-        },
         {
           "raw": "junos/services/l2circuit-hot-standby.conf",
           "id": "metro_ethernet_business_services/junos/services/l2circuit-hot-standby"
@@ -17084,10 +16919,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/apply-groups/gr-l3vpn.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-l3vpn"
-        },
-        {
           "raw": "junos/services/l3vpn-vrf.conf",
           "id": "metro_ethernet_business_services/junos/services/l3vpn-vrf"
         },
@@ -17138,10 +16969,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/apply-groups/gr-lag-member.conf",
-          "id": "metro_ethernet_business_services/evo/apply-groups/gr-lag-member"
-        },
-        {
           "raw": "junos/interfaces/lag-esi-multihoming.conf",
           "id": "metro_ethernet_business_services/junos/interfaces/lag-esi-multihoming"
         },
@@ -17191,12 +17018,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/cos/forwarding-classes.conf",
-          "id": "metro_ethernet_business_services/evo/cos/forwarding-classes"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "class-of-service {\n    forwarding-classes {\n        class BEST-EFFORT queue-num 0;\n        class BUSINESS queue-num 5;\n        class CONTROL queue-num 4;\n        class MEDIUM queue-num 1;\n        class REALTIME queue-num 2;\n        class SIG-OAM queue-num 3;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class BUSINESS queue-num </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class CONTROL queue-num </span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class MEDIUM queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class REALTIME queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        class SIG-OAM queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -17238,12 +17060,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/cos/schedulers.conf",
-          "id": "metro_ethernet_business_services/evo/cos/schedulers"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "class-of-service {\n    scheduler-maps {\n        5G_SCHEDULER {\n            forwarding-class BEST-EFFORT scheduler BEST-EFFORT-SC;\n            forwarding-class BUSINESS scheduler BUSINESS-SC;\n            forwarding-class CONTROL scheduler CONTROL-SC;\n            forwarding-class MEDIUM scheduler MEDIUM-SC;\n            forwarding-class REALTIME scheduler REALTIME-SC;\n            forwarding-class SIG-OAM scheduler SIG-OAM-SC;\n        }\n    }\n    schedulers {\n        BEST-EFFORT-SC {\n            transmit-rate {\n                remainder;\n            }\n            buffer-size {\n                remainder;\n            }\n            priority low;\n        }\n        BUSINESS-SC {\n            transmit-rate percent 20;\n            buffer-size percent 20;\n            priority low;\n        }\n        CONTROL-SC {\n            transmit-rate percent 5;\n            buffer-size percent 2;\n            priority low;\n        }\n        MEDIUM-SC {\n            transmit-rate percent 20;\n            buffer-size percent 20;\n            priority low;\n        }\n        REALTIME-SC {\n            transmit-rate percent 40;\n            buffer-size percent 30;\n            priority strict-high;\n        }\n        SIG-OAM-SC {\n            transmit-rate percent 5;\n            buffer-size percent 2;\n            priority low;\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">class-of-service {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    scheduler-maps {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        5G_SCHEDULER {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BEST-EFFORT scheduler BEST-EFFORT-SC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class BUSINESS scheduler BUSINESS-SC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class CONTROL scheduler CONTROL-SC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class MEDIUM scheduler MEDIUM-SC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class REALTIME scheduler REALTIME-SC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            forwarding-class SIG-OAM scheduler SIG-OAM-SC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        BEST-EFFORT-SC {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            transmit-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            buffer-size {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        BUSINESS-SC {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            transmit-rate percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        CONTROL-SC {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            transmit-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            buffer-size percent </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        MEDIUM-SC {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            transmit-rate percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        REALTIME-SC {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            transmit-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            buffer-size percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        SIG-OAM-SC {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            transmit-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            buffer-size percent </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -17288,12 +17105,7 @@
         ]
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/firewall/policers.conf",
-          "id": "metro_ethernet_business_services/evo/firewall/policers"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "firewall {\n    family any {\n        filter 50MB_filter {\n            interface-specific;\n            term t1 {\n                then policer 50mbps_policer;\n            }\n        }\n    }\n    policer 50mbps_policer {\n        if-exceeding {\n            bandwidth-limit 50m;\n            burst-size-limit 10m;\n        }\n        then discard;\n    }\n    policer 5mbps_policer {\n        if-exceeding {\n            bandwidth-limit 5m;\n            burst-size-limit 1m;\n        }\n        then discard;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family any {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter 50MB_filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term t1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then policer 50mbps_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policer 50mbps_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        if-exceeding {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bandwidth-limit 50m;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            burst-size-limit 10m;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policer 5mbps_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        if-exceeding {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bandwidth-limit 5m;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            burst-size-limit 1m;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
@@ -17325,12 +17137,7 @@
         "evo": []
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/interfaces/core-isis-mpls.conf",
-          "id": "metro_ethernet_business_services/evo/interfaces/core-isis-mpls"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$CORE_PHYS",
@@ -17399,10 +17206,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/interfaces/edge-vlan-normalization.conf",
-          "id": "metro_ethernet_business_services/evo/interfaces/edge-vlan-normalization"
-        },
-        {
           "raw": "junos/interfaces/lag-esi-multihoming.conf",
           "id": "metro_ethernet_business_services/junos/interfaces/lag-esi-multihoming"
         },
@@ -17462,12 +17265,7 @@
         ]
       },
       "highlights": [],
-      "pairWith": [
-        {
-          "raw": "evo/interfaces/lag-esi-multihoming.conf",
-          "id": "metro_ethernet_business_services/evo/interfaces/lag-esi-multihoming"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$AC_PHYS",
@@ -17522,12 +17320,7 @@
         "sla-iterator-profile 2WD-P3: two-way-delay measurements at 1 s cycle / 2 s iteration, weighting delay and delay-variation equally — feeds Bin-and-percentile stats for SLA reporting.",
         "One maintenance-domain MD_63535 at level 5 with one maintenance-association per attachment-circuit unit. Each MEP has remote-mep entries pointing at the far-end MEPs on the peer PEs (1002 and 1006 here)."
       ],
-      "pairWith": [
-        {
-          "raw": "evo/oam/oam-cfm-perf-mon.conf",
-          "id": "metro_ethernet_business_services/evo/oam/oam-cfm-perf-mon"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$MD_NAME",
@@ -17601,10 +17394,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/policy/communities.conf",
-          "id": "metro_ethernet_business_services/evo/policy/communities"
-        },
-        {
           "raw": "junos/policy/l3vpn-export-import.conf",
           "id": "metro_ethernet_business_services/junos/policy/l3vpn-export-import"
         },
@@ -17659,10 +17448,6 @@
         "Each VRF has its own pair of policies; the per-VPN RT community name matches the routing-instance name (DRY pattern)."
       ],
       "pairWith": [
-        {
-          "raw": "evo/policy/l3vpn-export-import.conf",
-          "id": "metro_ethernet_business_services/evo/policy/l3vpn-export-import"
-        },
         {
           "raw": "junos/policy/communities.conf",
           "id": "metro_ethernet_business_services/junos/policy/communities"
@@ -17731,10 +17516,6 @@
         "The JVD does NOT deploy LDP-VPLS on Junos PEs (no `vpls-id` + `neighbor` static config exists in any Junos conf/*.conf), nor does it deploy LDP-VPLS with BGP auto-discovery (no `l2vpn-id` form). For pure LDP-VPLS see the EVO snip."
       ],
       "pairWith": [
-        {
-          "raw": "evo/services/ldp-vpls.conf  (LDP-VPLS sibling pattern, EVO only)",
-          "id": null
-        },
         {
           "raw": "junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)",
           "id": null
@@ -17819,16 +17600,16 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/services/evpn-elan-mac-vrf-irb.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-elan-mac-vrf-irb"
-        },
-        {
           "raw": "junos/services/evpn-elan-mac-vrf.conf",
           "id": "metro_ethernet_business_services/junos/services/evpn-elan-mac-vrf"
         },
         {
           "raw": "junos/services/l3vpn-vrf.conf",
           "id": "metro_ethernet_business_services/junos/services/l3vpn-vrf"
+        },
+        {
+          "raw": "junos/services/evpn-type5.conf  (IRB co-occurrence)",
+          "id": null
         }
       ],
       "variables": [
@@ -17895,14 +17676,14 @@
       "path": "service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf.conf",
       "topic": "EVPN-ELAN (mac-vrf) routing-instance (MEF E-LAN)",
       "seenOn": {
-        "junos": [],
-        "evo": [
-          "an3_acx7100-48l",
-          "ma1-1_acx7024",
-          "ma1-2_acx7024",
-          "meg1_acx7100-32c",
-          "meg2_acx7509"
-        ]
+        "junos": [
+          "an1_mx204",
+          "ma4_mx204",
+          "ma5_mx204",
+          "mse1_mx304",
+          "mse2_mx304"
+        ],
+        "evo": []
       },
       "highlights": [
         "instance-type evpn (mac-vrf style for EVPN-ELAN)",
@@ -17920,10 +17701,6 @@
         {
           "raw": "junos/interfaces/lag-esi-multihoming.conf",
           "id": "metro_ethernet_business_services/junos/interfaces/lag-esi-multihoming"
-        },
-        {
-          "raw": "evo/services/evpn-elan-mac-vrf.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-elan-mac-vrf"
         }
       ],
       "variables": [
@@ -17993,10 +17770,6 @@
         "Junos syntax for the same pair is shown below as a reference. The JVD does NOT validate this on MX — Junos PEs in the JVD use VLAN-tagged (vlan-ccc) ACs everywhere."
       ],
       "pairWith": [
-        {
-          "raw": "evo/services/evpn-port-based.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-port-based"
-        },
         {
           "raw": "junos/services/evpn-vpws.conf  (vlan-tagged variant, validated)",
           "id": null
@@ -18089,10 +17862,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/services/evpn-type5.conf  (EVO end of the same VRF)",
-          "id": null
-        },
-        {
           "raw": "For the L2 / IRB side that owns irb.<N>:",
           "id": null
         },
@@ -18106,6 +17875,10 @@
         },
         {
           "raw": "junos/transport/bgp-overlay.conf  (family evpn signaling)",
+          "id": null
+        },
+        {
+          "raw": "junos/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)",
           "id": null
         }
       ],
@@ -18183,10 +17956,6 @@
         {
           "raw": "junos/interfaces/lag-esi-multihoming.conf",
           "id": "metro_ethernet_business_services/junos/interfaces/lag-esi-multihoming"
-        },
-        {
-          "raw": "evo/services/evpn-vpws.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-vpws"
         }
       ],
       "variables": [
@@ -18261,10 +18030,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/services/l2circuit-hot-standby.conf",
-          "id": "metro_ethernet_business_services/evo/services/l2circuit-hot-standby"
-        },
-        {
           "raw": "junos/apply-groups/gr-l2ckt-hs.conf  (reference apply-group shape)",
           "id": null
         }
@@ -18328,10 +18093,6 @@
         "The matching attachment-circuit is xe-0/1/2.0 (a port-mode unit, not vlan-tagged)."
       ],
       "pairWith": [
-        {
-          "raw": "evo/services/l2vpn-kompella.conf  (remote PE end)",
-          "id": null
-        },
         {
           "raw": "junos/apply-groups/gr-fatpw-label.conf  (FAT-PW for L2VPN)",
           "id": null
@@ -18412,10 +18173,6 @@
         "vrf-import / vrf-export point at the per-VRF policies in junos/policy/l3vpn-export-import.conf."
       ],
       "pairWith": [
-        {
-          "raw": "evo/services/l3vpn-vrf.conf  (EVO end of the same VRF)",
-          "id": null
-        },
         {
           "raw": "junos/apply-groups/gr-l3vpn.conf",
           "id": "metro_ethernet_business_services/junos/apply-groups/gr-l3vpn"
@@ -18510,12 +18267,7 @@
         "graceful-restart + multipath",
         "BCP knobs inherited from apply-groups GR-BGP-BCP"
       ],
-      "pairWith": [
-        {
-          "raw": "evo/transport/bgp-overlay.conf",
-          "id": "metro_ethernet_business_services/evo/transport/bgp-overlay"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$LOOPBACK_V4",
@@ -18590,12 +18342,7 @@
         "BFD on family inet (100ms x 3) for sub-50ms link-failure detection",
         "Inherits BCP knobs from apply-groups GR-ISIS-BCP"
       ],
-      "pairWith": [
-        {
-          "raw": "evo/transport/isis-srmpls-tilfa.conf",
-          "id": "metro_ethernet_business_services/evo/transport/isis-srmpls-tilfa"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$CORE_INTF_1",
@@ -18671,12 +18418,7 @@
         "icmp-tunneling for traceroute through MPLS",
         "ipv6-tunneling enables 6PE over the SR-MPLS underlay"
       ],
-      "pairWith": [
-        {
-          "raw": "evo/transport/mpls-segment-routing.conf",
-          "id": "metro_ethernet_business_services/evo/transport/mpls-segment-routing"
-        }
-      ],
+      "pairWith": [],
       "variables": [],
       "body": "protocols {\n    mpls {\n        admin-groups {\n            blue 1;\n            green 2;\n            red 3;\n        }\n        no-propagate-ttl;\n        icmp-tunneling;\n        label-range {\n            srgb-label-range 16000 24000;\n        }\n        ipv6-tunneling;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        admin-groups {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            blue </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            green </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            red </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        no-propagate-ttl;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        icmp-tunneling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        label-range {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            srgb-label-range </span><span style=\"color:#79C0FF\">16000</span><span style=\"color:#79C0FF\"> 24000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ipv6-tunneling;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/MANIFEST.json
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/MANIFEST.json
@@ -14,7 +14,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 1364,
+      "size_bytes": 1323,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-bgp-bcp.conf"
     },
     {
@@ -27,7 +27,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 1940,
+      "size_bytes": 1897,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-core-intf.conf"
     },
     {
@@ -41,7 +41,7 @@
         "ma1-1_acx7024",
         "ma1-2_acx7024"
       ],
-      "size_bytes": 1290,
+      "size_bytes": 1244,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-edge-intf-mh.conf"
     },
     {
@@ -54,7 +54,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 2117,
+      "size_bytes": 2054,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-edge-intf.conf"
     },
     {
@@ -73,7 +73,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2980,
+      "size_bytes": 2935,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-fatpw-label.conf"
     },
     {
@@ -92,7 +92,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 836,
+      "size_bytes": 794,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-fatpw-lb.conf"
     },
     {
@@ -105,7 +105,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 1684,
+      "size_bytes": 1642,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-isis-bcp.conf"
     },
     {
@@ -115,7 +115,7 @@
       "name": "gr-isis-bfd",
       "topic": "",
       "seen_on": [],
-      "size_bytes": 1409,
+      "size_bytes": 1367,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-isis-bfd.conf"
     },
     {
@@ -127,7 +127,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1123,
+      "size_bytes": 1081,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-l2ckt-hs.conf"
     },
     {
@@ -145,7 +145,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1122,
+      "size_bytes": 1083,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-l3vpn.conf"
     },
     {
@@ -155,7 +155,7 @@
       "name": "gr-lag-member",
       "topic": "",
       "seen_on": [],
-      "size_bytes": 2276,
+      "size_bytes": 2232,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-lag-member.conf"
     },
     {
@@ -168,7 +168,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 3462,
+      "size_bytes": 3422,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/cos/forwarding-classes.conf"
     },
     {
@@ -181,7 +181,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 2256,
+      "size_bytes": 2224,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/cos/schedulers.conf"
     },
     {
@@ -194,7 +194,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 1529,
+      "size_bytes": 1494,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/firewall/policers.conf"
     },
     {
@@ -207,7 +207,7 @@
         "an1_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 2242,
+      "size_bytes": 2199,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/core-isis-mpls.conf"
     },
     {
@@ -219,7 +219,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2206,
+      "size_bytes": 2154,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf"
     },
     {
@@ -239,7 +239,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2493,
+      "size_bytes": 2445,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/lag-esi-multihoming.conf"
     },
     {
@@ -256,7 +256,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2944,
+      "size_bytes": 2906,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/oam/oam-cfm-perf-mon.conf"
     },
     {
@@ -266,7 +266,7 @@
       "name": "communities",
       "topic": "Communities \u2014 transport-class colors and L3VPN service tags",
       "seen_on": [],
-      "size_bytes": 2434,
+      "size_bytes": 2398,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/communities.conf"
     },
     {
@@ -284,7 +284,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2204,
+      "size_bytes": 2160,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf"
     },
     {
@@ -299,7 +299,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1918,
+      "size_bytes": 1981,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf"
     },
     {
@@ -315,7 +315,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2260,
+      "size_bytes": 2181,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf.conf"
     },
     {
@@ -331,7 +331,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2322,
+      "size_bytes": 2280,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf"
     },
     {
@@ -347,7 +347,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2576,
+      "size_bytes": 2565,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5.conf"
     },
     {
@@ -369,7 +369,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1886,
+      "size_bytes": 1947,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-vpws.conf"
     },
     {
@@ -381,7 +381,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1874,
+      "size_bytes": 1826,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l2circuit-hot-standby.conf"
     },
     {
@@ -394,7 +394,7 @@
         "ma5_mx204",
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1611,
+      "size_bytes": 1506,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l2vpn-kompella.conf"
     },
     {
@@ -412,7 +412,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2110,
+      "size_bytes": 2017,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-vrf.conf"
     },
     {
@@ -424,7 +424,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1460,
+      "size_bytes": 1385,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/ldp-vpls.conf"
     },
     {
@@ -443,7 +443,7 @@
         "mse2_mx304",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 3610,
+      "size_bytes": 3571,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/bgp-overlay.conf"
     },
     {
@@ -464,7 +464,7 @@
         "mse2_mx304",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 3482,
+      "size_bytes": 3437,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/isis-srmpls-tilfa.conf"
     },
     {
@@ -485,7 +485,7 @@
         "mse2_mx304",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 1269,
+      "size_bytes": 1221,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/mpls-segment-routing.conf"
     },
     {
@@ -497,7 +497,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 939,
+      "size_bytes": 900,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-bgp-bcp.conf"
     },
     {
@@ -509,7 +509,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 1567,
+      "size_bytes": 1526,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-core-intf.conf"
     },
     {
@@ -521,7 +521,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 941,
+      "size_bytes": 897,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-edge-intf-mh.conf"
     },
     {
@@ -533,7 +533,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 1705,
+      "size_bytes": 1664,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-edge-intf.conf"
     },
     {
@@ -552,7 +552,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1954,
+      "size_bytes": 1911,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-fatpw-label.conf"
     },
     {
@@ -571,7 +571,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1222,
+      "size_bytes": 1182,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-fatpw-lb.conf"
     },
     {
@@ -583,7 +583,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 1195,
+      "size_bytes": 1155,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-isis-bcp.conf"
     },
     {
@@ -595,7 +595,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2428,
+      "size_bytes": 2388,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-isis-bfd.conf"
     },
     {
@@ -607,7 +607,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1577,
+      "size_bytes": 1537,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-l2ckt-hs.conf"
     },
     {
@@ -625,7 +625,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1686,
+      "size_bytes": 1649,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-l3vpn.conf"
     },
     {
@@ -638,7 +638,7 @@
         "ma5_mx204",
         "ma1-1_acx7024"
       ],
-      "size_bytes": 2544,
+      "size_bytes": 2502,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-lag-member.conf"
     },
     {
@@ -658,7 +658,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 1030,
+      "size_bytes": 992,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/cos/forwarding-classes.conf"
     },
     {
@@ -678,7 +678,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2472,
+      "size_bytes": 2442,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/cos/schedulers.conf"
     },
     {
@@ -700,7 +700,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1211,
+      "size_bytes": 1178,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/firewall/policers.conf"
     },
     {
@@ -710,7 +710,7 @@
       "name": "core-isis-mpls",
       "topic": "Core-facing LAG (ISIS + MPLS underlay attachment)",
       "seen_on": [],
-      "size_bytes": 1266,
+      "size_bytes": 1225,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/core-isis-mpls.conf"
     },
     {
@@ -732,7 +732,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2605,
+      "size_bytes": 2555,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/edge-vlan-normalization.conf"
     },
     {
@@ -752,7 +752,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2359,
+      "size_bytes": 2313,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/lag-esi-multihoming.conf"
     },
     {
@@ -769,7 +769,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 3205,
+      "size_bytes": 3169,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/oam/oam-cfm-perf-mon.conf"
     },
     {
@@ -787,7 +787,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2613,
+      "size_bytes": 2579,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/communities.conf"
     },
     {
@@ -805,7 +805,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2829,
+      "size_bytes": 2787,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf"
     },
     {
@@ -819,7 +819,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2663,
+      "size_bytes": 2592,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf"
     },
     {
@@ -834,7 +834,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2259,
+      "size_bytes": 2271,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf-irb.conf"
     },
     {
@@ -844,13 +844,13 @@
       "name": "evpn-elan-mac-vrf",
       "topic": "EVPN-ELAN (mac-vrf) routing-instance (MEF E-LAN)",
       "seen_on": [
-        "an3_acx7100-48l",
-        "ma1-1_acx7024",
-        "ma1-2_acx7024",
-        "meg1_acx7100-32c",
-        "meg2_acx7509"
+        "an1_mx204",
+        "ma4_mx204",
+        "ma5_mx204",
+        "mse1_mx304",
+        "mse2_mx304"
       ],
-      "size_bytes": 1626,
+      "size_bytes": 1627,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf.conf"
     },
     {
@@ -866,7 +866,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2517,
+      "size_bytes": 2477,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf"
     },
     {
@@ -882,7 +882,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2866,
+      "size_bytes": 2813,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5.conf"
     },
     {
@@ -904,7 +904,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1677,
+      "size_bytes": 1643,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-vpws.conf"
     },
     {
@@ -916,7 +916,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1773,
+      "size_bytes": 1727,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-hot-standby.conf"
     },
     {
@@ -929,7 +929,7 @@
         "ma5_mx204",
         "an3_acx7100-48l"
       ],
-      "size_bytes": 1911,
+      "size_bytes": 1855,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2vpn-kompella.conf"
     },
     {
@@ -947,7 +947,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2437,
+      "size_bytes": 2376,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-vrf.conf"
     },
     {
@@ -971,7 +971,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 3233,
+      "size_bytes": 3196,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/bgp-overlay.conf"
     },
     {
@@ -1002,7 +1002,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 4085,
+      "size_bytes": 4042,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/isis-srmpls-tilfa.conf"
     },
     {
@@ -1033,7 +1033,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1130,
+      "size_bytes": 1084,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/mpls-segment-routing.conf"
     }
   ],

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md
@@ -22,7 +22,6 @@
  *  - tcp-mss 4096 — avoid fragmentation of long EVPN/L3VPN updates.
  *
  * Pair with:
- *  - junos/apply-groups/gr-bgp-bcp.conf
  *  - evo/transport/bgp-overlay.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
@@ -65,7 +64,6 @@ groups {
  *    a moment to come back) but no down-damp (let BFD/IGP withdraw).
  *
  * Pair with:
- *  - junos/apply-groups/gr-core-intf.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *  - evo/transport/mpls-segment-routing.conf
  *
@@ -127,7 +125,6 @@ groups {
  *    — see evo/interfaces/lag-esi-multihoming.conf
  *
  * Pair with:
- *  - junos/apply-groups/gr-edge-intf-mh.conf
  *  - evo/interfaces/lag-esi-multihoming.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
@@ -172,7 +169,6 @@ groups {
  *  - Optics low-light alarms tied to link-down for fast convergence.
  *
  * Pair with:
- *  - junos/apply-groups/gr-edge-intf.conf (Junos counterpart)
  *  - evo/apply-groups/gr-edge-intf-mh.conf (multihomed variant)
  *  - evo/apply-groups/gr-lag-member.conf
  *
@@ -237,7 +233,6 @@ groups {
  *   <EVPN_ELAN_PORT_*>   port-based EVPN-ELAN  flow-label + flow-label-static
  *
  * Pair with:
- *  - junos/apply-groups/gr-fatpw-label.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -326,7 +321,6 @@ groups {
  *   set apply-groups GR-FATPW-LB
  *
  * Pair with:
- *  - junos/apply-groups/gr-fatpw-lb.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -363,7 +357,6 @@ groups {
  *    converges.
  *
  * Pair with:
- *  - junos/apply-groups/gr-isis-bcp.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
@@ -416,7 +409,6 @@ groups {
  * detection that drives TI-LFA fast reroute.
  *
  * Pair with:
- *  - junos/apply-groups/gr-isis-bfd.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -468,7 +460,6 @@ groups {
  *   switchover-delay 0                          → switch immediately
  *
  * Pair with:
- *  - junos/apply-groups/gr-l2ckt-hs.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -509,7 +500,6 @@ groups {
  *  - vrf-table-label (single label per VRF for label-switched data plane)
  *
  * Pair with:
- *  - junos/apply-groups/gr-l3vpn.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -556,7 +546,6 @@ groups {
  *   set interfaces et-0/0/N apply-groups GR-EDGE-INTF-LAG-MEMBER
  *
  * Pair with:
- *  - junos/apply-groups/gr-lag-member.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -636,7 +625,6 @@ groups {
  *    pseudowires).
  *
  * Pair with:
- *  - junos/cos/forwarding-classes.conf
  *  - evo/cos/schedulers.conf
  *
  * Variables: none. All values here are JVD-wide constants
@@ -739,7 +727,6 @@ class-of-service {
  *    rest use transmit-rate (guarantee).
  *
  * Pair with:
- *  - junos/cos/schedulers.conf
  *  - evo/cos/forwarding-classes.conf
  *
  * Variables: none. All values here are JVD-wide constants
@@ -819,7 +806,6 @@ class-of-service {
  *    referencing these policers — same pattern as Junos.
  *
  * Pair with:
- *  - junos/firewall/policers.conf
  *  - evo/interfaces/edge-vlan-normalization.conf  (per-unit input filter ref)
  *
  * Variables: none. All values here are JVD-wide constants
@@ -864,7 +850,6 @@ firewall {
  *  - lo0.0 below carries the loopback address used by ISIS/iBGP.
  *
  * Pair with:
- *  - junos/interfaces/core-isis-mpls.conf
  *  - evo/apply-groups/gr-core-intf.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *
@@ -947,7 +932,6 @@ interfaces {
  * encapsulation, optics alarms) come from apply-groups GR-EDGE-INTF.
  *
  * Pair with:
- *  - junos/interfaces/edge-vlan-normalization.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_PHYS    e.g. et-0/0/0   (the parent port; the per-unit
@@ -1025,7 +1009,6 @@ interfaces {
  *    DF election handles convergence).
  *
  * Pair with:
- *  - junos/interfaces/lag-esi-multihoming.conf
  *  - evo/services/evpn-vpws.conf
  *  - evo/apply-groups/gr-edge-intf-mh.conf
  *
@@ -1102,7 +1085,6 @@ interfaces {
  * (e.g., et-0/0/0.2800) that is also the L2Circuit attachment-circuit.
  *
  * Pair with:
- *  - junos/oam/oam-cfm-perf-mon.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $MD_NAME         e.g. MD_63535
@@ -1192,7 +1174,6 @@ protocols {
  *      CM-NO-ADVERTISE  — built-in well-known to suppress propagation
  *
  * Pair with:
- *  - junos/policy/communities.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,
@@ -1242,7 +1223,6 @@ policy-options {
  * single example is enough to understand the per-service template.
  *
  * Pair with:
- *  - junos/policy/l3vpn-export-import.conf
  *
  * Variables (example values from an3_acx7100-48l / METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101
@@ -1310,7 +1290,8 @@ policy-options {
  *    and the matching irb.4000 unit for L2/L3 gateway service
  *
  * Pair with:
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
+ *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
+ *  - evo/services/evpn-vpws.conf  (IRB co-occurrence)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $INSTANCE_NAME   e.g. evpn_group_60_4000
@@ -1373,7 +1354,6 @@ routing-instances {
  *    legacy receivers; full ELAN service still works).
  *
  * Pair with:
- *  - junos/services/evpn-elan-mac-vrf.conf  (Junos MX virtual-switch flavour)
  *  - evo/transport/bgp-overlay.conf (family evpn signaling)
  *  - evo/interfaces/lag-esi-multihoming.conf
  *
@@ -1440,7 +1420,6 @@ routing-instances {
  * matching flow-label knobs on these naming patterns.
  *
  * Pair with:
- *  - junos/services/evpn-port-based.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_INTF_VPWS         e.g. et-0/0/7.0
@@ -1518,13 +1497,13 @@ routing-instances {
  *    evo/policy/l3vpn-export-import.conf.
  *
  * Pair with:
- *  - junos/services/evpn-type5.conf  (Junos end of the same VRF)
  *  - evo/services/evpn-elan-mac-vrf-irb.conf  (the L2 / IRB side
  *    that owns irb.<N> — this is the bridge-domain whose MACs and
  *    silent-host IPs the Type-5 route exposes to remote PEs)
  *  - evo/apply-groups/gr-l3vpn.conf
  *  - evo/policy/l3vpn-export-import.conf
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
+ *  - evo/services/evpn-vpws.conf  (IRB co-occurrence)
  *
  * Variables (example values from an3_acx7100-48l / METRO_L3VPN_4000):
  *   $INSTANCE_NAME    e.g. METRO_L3VPN_4000
@@ -1579,9 +1558,10 @@ routing-instances {
  *    pseudowire end-to-end via EVPN Type-1 routes.
  *
  * Pair with:
- *  - junos/services/evpn-vpws.conf (remote single-homed end)
  *  - evo/interfaces/lag-esi-multihoming.conf (the AC interface)
  *  - evo/transport/bgp-overlay.conf (family evpn signaling)
+ *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
+ *  - evo/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)
  *
  * Variables (example values from ma1-1_acx7024):
  *   $INSTANCE_NAME       e.g. evpn_group_30_2400
@@ -1638,7 +1618,6 @@ routing-instances {
  *  - evo/apply-groups/gr-l2ckt-hs.conf (hot-standby knobs)
  *  - evo/apply-groups/gr-fatpw-lb.conf (forwarding-options)
  *  - evo/policy/communities.conf (CM-TC-MAP2GOLD definition)
- *  - junos/services/l2circuit-hot-standby.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $REMOTE_PE_V4    e.g. 1.1.0.6
@@ -1688,9 +1667,7 @@ protocols {
  *  - vrf-target establishes the BGP route-target community for the L2VPN
  *
  * Pair with:
- *  - junos/transport/bgp-overlay.conf (family l2vpn signaling)
  *  - evo/apply-groups/gr-fatpw-label.conf (matches L2VPN_PORT_BASED)
- *  - junos/services/l2vpn-kompella.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $L2VPN_SITE              e.g. r2
@@ -1745,8 +1722,6 @@ routing-instances {
  * Pair with:
  *  - evo/apply-groups/gr-l3vpn.conf
  *  - evo/policy/l3vpn-export-import.conf
- *  - junos/transport/bgp-overlay.conf (family inet-vpn)
- *  - junos/services/l3vpn-vrf.conf
  *
  * Variables (example values from an3_acx7100-48l / instance METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101
@@ -1811,7 +1786,6 @@ routing-instances {
  * (see KB-VPLS-TEST in the source file for that variant).
  *
  * Pair with:
- *  - junos/services/bgp-vpls.conf  (BGP-VPLS sibling pattern, Junos only)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $INSTANCE_NAME    e.g. KB-VPLS-EPL
@@ -1865,7 +1839,6 @@ routing-instances {
  *    box is also a service PE.
  *
  * Pair with:
- *  - junos/transport/bgp-overlay.conf
  *  - evo/apply-groups/gr-bgp-bcp.conf
  *
  * Variables (example values from ma1-1_acx7024):
@@ -1986,7 +1959,6 @@ protocols {
  *    failure detection that triggers TI-LFA.
  *
  * Pair with:
- *  - junos/transport/isis-srmpls-tilfa.conf
  *  - evo/transport/mpls-segment-routing.conf
  *  - evo/apply-groups/gr-isis-bcp.conf
  *
@@ -2087,7 +2059,6 @@ protocols {
  *  - icmp-tunneling preserves end-to-end traceroute through MPLS.
  *
  * Pair with:
- *  - junos/transport/mpls-segment-routing.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *
  * Variables: none. All values here (admin-group numbers, SRGB range)
@@ -2126,7 +2097,6 @@ protocols {
  *  - tcp-mss aligned with jumbo MTU
  *
  * Pair with:
- *  - evo/apply-groups/gr-bgp-bcp.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -2164,7 +2134,6 @@ groups {
  *  - LACP active for aggregated members
  *
  * Pair with:
- *  - evo/apply-groups/gr-core-intf.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -2219,7 +2188,6 @@ groups {
  * hold-time configured — managed via ESI/EVPN convergence instead).
  *
  * Pair with:
- *  - evo/apply-groups/gr-edge-intf-mh.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -2258,7 +2226,6 @@ groups {
  * Apply with:   set interfaces et-0/0/0 apply-groups GR-EDGE-INTF
  *
  * Pair with:
- *  - evo/apply-groups/gr-edge-intf.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -2322,7 +2289,6 @@ groups {
  *  - Apply this group at the device level alongside GR-FATPW-LB.
  *
  * Pair with:
- *  - evo/apply-groups/gr-fatpw-label.conf
  *  - junos/apply-groups/gr-fatpw-lb.conf
  *  - junos/services/l2vpn-kompella.conf
  *
@@ -2384,7 +2350,6 @@ groups {
  *    knob) — see junos/apply-groups/gr-fatpw-label.conf.
  *
  * Pair with:
- *  - evo/apply-groups/gr-fatpw-lb.conf
  *  - junos/apply-groups/gr-fatpw-label.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
@@ -2415,7 +2380,6 @@ groups {
  * overload-on-startup behaviour for graceful insertion.
  *
  * Pair with:
- *  - evo/apply-groups/gr-isis-bcp.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry
@@ -2476,7 +2440,6 @@ groups {
  *    used on EVO and the Junos equivalent inline pattern.
  *
  * Pair with:
- *  - evo/apply-groups/gr-isis-bfd.conf
  *  - junos/transport/isis-srmpls-tilfa.conf  (inline BFD example)
  *
  * Variables: none. Apply-groups in this JVD are entirely
@@ -2539,7 +2502,6 @@ groups {
  *    hot-standby on a Junos box.
  *
  * Pair with:
- *  - evo/apply-groups/gr-l2ckt-hs.conf
  *  - junos/services/l2circuit-hot-standby.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
@@ -2588,7 +2550,6 @@ groups {
  *    can do egress L3 lookup (required for IRB / firewall/NAT in VRF).
  *
  * Pair with:
- *  - evo/apply-groups/gr-l3vpn.conf
  *  - junos/services/l3vpn-vrf.conf
  *  - junos/policy/l3vpn-export-import.conf
  *
@@ -2637,7 +2598,6 @@ groups {
  *  - Identical to evo/apply-groups/gr-lag-member.conf.
  *
  * Pair with:
- *  - evo/apply-groups/gr-lag-member.conf
  *  - junos/interfaces/lag-esi-multihoming.conf
  *  - junos/interfaces/core-isis-mpls.conf
  *
@@ -2720,7 +2680,6 @@ groups {
  * scheduler-map and per-class scheduler definitions.
  *
  * Pair with:
- *  - evo/cos/forwarding-classes.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,
@@ -2763,7 +2722,6 @@ class-of-service {
  *   set class-of-service interfaces <name> scheduler-map 5G_SCHEDULER
  *
  * Pair with:
- *  - evo/cos/schedulers.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,
@@ -2835,7 +2793,6 @@ class-of-service {
  *   set interfaces <ifd> unit <unit> family any filter input 50MB_filter
  *
  * Pair with:
- *  - evo/firewall/policers.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,
@@ -2884,7 +2841,6 @@ firewall {
  * (see apply-groups/gr-core-intf).
  *
  * Pair with:
- *  - evo/interfaces/core-isis-mpls.conf
  *
  * Variables (example values from an1_mx204):
  *   $CORE_PHYS         e.g. ae71
@@ -2944,7 +2900,6 @@ interfaces {
  *    flexible-vlan-tagging) is in junos/interfaces/lag-esi-multihoming.conf.
  *
  * Pair with:
- *  - evo/interfaces/edge-vlan-normalization.conf
  *  - junos/interfaces/lag-esi-multihoming.conf
  *  - junos/services/evpn-vpws.conf  (vlan-ccc units)
  *  - junos/services/evpn-elan-mac-vrf.conf  (vlan-bridge units)
@@ -3023,7 +2978,6 @@ interfaces {
  * apply-groups GR-EDGE-INTF-MH (see apply-groups/gr-edge-intf-mh).
  *
  * Pair with:
- *  - evo/interfaces/lag-esi-multihoming.conf
  *
  * Variables (example values from an1_mx204):
  *   $AC_PHYS         e.g. ae11   (the multihomed AE)
@@ -3101,7 +3055,6 @@ interfaces {
  *    the peer PEs (1002 and 1006 here).
  *
  * Pair with:
- *  - evo/oam/oam-cfm-perf-mon.conf
  *
  * Variables (example values from an4_acx710):
  *   $MD_NAME         e.g. MD_63535
@@ -3194,7 +3147,6 @@ protocols {
  *    leak-prevention.
  *
  * Pair with:
- *  - evo/policy/communities.conf
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/services/l3vpn-vrf.conf
  *
@@ -3252,7 +3204,6 @@ policy-options {
  *    name matches the routing-instance name (DRY pattern).
  *
  * Pair with:
- *  - evo/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/services/l3vpn-vrf.conf
  *
@@ -3332,7 +3283,6 @@ policy-options {
  *    `l2vpn-id` form). For pure LDP-VPLS see the EVO snip.
  *
  * Pair with:
- *  - evo/services/ldp-vpls.conf  (LDP-VPLS sibling pattern, EVO only)
  *  - junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *
@@ -3403,9 +3353,9 @@ routing-instances {
  *    you have a reason to converge.
  *
  * Pair with:
- *  - evo/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/services/evpn-elan-mac-vrf.conf
  *  - junos/services/l3vpn-vrf.conf
+ *  - junos/services/evpn-type5.conf  (IRB co-occurrence)
  *
  * Variables (illustrative — not deployed on Junos in this JVD):
  *   $INSTANCE_NAME   e.g. evpn_group_60_4000
@@ -3450,8 +3400,8 @@ routing-instances {
 /*
  * Topic:   EVPN-ELAN (mac-vrf) routing-instance (MEF E-LAN)
  * Seen on:
- *   Junos: —
- *   EVO:   an3_acx7100-48l ma1-1_acx7024 ma1-2_acx7024 meg1_acx7100-32c meg2_acx7509
+ *   Junos: an1_mx204 ma4_mx204 ma5_mx204 mse1_mx304 mse2_mx304
+ *   EVO:   (none — EVO uses mac-vrf; see evo/services/evpn-elan-mac-vrf.conf)
  *
  * Highlights:
  *  - instance-type evpn (mac-vrf style for EVPN-ELAN)
@@ -3467,7 +3417,6 @@ routing-instances {
  * Pair with:
  *  - junos/transport/bgp-overlay.conf (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf
- *  - evo/services/evpn-elan-mac-vrf.conf
  *
  * Variables (example values from an1_mx204):
  *   $INSTANCE_NAME   e.g. evpn_group_90_700
@@ -3521,7 +3470,6 @@ routing-instances {
  *    use VLAN-tagged (vlan-ccc) ACs everywhere.
  *
  * Pair with:
- *  - evo/services/evpn-port-based.conf
  *  - junos/services/evpn-vpws.conf  (vlan-tagged variant, validated)
  *
  * Variables (illustrative — not deployed on Junos in this JVD):
@@ -3602,15 +3550,14 @@ routing-instances {
  *    families separate.
  *
  * Pair with:
- *  - evo/services/evpn-type5.conf  (EVO end of the same VRF)
  *  - For the L2 / IRB side that owns irb.<N>:
- *      evo/services/evpn-elan-mac-vrf-irb.conf  (EVO mate)
  *      Junos virtual-switch + bridge-domains + routing-interface
  *      (no dedicated snip yet — see deployed pattern in
  *       service_provider/.../conf/mse1_mx304.conf).
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
+ *  - junos/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)
  *
  * Variables (example values from mse1_mx304 / METRO_L3VPN_4000):
  *   $INSTANCE_NAME    e.g. METRO_L3VPN_4000
@@ -3665,7 +3612,6 @@ routing-instances {
  * Pair with:
  *  - junos/transport/bgp-overlay.conf (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf
- *  - evo/services/evpn-vpws.conf
  *
  * Variables (example values from an1_mx204):
  *   $INSTANCE_NAME       e.g. evpn_group_30_2400
@@ -3720,7 +3666,6 @@ routing-instances {
  *    evo/services/l2circuit-hot-standby.conf.
  *
  * Pair with:
- *  - evo/services/l2circuit-hot-standby.conf
  *  - junos/apply-groups/gr-l2ckt-hs.conf  (reference apply-group shape)
  *
  * Variables (illustrative — not deployed on Junos in this JVD):
@@ -3770,7 +3715,6 @@ protocols {
  *    not vlan-tagged).
  *
  * Pair with:
- *  - evo/services/l2vpn-kompella.conf  (remote PE end)
  *  - junos/apply-groups/gr-fatpw-label.conf  (FAT-PW for L2VPN)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *
@@ -3829,7 +3773,6 @@ routing-instances {
  *    junos/policy/l3vpn-export-import.conf.
  *
  * Pair with:
- *  - evo/services/l3vpn-vrf.conf  (EVO end of the same VRF)
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
@@ -3901,7 +3844,6 @@ routing-instances {
  *  - BCP knobs inherited from apply-groups GR-BGP-BCP
  *
  * Pair with:
- *  - evo/transport/bgp-overlay.conf
  *
  * Variables (example values from an1_mx204):
  *   $LOOPBACK_V4   e.g. 1.1.0.0
@@ -4001,7 +3943,6 @@ protocols {
  *  - Inherits BCP knobs from apply-groups GR-ISIS-BCP
  *
  * Pair with:
- *  - evo/transport/isis-srmpls-tilfa.conf
  *
  * Variables (example values from an1_mx204):
  *   $CORE_INTF_1   e.g. ae71.0   (one stanza per core neighbour;
@@ -4125,7 +4066,6 @@ protocols {
  *  - ipv6-tunneling enables 6PE over the SR-MPLS underlay
  *
  * Pair with:
- *  - evo/transport/mpls-segment-routing.conf
  *
  * Variables: none. All values here (admin-group numbers, SRGB range)
  * are JVD-wide constants — same on every PE.

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-bgp-bcp.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-bgp-bcp.conf
@@ -17,7 +17,6 @@
  *  - tcp-mss 4096 — avoid fragmentation of long EVPN/L3VPN updates.
  *
  * Pair with:
- *  - junos/apply-groups/gr-bgp-bcp.conf
  *  - evo/transport/bgp-overlay.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-core-intf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-core-intf.conf
@@ -15,7 +15,6 @@
  *    a moment to come back) but no down-damp (let BFD/IGP withdraw).
  *
  * Pair with:
- *  - junos/apply-groups/gr-core-intf.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *  - evo/transport/mpls-segment-routing.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-edge-intf-mh.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-edge-intf-mh.conf
@@ -13,7 +13,6 @@
  *    — see evo/interfaces/lag-esi-multihoming.conf
  *
  * Pair with:
- *  - junos/apply-groups/gr-edge-intf-mh.conf
  *  - evo/interfaces/lag-esi-multihoming.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-edge-intf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-edge-intf.conf
@@ -17,7 +17,6 @@
  *  - Optics low-light alarms tied to link-down for fast convergence.
  *
  * Pair with:
- *  - junos/apply-groups/gr-edge-intf.conf (Junos counterpart)
  *  - evo/apply-groups/gr-edge-intf-mh.conf (multihomed variant)
  *  - evo/apply-groups/gr-lag-member.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-fatpw-label.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-fatpw-label.conf
@@ -17,7 +17,6 @@
  *   <EVPN_ELAN_PORT_*>   port-based EVPN-ELAN  flow-label + flow-label-static
  *
  * Pair with:
- *  - junos/apply-groups/gr-fatpw-label.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-fatpw-lb.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-fatpw-lb.conf
@@ -12,7 +12,6 @@
  *   set apply-groups GR-FATPW-LB
  *
  * Pair with:
- *  - junos/apply-groups/gr-fatpw-lb.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-isis-bcp.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-isis-bcp.conf
@@ -16,7 +16,6 @@
  *    converges.
  *
  * Pair with:
- *  - junos/apply-groups/gr-isis-bcp.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-isis-bfd.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-isis-bfd.conf
@@ -13,7 +13,6 @@
  * detection that drives TI-LFA fast reroute.
  *
  * Pair with:
- *  - junos/apply-groups/gr-isis-bfd.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-l2ckt-hs.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-l2ckt-hs.conf
@@ -12,7 +12,6 @@
  *   switchover-delay 0                          → switch immediately
  *
  * Pair with:
- *  - junos/apply-groups/gr-l2ckt-hs.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-l3vpn.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-l3vpn.conf
@@ -11,7 +11,6 @@
  *  - vrf-table-label (single label per VRF for label-switched data plane)
  *
  * Pair with:
- *  - junos/apply-groups/gr-l3vpn.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-lag-member.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/apply-groups/gr-lag-member.conf
@@ -17,7 +17,6 @@
  *   set interfaces et-0/0/N apply-groups GR-EDGE-INTF-LAG-MEMBER
  *
  * Pair with:
- *  - junos/apply-groups/gr-lag-member.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/cos/forwarding-classes.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/cos/forwarding-classes.conf
@@ -15,7 +15,6 @@
  *    pseudowires).
  *
  * Pair with:
- *  - junos/cos/forwarding-classes.conf
  *  - evo/cos/schedulers.conf
  *
  * Variables: none. All values here are JVD-wide constants

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/cos/schedulers.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/cos/schedulers.conf
@@ -14,7 +14,6 @@
  *    rest use transmit-rate (guarantee).
  *
  * Pair with:
- *  - junos/cos/schedulers.conf
  *  - evo/cos/forwarding-classes.conf
  *
  * Variables: none. All values here are JVD-wide constants

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/firewall/policers.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/firewall/policers.conf
@@ -18,7 +18,6 @@
  *    referencing these policers — same pattern as Junos.
  *
  * Pair with:
- *  - junos/firewall/policers.conf
  *  - evo/interfaces/edge-vlan-normalization.conf  (per-unit input filter ref)
  *
  * Variables: none. All values here are JVD-wide constants

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/core-isis-mpls.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/core-isis-mpls.conf
@@ -15,7 +15,6 @@
  *  - lo0.0 below carries the loopback address used by ISIS/iBGP.
  *
  * Pair with:
- *  - junos/interfaces/core-isis-mpls.conf
  *  - evo/apply-groups/gr-core-intf.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf
@@ -20,7 +20,6 @@
  * encapsulation, optics alarms) come from apply-groups GR-EDGE-INTF.
  *
  * Pair with:
- *  - junos/interfaces/edge-vlan-normalization.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_PHYS    e.g. et-0/0/0   (the parent port; the per-unit

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/lag-esi-multihoming.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/lag-esi-multihoming.conf
@@ -23,7 +23,6 @@
  *    DF election handles convergence).
  *
  * Pair with:
- *  - junos/interfaces/lag-esi-multihoming.conf
  *  - evo/services/evpn-vpws.conf
  *  - evo/apply-groups/gr-edge-intf-mh.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/oam/oam-cfm-perf-mon.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/oam/oam-cfm-perf-mon.conf
@@ -22,7 +22,6 @@
  * (e.g., et-0/0/0.2800) that is also the L2Circuit attachment-circuit.
  *
  * Pair with:
- *  - junos/oam/oam-cfm-perf-mon.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $MD_NAME         e.g. MD_63535

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/communities.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/communities.conf
@@ -29,7 +29,6 @@
  *      CM-NO-ADVERTISE  — built-in well-known to suppress propagation
  *
  * Pair with:
- *  - junos/policy/communities.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf
@@ -18,7 +18,6 @@
  * single example is enough to understand the per-service template.
  *
  * Pair with:
- *  - junos/policy/l3vpn-export-import.conf
  *
  * Variables (example values from an3_acx7100-48l / METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf
@@ -19,7 +19,8 @@
  *    and the matching irb.4000 unit for L2/L3 gateway service
  *
  * Pair with:
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
+ *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
+ *  - evo/services/evpn-vpws.conf  (IRB co-occurrence)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $INSTANCE_NAME   e.g. evpn_group_60_4000

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf.conf
@@ -20,7 +20,6 @@
  *    legacy receivers; full ELAN service still works).
  *
  * Pair with:
- *  - junos/services/evpn-elan-mac-vrf.conf  (Junos MX virtual-switch flavour)
  *  - evo/transport/bgp-overlay.conf (family evpn signaling)
  *  - evo/interfaces/lag-esi-multihoming.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf
@@ -23,7 +23,6 @@
  * matching flow-label knobs on these naming patterns.
  *
  * Pair with:
- *  - junos/services/evpn-port-based.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_INTF_VPWS         e.g. et-0/0/7.0

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5.conf
@@ -24,13 +24,13 @@
  *    evo/policy/l3vpn-export-import.conf.
  *
  * Pair with:
- *  - junos/services/evpn-type5.conf  (Junos end of the same VRF)
  *  - evo/services/evpn-elan-mac-vrf-irb.conf  (the L2 / IRB side
  *    that owns irb.<N> — this is the bridge-domain whose MACs and
  *    silent-host IPs the Type-5 route exposes to remote PEs)
  *  - evo/apply-groups/gr-l3vpn.conf
  *  - evo/policy/l3vpn-export-import.conf
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
+ *  - evo/services/evpn-vpws.conf  (IRB co-occurrence)
  *
  * Variables (example values from an3_acx7100-48l / METRO_L3VPN_4000):
  *   $INSTANCE_NAME    e.g. METRO_L3VPN_4000

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-vpws.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-vpws.conf
@@ -16,9 +16,10 @@
  *    pseudowire end-to-end via EVPN Type-1 routes.
  *
  * Pair with:
- *  - junos/services/evpn-vpws.conf (remote single-homed end)
  *  - evo/interfaces/lag-esi-multihoming.conf (the AC interface)
  *  - evo/transport/bgp-overlay.conf (family evpn signaling)
+ *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
+ *  - evo/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)
  *
  * Variables (example values from ma1-1_acx7024):
  *   $INSTANCE_NAME       e.g. evpn_group_30_2400

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l2circuit-hot-standby.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l2circuit-hot-standby.conf
@@ -20,7 +20,6 @@
  *  - evo/apply-groups/gr-l2ckt-hs.conf (hot-standby knobs)
  *  - evo/apply-groups/gr-fatpw-lb.conf (forwarding-options)
  *  - evo/policy/communities.conf (CM-TC-MAP2GOLD definition)
- *  - junos/services/l2circuit-hot-standby.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $REMOTE_PE_V4    e.g. 1.1.0.6

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l2vpn-kompella.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l2vpn-kompella.conf
@@ -13,9 +13,7 @@
  *  - vrf-target establishes the BGP route-target community for the L2VPN
  *
  * Pair with:
- *  - junos/transport/bgp-overlay.conf (family l2vpn signaling)
  *  - evo/apply-groups/gr-fatpw-label.conf (matches L2VPN_PORT_BASED)
- *  - junos/services/l2vpn-kompella.conf
  *
  * Variables (example values from an3_acx7100-48l):
  *   $L2VPN_SITE              e.g. r2

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-vrf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-vrf.conf
@@ -18,8 +18,6 @@
  * Pair with:
  *  - evo/apply-groups/gr-l3vpn.conf
  *  - evo/policy/l3vpn-export-import.conf
- *  - junos/transport/bgp-overlay.conf (family inet-vpn)
- *  - junos/services/l3vpn-vrf.conf
  *
  * Variables (example values from an3_acx7100-48l / instance METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/ldp-vpls.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/ldp-vpls.conf
@@ -18,7 +18,6 @@
  * (see KB-VPLS-TEST in the source file for that variant).
  *
  * Pair with:
- *  - junos/services/bgp-vpls.conf  (BGP-VPLS sibling pattern, Junos only)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $INSTANCE_NAME    e.g. KB-VPLS-EPL

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/bgp-overlay.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/bgp-overlay.conf
@@ -21,7 +21,6 @@
  *    box is also a service PE.
  *
  * Pair with:
- *  - junos/transport/bgp-overlay.conf
  *  - evo/apply-groups/gr-bgp-bcp.conf
  *
  * Variables (example values from ma1-1_acx7024):

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/isis-srmpls-tilfa.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/isis-srmpls-tilfa.conf
@@ -21,7 +21,6 @@
  *    failure detection that triggers TI-LFA.
  *
  * Pair with:
- *  - junos/transport/isis-srmpls-tilfa.conf
  *  - evo/transport/mpls-segment-routing.conf
  *  - evo/apply-groups/gr-isis-bcp.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/mpls-segment-routing.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/transport/mpls-segment-routing.conf
@@ -15,7 +15,6 @@
  *  - icmp-tunneling preserves end-to-end traceroute through MPLS.
  *
  * Pair with:
- *  - junos/transport/mpls-segment-routing.conf
  *  - evo/transport/isis-srmpls-tilfa.conf
  *
  * Variables: none. All values here (admin-group numbers, SRGB range)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-bgp-bcp.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-bgp-bcp.conf
@@ -11,7 +11,6 @@
  *  - tcp-mss aligned with jumbo MTU
  *
  * Pair with:
- *  - evo/apply-groups/gr-bgp-bcp.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-core-intf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-core-intf.conf
@@ -11,7 +11,6 @@
  *  - LACP active for aggregated members
  *
  * Pair with:
- *  - evo/apply-groups/gr-core-intf.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-edge-intf-mh.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-edge-intf-mh.conf
@@ -8,7 +8,6 @@
  * hold-time configured — managed via ESI/EVPN convergence instead).
  *
  * Pair with:
- *  - evo/apply-groups/gr-edge-intf-mh.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-edge-intf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-edge-intf.conf
@@ -12,7 +12,6 @@
  * Apply with:   set interfaces et-0/0/0 apply-groups GR-EDGE-INTF
  *
  * Pair with:
- *  - evo/apply-groups/gr-edge-intf.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-fatpw-label.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-fatpw-label.conf
@@ -17,7 +17,6 @@
  *  - Apply this group at the device level alongside GR-FATPW-LB.
  *
  * Pair with:
- *  - evo/apply-groups/gr-fatpw-label.conf
  *  - junos/apply-groups/gr-fatpw-lb.conf
  *  - junos/services/l2vpn-kompella.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-fatpw-lb.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-fatpw-lb.conf
@@ -16,7 +16,6 @@
  *    knob) — see junos/apply-groups/gr-fatpw-label.conf.
  *
  * Pair with:
- *  - evo/apply-groups/gr-fatpw-lb.conf
  *  - junos/apply-groups/gr-fatpw-label.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-isis-bcp.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-isis-bcp.conf
@@ -9,7 +9,6 @@
  * overload-on-startup behaviour for graceful insertion.
  *
  * Pair with:
- *  - evo/apply-groups/gr-isis-bcp.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely
  *            wildcard-driven (e.g. <ae*>, <METRO_*>) and carry

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-isis-bfd.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-isis-bfd.conf
@@ -23,7 +23,6 @@
  *    used on EVO and the Junos equivalent inline pattern.
  *
  * Pair with:
- *  - evo/apply-groups/gr-isis-bfd.conf
  *  - junos/transport/isis-srmpls-tilfa.conf  (inline BFD example)
  *
  * Variables: none. Apply-groups in this JVD are entirely

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-l2ckt-hs.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-l2ckt-hs.conf
@@ -18,7 +18,6 @@
  *    hot-standby on a Junos box.
  *
  * Pair with:
- *  - evo/apply-groups/gr-l2ckt-hs.conf
  *  - junos/services/l2circuit-hot-standby.conf
  *
  * Variables: none. Apply-groups in this JVD are entirely

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-l3vpn.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-l3vpn.conf
@@ -19,7 +19,6 @@
  *    can do egress L3 lookup (required for IRB / firewall/NAT in VRF).
  *
  * Pair with:
- *  - evo/apply-groups/gr-l3vpn.conf
  *  - junos/services/l3vpn-vrf.conf
  *  - junos/policy/l3vpn-export-import.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-lag-member.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/apply-groups/gr-lag-member.conf
@@ -17,7 +17,6 @@
  *  - Identical to evo/apply-groups/gr-lag-member.conf.
  *
  * Pair with:
- *  - evo/apply-groups/gr-lag-member.conf
  *  - junos/interfaces/lag-esi-multihoming.conf
  *  - junos/interfaces/core-isis-mpls.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/cos/forwarding-classes.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/cos/forwarding-classes.conf
@@ -16,7 +16,6 @@
  * scheduler-map and per-class scheduler definitions.
  *
  * Pair with:
- *  - evo/cos/forwarding-classes.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/cos/schedulers.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/cos/schedulers.conf
@@ -20,7 +20,6 @@
  *   set class-of-service interfaces <name> scheduler-map 5G_SCHEDULER
  *
  * Pair with:
- *  - evo/cos/schedulers.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/firewall/policers.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/firewall/policers.conf
@@ -11,7 +11,6 @@
  *   set interfaces <ifd> unit <unit> family any filter input 50MB_filter
  *
  * Pair with:
- *  - evo/firewall/policers.conf
  *
  * Variables: none. All values here are JVD-wide constants
  *            (queue numbers, class names, scheduler weights,

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/core-isis-mpls.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/core-isis-mpls.conf
@@ -12,7 +12,6 @@
  * (see apply-groups/gr-core-intf).
  *
  * Pair with:
- *  - evo/interfaces/core-isis-mpls.conf
  *
  * Variables (example values from an1_mx204):
  *   $CORE_PHYS         e.g. ae71

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/edge-vlan-normalization.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/edge-vlan-normalization.conf
@@ -21,7 +21,6 @@
  *    flexible-vlan-tagging) is in junos/interfaces/lag-esi-multihoming.conf.
  *
  * Pair with:
- *  - evo/interfaces/edge-vlan-normalization.conf
  *  - junos/interfaces/lag-esi-multihoming.conf
  *  - junos/services/evpn-vpws.conf  (vlan-ccc units)
  *  - junos/services/evpn-elan-mac-vrf.conf  (vlan-bridge units)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/lag-esi-multihoming.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/interfaces/lag-esi-multihoming.conf
@@ -21,7 +21,6 @@
  * apply-groups GR-EDGE-INTF-MH (see apply-groups/gr-edge-intf-mh).
  *
  * Pair with:
- *  - evo/interfaces/lag-esi-multihoming.conf
  *
  * Variables (example values from an1_mx204):
  *   $AC_PHYS         e.g. ae11   (the multihomed AE)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/oam/oam-cfm-perf-mon.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/oam/oam-cfm-perf-mon.conf
@@ -21,7 +21,6 @@
  *    the peer PEs (1002 and 1006 here).
  *
  * Pair with:
- *  - evo/oam/oam-cfm-perf-mon.conf
  *
  * Variables (example values from an4_acx710):
  *   $MD_NAME         e.g. MD_63535

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/communities.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/communities.conf
@@ -26,7 +26,6 @@
  *    leak-prevention.
  *
  * Pair with:
- *  - evo/policy/communities.conf
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/services/l3vpn-vrf.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf
@@ -25,7 +25,6 @@
  *    name matches the routing-instance name (DRY pattern).
  *
  * Pair with:
- *  - evo/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/services/l3vpn-vrf.conf
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf
@@ -25,7 +25,6 @@
  *    `l2vpn-id` form). For pure LDP-VPLS see the EVO snip.
  *
  * Pair with:
- *  - evo/services/ldp-vpls.conf  (LDP-VPLS sibling pattern, EVO only)
  *  - junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf-irb.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf-irb.conf
@@ -22,9 +22,9 @@
  *    you have a reason to converge.
  *
  * Pair with:
- *  - evo/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/services/evpn-elan-mac-vrf.conf
  *  - junos/services/l3vpn-vrf.conf
+ *  - junos/services/evpn-type5.conf  (IRB co-occurrence)
  *
  * Variables (illustrative — not deployed on Junos in this JVD):
  *   $INSTANCE_NAME   e.g. evpn_group_60_4000

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-mac-vrf.conf
@@ -1,8 +1,8 @@
 /*
  * Topic:   EVPN-ELAN (mac-vrf) routing-instance (MEF E-LAN)
  * Seen on:
- *   Junos: —
- *   EVO:   an3_acx7100-48l ma1-1_acx7024 ma1-2_acx7024 meg1_acx7100-32c meg2_acx7509
+ *   Junos: an1_mx204 ma4_mx204 ma5_mx204 mse1_mx304 mse2_mx304
+ *   EVO:   (none — EVO uses mac-vrf; see evo/services/evpn-elan-mac-vrf.conf)
  *
  * Highlights:
  *  - instance-type evpn (mac-vrf style for EVPN-ELAN)
@@ -18,7 +18,6 @@
  * Pair with:
  *  - junos/transport/bgp-overlay.conf (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf
- *  - evo/services/evpn-elan-mac-vrf.conf
  *
  * Variables (example values from an1_mx204):
  *   $INSTANCE_NAME   e.g. evpn_group_90_700

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf
@@ -19,7 +19,6 @@
  *    use VLAN-tagged (vlan-ccc) ACs everywhere.
  *
  * Pair with:
- *  - evo/services/evpn-port-based.conf
  *  - junos/services/evpn-vpws.conf  (vlan-tagged variant, validated)
  *
  * Variables (illustrative — not deployed on Junos in this JVD):

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5.conf
@@ -27,15 +27,14 @@
  *    families separate.
  *
  * Pair with:
- *  - evo/services/evpn-type5.conf  (EVO end of the same VRF)
  *  - For the L2 / IRB side that owns irb.<N>:
- *      evo/services/evpn-elan-mac-vrf-irb.conf  (EVO mate)
  *      Junos virtual-switch + bridge-domains + routing-interface
  *      (no dedicated snip yet — see deployed pattern in
  *       service_provider/.../conf/mse1_mx304.conf).
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
+ *  - junos/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)
  *
  * Variables (example values from mse1_mx304 / METRO_L3VPN_4000):
  *   $INSTANCE_NAME    e.g. METRO_L3VPN_4000

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-vpws.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-vpws.conf
@@ -16,7 +16,6 @@
  * Pair with:
  *  - junos/transport/bgp-overlay.conf (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf
- *  - evo/services/evpn-vpws.conf
  *
  * Variables (example values from an1_mx204):
  *   $INSTANCE_NAME       e.g. evpn_group_30_2400

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-hot-standby.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-hot-standby.conf
@@ -18,7 +18,6 @@
  *    evo/services/l2circuit-hot-standby.conf.
  *
  * Pair with:
- *  - evo/services/l2circuit-hot-standby.conf
  *  - junos/apply-groups/gr-l2ckt-hs.conf  (reference apply-group shape)
  *
  * Variables (illustrative — not deployed on Junos in this JVD):

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2vpn-kompella.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2vpn-kompella.conf
@@ -18,7 +18,6 @@
  *    not vlan-tagged).
  *
  * Pair with:
- *  - evo/services/l2vpn-kompella.conf  (remote PE end)
  *  - junos/apply-groups/gr-fatpw-label.conf  (FAT-PW for L2VPN)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-vrf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-vrf.conf
@@ -19,7 +19,6 @@
  *    junos/policy/l3vpn-export-import.conf.
  *
  * Pair with:
- *  - evo/services/l3vpn-vrf.conf  (EVO end of the same VRF)
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/bgp-overlay.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/bgp-overlay.conf
@@ -21,7 +21,6 @@
  *  - BCP knobs inherited from apply-groups GR-BGP-BCP
  *
  * Pair with:
- *  - evo/transport/bgp-overlay.conf
  *
  * Variables (example values from an1_mx204):
  *   $LOOPBACK_V4   e.g. 1.1.0.0

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/isis-srmpls-tilfa.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/isis-srmpls-tilfa.conf
@@ -16,7 +16,6 @@
  *  - Inherits BCP knobs from apply-groups GR-ISIS-BCP
  *
  * Pair with:
- *  - evo/transport/isis-srmpls-tilfa.conf
  *
  * Variables (example values from an1_mx204):
  *   $CORE_INTF_1   e.g. ae71.0   (one stanza per core neighbour;

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/mpls-segment-routing.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/transport/mpls-segment-routing.conf
@@ -12,7 +12,6 @@
  *  - ipv6-tunneling enables 6PE over the SR-MPLS underlay
  *
  * Pair with:
- *  - evo/transport/mpls-segment-routing.conf
  *
  * Variables: none. All values here (admin-group numbers, SRGB range)
  * are JVD-wide constants — same on every PE.


### PR DESCRIPTION
## What's New
- Remove cross-OS pair-with references from all Metro EBS snip headers (65 entries)
- Add IRB co-occurrence pair-with links between evpn-type5 and evpn-elan-mac-vrf-irb (both Junos and EVO)
- Correct Seen-on device list in junos/services/evpn-elan-mac-vrf.conf

## Why
Dependency graph accuracy: EVO and Junos configs should not have dependency links between each other. Cross-OS sibling relationships are conveyed via filename matching in the portal, not via pair-with headers. Additionally, the co-occurrence analysis identified evpn-type5-vrf and evpn-vlan-bundle-irb as mandatory pairs (shared IRB units on 100 Junos + 162 EVO instances).

## Details
- 64 files changed across `service_provider/metro_ethernet_business_services/configuration/snips/`
- Removed `Pair with:` lines referencing the other OS tree (`evo/` refs in `junos/` snips and vice versa)
- Added co-occurrence pairs: `evpn-type5.conf` ↔ `evpn-elan-mac-vrf-irb.conf` (both OS), plus EVO-only `evpn-vpws.conf` connections
- Fixed `junos/services/evpn-elan-mac-vrf.conf` Seen-on which incorrectly listed EVO devices instead of Junos devices

## Testing
Validated with `snips_scrub.py` — cross-OS errors reduced from 65 to 0, total errors from 110 to 44 (remaining are pre-existing incomplete headers and taxonomy-granularity edge cases).