### PR TITLE
feat(maas): publish config snip library (112 templates, junos+evo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ was also refreshed for accuracy.
   config, and a missing closing brace on one class-of-service
   block was repaired.
 
+- **JVD Portal snip browser** — the new MaaS library is wired
+  into the [Snip Library browser](https://juniper.github.io/jvd/portal/#snips)
+  on the JVD Portal. Browse by JVD, technology, or use case
+  (Service Provider / Metro / Business Services / MEF); each
+  snip page renders the body with syntax highlighting and
+  resolves `Pair with` links to other MaaS snips.
+
 ### What this means for you
 
 - If you're deploying Metro Ethernet services on Juniper MX or
@@ -86,7 +93,8 @@ was also refreshed for accuracy.
 | --- | ---: | ---: |
 | `service_provider/metro_as_a_service/configuration/snips` | 114 | 0 |
 | `service_provider/metro_as_a_service/configuration/conf` | 0 | 10 |
-| **TOTAL** | **114** | **10** |
+| `portal` (snip browser wiring) | 0 | 4 |
+| **TOTAL** | **114** | **14** |
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,134 @@ Release notes for the Juniper Validated Design (JVD) configuration repository.
 
 ---
 
+## 2026-05-28
+
+The Metro-as-a-Service (MaaS) JVD gains its first reusable
+configuration-snippet library — 112 templates covering the full
+MEF service portfolio (E-Line, E-LAN, E-Tree, E-Access) across
+both Junos (MX, ACX5448, ACX710) and Junos EVO (ACX7024,
+ACX7100, ACX7509) platforms, organized into a parallel
+`junos/` and `evo/` tree by category. A small set of source
+configurations under [`metro_as_a_service/configuration/conf/`](service_provider/metro_as_a_service/configuration/conf/)
+was also refreshed for accuracy.
+
+### New content
+
+- **MaaS Configuration Snip Library** — 112 reusable templates for the
+  [`metro_as_a_service`](service_provider/metro_as_a_service/) JVD,
+  organized under
+  [`configuration/snips/`](service_provider/metro_as_a_service/configuration/snips/)
+  with dual Junos and EVO trees across 6 categories:
+  `services/` (EVPN E-LAN incl. port-based / vlan-bundle / type-5,
+  EVPN E-Tree, EVPN VPWS incl. LSW and port-based, EVPN FXC
+  vlan-aware / vlan-unaware, BGP-VPLS, L2VPN Kompella,
+  static l2circuit incl. floating-pw / hot-standby, bridge-domain),
+  `interfaces/` (vlan-bridge incl. ESI / QinQ / E-Tree leaf/root,
+  vlan-ccc with vlan-map ESI, ethernet-bridge, ethernet-ccc,
+  IRB L3, pseudowire subscriber, physical-mtu),
+  `firewall/` (color-aware and color-blind filters for families
+  ccc, bridge, and ethernet-switching, with L2CP and per-CoS
+  variants),
+  `cos/` (forwarding-classes, ieee-802.1p / MPLS-EXP classifiers,
+  rewrite-rules, schedulers and scheduler-map, CoS-binding
+  templates for both ieee-802.1p and MPLS encaps),
+  `policy/` (L3VPN RT, VPN RT export), and
+  `apply-groups/` (MEF forwarding-profile).
+  Every template carries the standard five-section header
+  (`Topic`, `Seen on`, `Highlights`, `Pair with`, `JVD service
+  mapping`, `Variables`) and a
+  [`_variables.md`](service_provider/metro_as_a_service/configuration/snips/_variables.md)
+  glossary defines all 49 `$VARIABLE` placeholders. A
+  [`README.md`](service_provider/metro_as_a_service/configuration/snips/README.md)
+  documents the OS / category layout, deployment workflow, and
+  the same-device `Pair with` dependency model.
+
+- **Source configuration updates** — ten files under
+  [`configuration/conf/`](service_provider/metro_as_a_service/configuration/conf/)
+  were updated for accuracy: a CoS code-point value was
+  corrected on `FC-HIGH` in eight service captures, a `family
+  ccc` wrapper was restored on one firewall filter, a missing
+  CoS `scheduler-map` binding was added to one VPWS edge
+  config, and a missing closing brace on one class-of-service
+  block was repaired.
+
+### What this means for you
+
+- If you're deploying Metro Ethernet services on Juniper MX or
+  ACX platforms, start from the new
+  [MaaS snip library](service_provider/metro_as_a_service/configuration/snips/).
+  Each `services/` template lists exactly which `interfaces/`,
+  `firewall/`, and `cos/` snips must coexist on the same device,
+  so you can assemble a working configuration without
+  cross-referencing the full source captures.
+- Junos and EVO templates live in sibling paths under
+  `junos/` and `evo/`, making it easy to compare the two OSes
+  for the same service shape (e.g. EVPN-FXC, l2circuit, EVPN
+  E-LAN) and pick the right one for your platform.
+- The library covers six MEF service families end-to-end —
+  E-Line (EPL, EVPL), E-LAN (EP-LAN, EVP-LAN), E-Tree
+  (EP-Tree, EVP-Tree), and E-Access — including less-common
+  patterns like EVPN E-LAN Type-5, EVPN E-Tree, L2VPN
+  Kompella, and pseudowire-headend-termination via
+  `l2circuit-floating-pw`.
+
+---
+
+### By the numbers
+
+<details>
+<summary>Per-area changes</summary>
+
+| Area / JVD | Added | Modified |
+| --- | ---: | ---: |
+| `service_provider/metro_as_a_service/configuration/snips` | 114 | 0 |
+| `service_provider/metro_as_a_service/configuration/conf` | 0 | 10 |
+| **TOTAL** | **114** | **10** |
+
+</details>
+
+<details>
+<summary>Net lines added</summary>
+
+| Area | Lines added |
+| --- | ---: |
+| Junos templates (`junos/`) | 3,132 |
+| EVO templates (`evo/`) | 3,417 |
+| Documentation (`_variables.md` + `README.md`) | 282 |
+| **Total** | **6,831** |
+
+</details>
+
+<details>
+<summary>MaaS snip-library content breakdown</summary>
+
+| Content | Files | Lines |
+| --- | ---: | ---: |
+| Junos templates (6 categories) | 50 | 3,132 |
+| EVO templates (6 categories) | 62 | 3,417 |
+| Variables glossary (`_variables.md`) | 1 | 59 |
+| Snip-library `README.md` | 1 | 223 |
+| **Total** | **114** | **6,831** |
+
+</details>
+
+<details>
+<summary>MaaS snips by OS and category</summary>
+
+| Category | Junos | EVO |
+| --- | ---: | ---: |
+| `services` | 12 | 20 |
+| `interfaces` | 16 | 25 |
+| `firewall` | 10 | 6 |
+| `cos` | 9 | 7 |
+| `policy` | 2 | 3 |
+| `apply-groups` | 1 | 1 |
+| **Total** | **50** | **62** |
+
+</details>
+
+---
+
 ## 2026-05-21
 
 Three JVDs gain full config-snippet libraries this week: the 3-Stage

--- a/portal/public/byoai/metro_ethernet_business_services/MANIFEST.json
+++ b/portal/public/byoai/metro_ethernet_business_services/MANIFEST.json
@@ -299,7 +299,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1981,
+      "size_bytes": 1926,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf"
     },
     {
@@ -347,7 +347,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2565,
+      "size_bytes": 2510,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5.conf"
     },
     {
@@ -369,7 +369,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 1947,
+      "size_bytes": 1824,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-vpws.conf"
     },
     {

--- a/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-snips.md
+++ b/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-snips.md
@@ -1291,7 +1291,6 @@ policy-options {
  *
  * Pair with:
  *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
- *  - evo/services/evpn-vpws.conf  (IRB co-occurrence)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $INSTANCE_NAME   e.g. evpn_group_60_4000
@@ -1503,7 +1502,6 @@ routing-instances {
  *  - evo/apply-groups/gr-l3vpn.conf
  *  - evo/policy/l3vpn-export-import.conf
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
- *  - evo/services/evpn-vpws.conf  (IRB co-occurrence)
  *
  * Variables (example values from an3_acx7100-48l / METRO_L3VPN_4000):
  *   $INSTANCE_NAME    e.g. METRO_L3VPN_4000
@@ -1560,8 +1558,6 @@ routing-instances {
  * Pair with:
  *  - evo/interfaces/lag-esi-multihoming.conf (the AC interface)
  *  - evo/transport/bgp-overlay.conf (family evpn signaling)
- *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
- *  - evo/services/evpn-elan-mac-vrf-irb.conf  (IRB co-occurrence)
  *
  * Variables (example values from ma1-1_acx7024):
  *   $INSTANCE_NAME       e.g. evpn_group_30_2400

--- a/portal/scripts/jvd-usecase-map.json
+++ b/portal/scripts/jvd-usecase-map.json
@@ -2,6 +2,7 @@
   "_comment": "Use-case tags applied to every snip from a given JVD folder. Tags are free-form strings; the snip browser groups by them in 'Use case' browse mode. Add new entries here as JVDs gain snip libraries — at minimum include the area name (Service Provider, Data Center, etc) so the JVD shows up under that bucket.",
 
   "broadband_edge": ["Service Provider", "BNG", "Subscriber Mgmt", "Metro"],
+  "metro_as_a_service": ["Service Provider", "Metro", "Business Services", "MEF"],
   "metro_ethernet_business_services": ["Service Provider", "Metro", "Business Services", "MEF"],
   "srv6_core_edge": ["Service Provider", "SRv6", "Core/Edge"]
 }

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-27T22:21:03.512Z",
+  "generatedAt": "2026-05-29T05:11:40.203Z",
   "counts": {
-    "total": 320,
-    "junos": 160,
-    "evo": 160,
-    "jvds": 7
+    "total": 432,
+    "junos": 210,
+    "evo": 222,
+    "jvds": 8
   },
   "categories": [
     "apply-groups",
@@ -99,6 +99,17 @@
         "junos": 22,
         "evo": 16,
         "total": 38
+      }
+    },
+    {
+      "id": "metro_as_a_service",
+      "label": "Metro as a Service",
+      "area": "Service Provider",
+      "repoPath": "service_provider/metro_as_a_service",
+      "counts": {
+        "junos": 50,
+        "evo": 62,
+        "total": 112
       }
     },
     {
@@ -14642,6 +14653,7478 @@
       "parseWarnings": []
     },
     {
+      "id": "metro_as_a_service/evo/apply-groups/mef-forwarding-profile",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "apply-groups",
+      "name": "mef-forwarding-profile",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/apply-groups/mef-forwarding-profile.conf",
+      "topic": "Apply-group: mef forwarding profile (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Enables MEF forwarding profile system-wide"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "system {\n    packet-forwarding-options {\n        mef-forwarding-profile;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">system {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    packet-forwarding-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        mef-forwarding-profile;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 80,
+      "lineCount": 5,
+      "techFamily": "Apply-groups",
+      "subfamily": "Apply Groups",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/classifiers",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "classifiers",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/classifiers.conf",
+      "topic": "Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Forwarding-class definitions / classifier mapping"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "classifiers {\n    dscp CL-DSCP {\n        import default;\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-points cs6;\n            loss-priority high code-points cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-points [ cs4 af41 ];\n            loss-priority medium-high code-points af42;\n            loss-priority high code-points af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-points ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-points [ cs3 af31 ];\n            loss-priority medium-high code-points af32;\n            loss-priority high code-points af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-points cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points [ cs2 af21 ];\n            loss-priority medium-high code-points af22;\n            loss-priority high code-points af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points [ cs1 af11 ];\n            loss-priority medium-high code-points af12;\n            loss-priority high code-points af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority high code-points be;\n        }\n    }\n    dscp-ipv6 CL-DSCP-IPV6 {\n        import default;\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-points cs6;\n            loss-priority high code-points cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-points [ cs4 af41 ];\n            loss-priority medium-high code-points af42;\n            loss-priority high code-points af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-points ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-points [ cs3 af31 ];\n            loss-priority medium-high code-points af32;\n            loss-priority high code-points af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-points cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points [ cs2 af21 ];\n            loss-priority medium-high code-points af22;\n            loss-priority high code-points af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points [ cs1 af11 ];\n            loss-priority medium-high code-points af12;\n            loss-priority high code-points af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority high code-points be;\n        }\n    }\n    exp CL-MPLS {\n        import default;\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-points 110;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-points 100;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-points 101;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-points 011;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-points 111;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points 010;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points 001;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-points 000;\n        }\n    }\n    ieee-802.1 CL-8021P {\n        forwarding-class FC-HIGH {\n            loss-priority low code-points [ 101 100 ];\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points [ 011 010 ];\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points [ 001 000 ];\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp CL-DSCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        import default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs4 af41 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs3 af31 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs2 af21 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs1 af11 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp-ipv6 CL-DSCP-IPV6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        import default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs4 af41 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs3 af31 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs2 af21 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs1 af11 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    exp CL-MPLS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        import default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> CL-8021P {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#79C0FF\"> 100</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#79C0FF\"> 010</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#79C0FF\"> 000</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3775,
+      "lineCount": 112,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "cos-binding-ieee8021p",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-ieee8021p.conf",
+      "topic": "Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "L2 CE-facing CoS binding (classify + rewrite IEEE 802.1p)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/forwarding-classes.conf",
+          "id": "metro_as_a_service/evo/cos/forwarding-classes"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/cos/scheduler-map.conf",
+          "id": "metro_as_a_service/evo/cos/scheduler-map"
+        },
+        {
+          "raw": "evo/cos/schedulers.conf",
+          "id": "metro_as_a_service/evo/cos/schedulers"
+        }
+      ],
+      "variables": [],
+      "body": "interfaces {\n    $AC_INTF {\n        scheduler-map SM-5G-SCHEDULER;\n        unit $UNIT {\n            classifiers {\n                ieee-802.1 CL-8021P;\n            }\n            rewrite-rules {\n                ieee-802.1 RR-8021P;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        scheduler-map SM-5G-SCHEDULER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> CL-8021P;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> RR-8021P;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 261,
+      "lineCount": 13,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/cos-binding-mpls",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "cos-binding-mpls",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-mpls.conf",
+      "topic": "Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "MPLS core-facing CoS binding (classify + rewrite EXP)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/forwarding-classes.conf",
+          "id": "metro_as_a_service/evo/cos/forwarding-classes"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/cos/scheduler-map.conf",
+          "id": "metro_as_a_service/evo/cos/scheduler-map"
+        },
+        {
+          "raw": "evo/cos/schedulers.conf",
+          "id": "metro_as_a_service/evo/cos/schedulers"
+        }
+      ],
+      "variables": [],
+      "body": "interfaces {\n    $AC_INTF {\n        scheduler-map SM-5G-SCHEDULER;\n        unit $UNIT {\n            classifiers {\n                exp CL-MPLS;\n            }\n            rewrite-rules {\n                exp RR-MPLS;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        scheduler-map SM-5G-SCHEDULER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                exp CL-MPLS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                exp RR-MPLS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 245,
+      "lineCount": 13,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/forwarding-classes",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "forwarding-classes",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/forwarding-classes.conf",
+      "topic": "Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Forwarding-class definitions / classifier mapping"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "forwarding-classes {\n    class FC-SIGNALING queue-num 7;\n    class FC-LLQ queue-num 6;\n    class FC-REALTIME queue-num 5;\n    class FC-HIGH queue-num 4;\n    class FC-CONTROL queue-num 3;\n    class FC-MEDIUM queue-num 2;\n    class FC-LOW queue-num 1;\n    class FC-BEST-EFFORT queue-num 0;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-SIGNALING queue-num </span><span style=\"color:#79C0FF\">7</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-LLQ queue-num </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-REALTIME queue-num </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-HIGH queue-num </span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-CONTROL queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-MEDIUM queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-LOW queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 289,
+      "lineCount": 10,
+      "techFamily": "QoS / CoS",
+      "subfamily": "Cos",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/rewrite-rules",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "rewrite-rules",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/rewrite-rules.conf",
+      "topic": "Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Forwarding-class definitions / classifier mapping",
+        "Rewrite-rules for egress marking"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "rewrite-rules {\n    dscp RR-DSCP {\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-point cs6;\n            loss-priority high code-point cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-point af41;\n            loss-priority medium-high code-point af42;\n            loss-priority high code-point af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-point ef;\n            loss-priority high code-point ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-point af31;\n            loss-priority medium-high code-point af32;\n            loss-priority high code-point af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-point cs7;\n            loss-priority high code-point cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point af21;\n            loss-priority medium-high code-point af22;\n            loss-priority high code-point af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point af11;\n            loss-priority medium-high code-point af12;\n            loss-priority high code-point af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-point be;\n            loss-priority high code-point be;\n        }\n    }\n    dscp-ipv6 RR-DSCP-IPV6 {\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-point cs6;\n            loss-priority high code-point cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-point af41;\n            loss-priority medium-high code-point af42;\n            loss-priority high code-point af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-point ef;\n            loss-priority high code-point ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-point af31;\n            loss-priority medium-high code-point af32;\n            loss-priority high code-point af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-point cs7;\n            loss-priority high code-point cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point af21;\n            loss-priority medium-high code-point af22;\n            loss-priority high code-point af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point af11;\n            loss-priority medium-high code-point af12;\n            loss-priority high code-point af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-point be;\n            loss-priority high code-point be;\n        }\n    }\n    exp RR-MPLS {\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-point 110;\n            loss-priority high code-point 110;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-point 100;\n            loss-priority medium-high code-point 100;\n            loss-priority high code-point 100;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-point 101;\n            loss-priority high code-point 101;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-point 011;\n            loss-priority medium-high code-point 011;\n            loss-priority high code-point 011;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-point 111;\n            loss-priority high code-point 111;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point 010;\n            loss-priority medium-high code-point 010;\n            loss-priority high code-point 010;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point 001;\n            loss-priority medium-high code-point 001;\n            loss-priority high code-point 001;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-point 000;\n            loss-priority high code-point 000;\n        }\n    }\n    ieee-802.1 RR-8021P {\n        forwarding-class FC-HIGH {\n            loss-priority low code-point 100;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point 010;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point 000;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp RR-DSCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af41;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af31;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af21;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af11;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp-ipv6 RR-DSCP-IPV6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af41;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af31;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af21;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af11;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    exp RR-MPLS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> RR-8021P {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 4440,
+      "lineCount": 127,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/scheduler-map",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "scheduler-map",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/scheduler-map.conf",
+      "topic": "Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Scheduler-map binding queues to schedulers",
+        "Forwarding-class definitions / classifier mapping"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "scheduler-maps {\n    SM-5G-SCHEDULER {\n        forwarding-class FC-SIGNALING scheduler SC-SIGNALING;\n        forwarding-class FC-LLQ scheduler SC-LLQ;\n        forwarding-class FC-REALTIME scheduler SC-REALTIME;\n        forwarding-class FC-HIGH scheduler SC-HIGH;\n        forwarding-class FC-CONTROL scheduler SC-CONTROL;\n        forwarding-class FC-MEDIUM scheduler SC-MEDIUM;\n        forwarding-class FC-LOW scheduler SC-LOW;\n        forwarding-class FC-BEST-EFFORT scheduler SC-BEST-EFFORT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">scheduler-maps {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SM-5G-SCHEDULER {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING scheduler SC-SIGNALING;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ scheduler SC-LLQ;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME scheduler SC-REALTIME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH scheduler SC-HIGH;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL scheduler SC-CONTROL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM scheduler SC-MEDIUM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW scheduler SC-LOW;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT scheduler SC-BEST-EFFORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 500,
+      "lineCount": 12,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/cos/schedulers",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "cos",
+      "name": "schedulers",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/cos/schedulers.conf",
+      "topic": "Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Per-queue scheduler shaping / buffer / priority"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "schedulers {\n    SC-SIGNALING {\n        shaping-rate percent 5;\n        buffer-size percent 5;\n        priority strict-high;\n    }\n    SC-LLQ {\n        shaping-rate percent 40;\n        buffer-size percent 10;\n        priority low-latency;\n    }\n    SC-REALTIME {\n        shaping-rate percent 30;\n        buffer-size percent 20;\n        priority medium-high;\n    }\n    SC-HIGH {\n        transmit-rate percent 40;\n        buffer-size percent 30;\n        priority low;\n    }\n    SC-CONTROL {\n        shaping-rate percent 5;\n        buffer-size percent 5;\n        priority high;\n    }\n    SC-MEDIUM {\n        transmit-rate percent 30;\n        buffer-size percent 20;\n        priority low;\n    }\n    SC-LOW {\n        transmit-rate percent 20;\n        buffer-size percent 10;\n        priority low;\n    }\n    SC-BEST-EFFORT {\n        transmit-rate {\n            remainder;\n        }\n        buffer-size {\n            remainder;\n        }\n        priority low;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low-latency;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority medium-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 960,
+      "lineCount": 46,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind-l2cp",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-ccc-color-blind-l2cp",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-l2cp.conf",
+      "topic": "Firewall: filter ccc color blind l2cp (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards L2CP/BPDU destination-mac frames",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_port_based_fam_ccc"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard-l2cp {\n                from {\n                    destination-mac-address {\n                        01:80:c2:00:00:07/48;\n                        01:80:c2:00:00:0e/48;\n                        01:80:c2:00:00:20/48;\n                        01:80:c2:00:00:21/48;\n                        01:80:c2:00:00:22/48;\n                        01:80:c2:00:00:23/48;\n                        01:80:c2:00:00:2a/48;\n                        01:80:c2:00:00:2d/48;\n                        01:80:c2:00:00:2e/48;\n                        01:80:c2:00:00:2f/48;\n                        01:80:c2:00:00:2b/48;\n                        01:80:c2:00:00:24/48;\n                        01:80:c2:00:00:25/48;\n                        01:80:c2:00:00:26/48;\n                        01:80:c2:00:00:27/48;\n                        01:80:c2:00:00:28/48;\n                        01:80:c2:00:00:29/48;\n                        01:80:c2:00:00:2c/48;\n                    }\n                }\n                then {\n                    count l2cp_discard;\n                    discard;\n                }\n            }\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard-l2cp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-mac-address {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">07</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:0e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">21</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">22</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">23</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2a/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2d/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2f/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2b/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">24</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">25</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">26</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">27</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">28</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">29</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2c/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count l2cp_discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3666,
+      "lineCount": 121,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-ccc-color-blind-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-v2.conf",
+      "topic": "Firewall: filter ccc color blind (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.1"
+        ]
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_vlan-based_fam_ccc"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2573,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-ccc-color-blind",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind.conf",
+      "topic": "Firewall: filter ccc color blind (MEF E-Access, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_vlan-based_fam_ccc"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2574,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-l2cp",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-eswitch-color-blind-l2cp",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-l2cp.conf",
+      "topic": "Firewall: filter eswitch color blind l2cp (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "family ethernet-switching filter (Junos/ACX L2 switching path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards L2CP/BPDU destination-mac frames",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_epl_bridge"
+        }
+      ],
+      "body": "firewall {\n    family ethernet-switching {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard-l2cp {\n                from {\n                    destination-mac-address {\n                        01:80:c2:00:00:07/48;\n                        01:80:c2:00:00:0e/48;\n                        01:80:c2:00:00:20/48;\n                        01:80:c2:00:00:21/48;\n                        01:80:c2:00:00:22/48;\n                        01:80:c2:00:00:23/48;\n                        01:80:c2:00:00:2a/48;\n                        01:80:c2:00:00:2d/48;\n                        01:80:c2:00:00:2e/48;\n                        01:80:c2:00:00:2f/48;\n                        01:80:c2:00:00:2b/48;\n                        01:80:c2:00:00:24/48;\n                        01:80:c2:00:00:25/48;\n                        01:80:c2:00:00:26/48;\n                        01:80:c2:00:00:27/48;\n                        01:80:c2:00:00:28/48;\n                        01:80:c2:00:00:29/48;\n                        01:80:c2:00:00:2c/48;\n                    }\n                }\n                then {\n                    discard;\n                    count l2cp_discard;\n                }\n            }\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    discard;\n                    count discard_pcp6_7;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    count high_class;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    count class_medium;\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    count class_low;\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                }\n            }\n            term default {\n                then {\n                    count default;\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard-l2cp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-mac-address {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">07</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:0e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">21</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">22</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">23</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2a/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2d/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2f/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2b/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">24</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">25</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">26</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">27</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">28</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">29</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2c/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count l2cp_discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3681,
+      "lineCount": 121,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-eswitch-color-blind-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-v2.conf",
+      "topic": "Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "family ethernet-switching filter (Junos/ACX L2 switching path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_elan-evpn"
+        }
+      ],
+      "body": "firewall {\n    family ethernet-switching {\n        filter $FILTER_NAME {\n            interface-specific;\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    count high_class;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    count class_medium;\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    count class_low;\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                }\n            }\n            term default {\n                then {\n                    count default;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2339,
+      "lineCount": 84,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "firewall",
+      "name": "filter-eswitch-color-blind",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind.conf",
+      "topic": "Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "family ethernet-switching filter (Junos/ACX L2 switching path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_elan-evpn"
+        }
+      ],
+      "body": "firewall {\n    family ethernet-switching {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    discard;\n                    count discard_pcp6_7;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    count high_class;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    count class_medium;\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    count class_low;\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                }\n            }\n            term default {\n                then {\n                    count default;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2589,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/ethernet-bridge-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "ethernet-bridge-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge-v2.conf",
+      "topic": "Interface: ethernet bridge (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "encapsulation ethernet-bridge"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/services/evpn-elan-bundle-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$MTU",
+          "example": "9192"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "$AC_INTF {\n    mtu $MTU;\n    encapsulation ethernet-bridge;\n    unit $UNIT {\n        family ethernet-switching {\n            filter {\n                input f_epl_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation ethernet-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_epl_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 201,
+      "lineCount": 11,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/ethernet-bridge",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "ethernet-bridge",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge.conf",
+      "topic": "Interface: ethernet bridge (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation ethernet-bridge"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/services/evpn-elan-bundle-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "$AC_INTF {\n    encapsulation ethernet-bridge;\n    unit $UNIT {\n        family ethernet-switching {\n            filter {\n                input f_epl_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation ethernet-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_epl_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 187,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/ethernet-ccc-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "ethernet-ccc-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc-v2.conf",
+      "topic": "Interface: ethernet ccc (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation ethernet-ccc"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/l2vpn-kompella-port-based.conf",
+          "id": "metro_as_a_service/evo/services/l2vpn-kompella-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "$AC_INTF {\n    encapsulation ethernet-ccc;\n    unit $UNIT {\n        family ccc {\n            filter {\n                input f_eline-evpn-vpws;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation ethernet-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_eline-evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 174,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/ethernet-ccc",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "ethernet-ccc",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc.conf",
+      "topic": "Interface: ethernet ccc (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation ethernet-ccc"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "$AC_INTF {\n    encapsulation ethernet-ccc;\n    unit $UNIT {\n        family ccc {\n            filter {\n                input f_port_based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation ethernet-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_port_based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 177,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/irb-l3-vga",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "irb-l3-vga",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3-vga.conf",
+      "topic": "Interface: irb l3 vga (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "IRB unit for L3 termination"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$IP_ADDRESS",
+          "example": "198.51.100.2/27"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$VG_ADDRESS",
+          "example": "198.51.100.1"
+        },
+        {
+          "name": "$VG_MAC",
+          "example": "00:01:33:44:11:11"
+        }
+      ],
+      "body": "irb {\n    unit $UNIT {\n        virtual-gateway-accept-data;\n        family inet {\n            address $IP_ADDRESS {\n                virtual-gateway-address $VG_ADDRESS;\n            }\n        }\n        virtual-gateway-v4-mac $VG_MAC;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">irb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        virtual-gateway-accept-data;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            address $IP_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-gateway-address $VG_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        virtual-gateway-v4-mac $VG_MAC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 240,
+      "lineCount": 11,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/irb-l3",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "irb-l3",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3.conf",
+      "topic": "Interface: irb l3 (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "IRB unit for L3 termination"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$IP_ADDRESS",
+          "example": "203.0.113.1/27"
+        },
+        {
+          "name": "$MAC",
+          "example": "00:01:33:44:11:12"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        }
+      ],
+      "body": "irb {\n    unit $UNIT {\n        family inet {\n            address $IP_ADDRESS;\n        }\n        mac $MAC;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">irb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            address $IP_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        mac $MAC;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 113,
+      "lineCount": 8,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/physical-mtu",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "physical-mtu",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/physical-mtu.conf",
+      "topic": "Interface: physical mtu (MEF E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "(no auto-generated highlights)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/bgp-vpls.conf",
+          "id": "metro_as_a_service/evo/services/bgp-vpls"
+        },
+        {
+          "raw": "evo/services/evpn-elan-bundle-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based"
+        },
+        {
+          "raw": "evo/services/evpn-elan-type5.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-type5"
+        },
+        {
+          "raw": "evo/services/evpn-elan-vlan-bundle.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-vlan-bundle"
+        },
+        {
+          "raw": "evo/services/evpn-fxc-vlan-unaware.conf",
+          "id": "metro_as_a_service/evo/services/evpn-fxc-vlan-unaware"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-port-based"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based"
+        },
+        {
+          "raw": "evo/services/l2circuit-hot-standby-primary.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-hot-standby-primary"
+        },
+        {
+          "raw": "evo/services/l2vpn-kompella-port-based.conf",
+          "id": "metro_as_a_service/evo/services/l2vpn-kompella-port-based"
+        },
+        {
+          "raw": "evo/services/l2vpn-kompella-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/l2vpn-kompella-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$MTU",
+          "example": "9102"
+        }
+      ],
+      "body": "$AC_INTF {\n    mtu $MTU;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 26,
+      "lineCount": 3,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge-bundle",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-bundle",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-bundle.conf",
+      "topic": "Interface: vlan bridge bundle (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-elan-vlan-bundle.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-vlan-bundle"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4013"
+        },
+        {
+          "name": "$VLAN_LIST_END",
+          "example": "4014"
+        },
+        {
+          "name": "$VLAN_LIST_START",
+          "example": "4013"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;\n        family ethernet-switching {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 313,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge-esi-bundle",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-esi-bundle",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi-bundle.conf",
+      "topic": "Interface: vlan bridge esi bundle (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-elan-vlan-bundle.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-vlan-bundle"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae67"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:81:10:13:10:10:10:00:00:01"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4013"
+        },
+        {
+          "name": "$VLAN_LIST_END",
+          "example": "4014"
+        },
+        {
+          "name": "$VLAN_LIST_START",
+          "example": "4013"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family ethernet-switching {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 309,
+      "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge-esi",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-esi",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi.conf",
+      "topic": "Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-elan-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-port-based"
+        },
+        {
+          "raw": "evo/services/evpn-elan-type5.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-type5"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae67"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:22:11:77:11:12:a1:00:00:01"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4075"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family ethernet-switching {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 278,
+      "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-v2.conf",
+      "topic": "Interface: vlan bridge (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/bgp-vpls-p2p.conf",
+          "id": "metro_as_a_service/evo/services/bgp-vpls-p2p"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/12"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4005"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4005"
+        }
+      ],
+      "body": "$AC_INTF {\n    vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        family ethernet-switching {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 285,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge-vlan-map-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-vlan-map-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map-v2.conf",
+      "topic": "Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG2"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-bridge"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/bgp-vpls.conf",
+          "id": "metro_as_a_service/evo/services/bgp-vpls"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-2/0/4"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "3712"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4012"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4012"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        family ethernet-switching {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 323,
+      "lineCount": 16,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge-vlan-map",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge-vlan-map",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map.conf",
+      "topic": "Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/bgp-vpls.conf",
+          "id": "metro_as_a_service/evo/services/bgp-vpls"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "3712"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4012"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4012"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        family ethernet-switching {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 396,
+      "lineCount": 18,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-bridge",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-bridge",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge.conf",
+      "topic": "Interface: vlan bridge (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-elan-type5.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-type5"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4075"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        family ethernet-switching {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 282,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-2-units",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-2-units",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-2-units.conf",
+      "topic": "Interface: vlan ccc 2 units (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-fxc-vlan-unaware.conf",
+          "id": "metro_as_a_service/evo/services/evpn-fxc-vlan-unaware"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "4007"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4008"
+        },
+        {
+          "name": "$VLAN_1",
+          "example": "4007"
+        },
+        {
+          "name": "$VLAN_2",
+          "example": "4008"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT_1 {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN_1;\n        family ccc {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n    }\n    unit $UNIT_2 {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN_2;\n        family ccc {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 475,
+      "lineCount": 22,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-esi",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-esi",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi.conf",
+      "topic": "Interface: vlan ccc esi (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae67"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:40:11:11:21:22:01:00:00:01"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4000"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4000"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 269,
+      "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-qinq-stacked-qinq-tpid",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf",
+      "topic": "Interface: vlan ccc qinq stacked qinq tpid (MEF E-Access)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-lsw.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-lsw"
+        },
+        {
+          "raw": "evo/services/l2circuit-lsw.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-lsw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/51"
+        },
+        {
+          "name": "$MTU",
+          "example": "9102"
+        },
+        {
+          "name": "$OUTER_VID_TPID",
+          "example": "0x88a8.4082"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4082"
+        }
+      ],
+      "body": "$AC_INTF {\n    mtu $MTU;\n    ether-options {\n        ethernet-switch-profile {\n            tag-protocol-id [ 0x8100 0x88a8 ];\n        }\n    }\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-tags outer $OUTER_VID_TPID;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet-switch-profile {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            tag-protocol-id [ 0x8100 0x88a8 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-tags outer $OUTER_VID_TPID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 239,
+      "lineCount": 12,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-v2.conf",
+      "topic": "Interface: vlan ccc (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/l2circuit-floating-pw.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-floating-pw"
+        },
+        {
+          "raw": "evo/services/l2vpn-kompella-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/l2vpn-kompella-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/12"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4004"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4004"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 273,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-bundle-qinq-tpid",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf",
+      "topic": "Interface: vlan ccc vlan map bundle qinq tpid (MEF E-Access)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-lsw.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-lsw"
+        },
+        {
+          "raw": "evo/services/l2circuit-lsw.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-lsw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/0"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "4082"
+        },
+        {
+          "name": "$MTU",
+          "example": "9102"
+        },
+        {
+          "name": "$UNIT",
+          "example": "2500"
+        },
+        {
+          "name": "$VLAN_LIST_END",
+          "example": "2599"
+        },
+        {
+          "name": "$VLAN_LIST_START",
+          "example": "2500"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    mtu $MTU;\n    encapsulation flexible-ethernet-services;\n    ether-options {\n        ethernet-switch-profile {\n            tag-protocol-id [ 0x8100 0x88a8 ];\n        }\n    }\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;\n        input-vlan-map {\n            push;\n            tag-protocol-id 0x88a8;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet-switch-profile {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            tag-protocol-id [ 0x8100 0x88a8 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            tag-protocol-id 0x88a8;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 585,
+      "lineCount": 25,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-esi-2-units-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf",
+      "topic": "Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.1"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae12"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:10:11:49:30:12:01:00:00:00"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "4094"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "200"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4009"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4009"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT_1 {\n        input-vlan-map vlan-id $VLAN;\n    }\n    unit $UNIT_2 {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family ccc {\n            filter {\n                input f_eline-evpn-vpws;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_eline-evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 445,
+      "lineCount": 23,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-esi-2-units",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-esi-2-units",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf",
+      "topic": "Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-fxc-vlan-aware.conf",
+          "id": "metro_as_a_service/evo/services/evpn-fxc-vlan-aware"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae67"
+        },
+        {
+          "name": "$ESI_ID_1",
+          "example": "00:10:44:11:50:12:02:00:00:00"
+        },
+        {
+          "name": "$ESI_ID_2",
+          "example": "00:10:44:11:50:12:01:00:00:00"
+        },
+        {
+          "name": "$INPUT_VID_1",
+          "example": "3400"
+        },
+        {
+          "name": "$INPUT_VID_2",
+          "example": "3000"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "4002"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4001"
+        },
+        {
+          "name": "$VLAN_1",
+          "example": "4002"
+        },
+        {
+          "name": "$VLAN_2",
+          "example": "4001"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT_1 {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN_1;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID_1;\n        }\n        output-vlan-map pop;\n        esi {\n            $ESI_ID_1;\n            all-active;\n        }\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n    unit $UNIT_2 {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN_2;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID_2;\n        }\n        output-vlan-map pop;\n        esi {\n            $ESI_ID_2;\n            all-active;\n        }\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 770,
+      "lineCount": 38,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-esi",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-esi",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi.conf",
+      "topic": "Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:10:11:49:30:11:01:00:00:00"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "4094"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4009"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4009"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family ccc {\n            filter {\n                input f_eline-evpn-vpws;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_eline-evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 380,
+      "lineCount": 20,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-v2.conf",
+      "topic": "Interface: vlan ccc vlan map (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/28:2"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "1000"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4006"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4006"
+        }
+      ],
+      "body": "interfaces {\n    $AC_INTF {\n        flexible-vlan-tagging;\n        encapsulation flexible-ethernet-services;\n        unit $UNIT {\n            encapsulation vlan-ccc;\n            vlan-id $VLAN;\n            input-vlan-map {\n                push;\n                vlan-id $INPUT_VID;\n            }\n            output-vlan-map pop;\n            family ccc {\n                filter {\n                    input f_vlan-based_fam_ccc;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 474,
+      "lineCount": 20,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map.conf",
+      "topic": "Interface: vlan ccc vlan map (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based"
+        },
+        {
+          "raw": "evo/services/l2circuit-hot-standby-backup.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-hot-standby-backup"
+        },
+        {
+          "raw": "evo/services/l2circuit-hot-standby-primary.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-hot-standby-primary"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "4080"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4010"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4010"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 387,
+      "lineCount": 18,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc.conf",
+      "topic": "Interface: vlan ccc (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4000"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4000"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 200,
+      "lineCount": 11,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/policy/policy-l3vpn-import-export",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "policy-l3vpn-import-export",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-l3vpn-import-export.conf",
+      "topic": "Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "Community-driven RT policy"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$COMM_RT",
+          "example": "61535:13075"
+        },
+        {
+          "name": "$POLICY_NAME_1",
+          "example": "PS-$VPN_RT_COMM-EXPORT"
+        },
+        {
+          "name": "$POLICY_NAME_2",
+          "example": "PS-$VPN_RT_COMM-IMPORT"
+        },
+        {
+          "name": "$PUBLIC_PREFIX",
+          "example": "203.0.113.0/24"
+        },
+        {
+          "name": "$VPN_RT_COMM",
+          "example": "METRO_L3VPN_4075"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $POLICY_NAME_1 {\n        term tag-public-routes {\n            from {\n                route-filter $PUBLIC_PREFIX orlonger;\n            }\n            then {\n                community add CM-L3VPN-PUB;\n                community add $VPN_RT_COMM;\n                accept;\n            }\n        }\n    }\n    policy-statement $POLICY_NAME_2 {\n        term L3VPN-CUST {\n            from community $VPN_RT_COMM;\n            then accept;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term tag-public-routes {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                route-filter $PUBLIC_PREFIX orlonger;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-L3VPN-PUB;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term L3VPN-CUST {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> community $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 535,
+      "lineCount": 21,
+      "techFamily": "Policy & Routing",
+      "subfamily": "L3VPN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/policy/policy-vpn-rt-export-bronze",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "policy-vpn-rt-export-bronze",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf",
+      "topic": "Policy: policy vpn rt export bronze (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "Community-driven RT policy",
+        "Color-mapping community is OPTIONAL — VPN works with or without it"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$COMM_RT",
+          "example": "63535:4013"
+        },
+        {
+          "name": "$POLICY_NAME",
+          "example": "evpn_group_80_4013"
+        },
+        {
+          "name": "$VPN_RT_COMM",
+          "example": "evpn_group_80_4013_RT"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2BRONZE;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2BRONZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 340,
+      "lineCount": 15,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/policy/policy-vpn-rt-export-gold",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "policy-vpn-rt-export-gold",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf",
+      "topic": "Policy: policy vpn rt export gold (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "Community-driven RT policy",
+        "Color-mapping community is OPTIONAL — VPN works with or without it"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$COMM_RT",
+          "example": "63535:33300"
+        },
+        {
+          "name": "$POLICY_NAME",
+          "example": "evpn_group_edge_4000"
+        },
+        {
+          "name": "$VPN_RT_COMM",
+          "example": "evpn_group_edge_4000_RT"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2GOLD;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2GOLD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 338,
+      "lineCount": 15,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/bgp-vpls-p2p",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "bgp-vpls-p2p",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls-p2p.conf",
+      "topic": "Service instance: bgp vpls p2p (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "instance-type virtual-switch",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/12"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vpls_group_4005"
+        },
+        {
+          "name": "$LABEL_BLOCK_SIZE",
+          "example": "2"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.18:44444"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "5"
+        },
+        {
+          "name": "$SITE_NAME",
+          "example": "r18"
+        },
+        {
+          "name": "$SITE_RANGE",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4005"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "64535:44444"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type virtual-switch;\n        protocols {\n            vpls {\n                site $SITE_NAME {\n                    site-identifier $SITE_ID;\n                }\n                service-type single;\n                site-range $SITE_RANGE;\n                label-block-size $LABEL_BLOCK_SIZE;\n                no-tunnel-services;\n            }\n        }\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            vlan4005 {\n                interface $AC_INTF.$UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-switch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site $SITE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                service-type single;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site-range $SITE_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                label-block-size $LABEL_BLOCK_SIZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-tunnel-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan4005 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 589,
+      "lineCount": 23,
+      "techFamily": "Service Overlay",
+      "subfamily": "VPLS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/bgp-vpls",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "bgp-vpls",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls.conf",
+      "topic": "Service instance: bgp vpls (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type virtual-switch",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge-vlan-map.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge-vlan-map"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vpls_group_103_4012"
+        },
+        {
+          "name": "$LABEL_BLOCK_SIZE",
+          "example": "8"
+        },
+        {
+          "name": "$RD",
+          "example": "63535:1894012"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "1"
+        },
+        {
+          "name": "$SITE_NAME",
+          "example": "r2"
+        },
+        {
+          "name": "$SITE_RANGE",
+          "example": "10"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4012"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:1094012"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type virtual-switch;\n        protocols {\n            vpls {\n                site $SITE_NAME {\n                    site-identifier $SITE_ID;\n                }\n                service-type single;\n                site-range $SITE_RANGE;\n                label-block-size $LABEL_BLOCK_SIZE;\n                no-tunnel-services;\n            }\n        }\n        route-distinguisher $RD;\n        vrf-export $INSTANCE_NAME;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            vlan4012 {\n                interface $AC_INTF.$UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-switch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site $SITE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                service-type single;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site-range $SITE_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                label-block-size $LABEL_BLOCK_SIZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-tunnel-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> $INSTANCE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan4012 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 624,
+      "lineCount": 24,
+      "techFamily": "Service Overlay",
+      "subfamily": "VPLS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-elan-bundle-port-based-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based-v2.conf",
+      "topic": "Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "instance-type mac-vrf",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/interfaces/ethernet-bridge.conf",
+          "id": "metro_as_a_service/evo/interfaces/ethernet-bridge"
+        },
+        {
+          "raw": "evo/services/evpn-elan-bundle-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MEF_EVPN_ELAN_PORT_BASED"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.18:4014"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:4014"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                no-control-word;\n            }\n        }\n        service-type vlan-bundle;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            v-2 {\n                interface $AC_INTF.$UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-bundle;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            v-</span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 381,
+      "lineCount": 18,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-elan-bundle-port-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based.conf",
+      "topic": "Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type mac-vrf",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/interfaces/ethernet-bridge.conf",
+          "id": "metro_as_a_service/evo/interfaces/ethernet-bridge"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/services/evpn-elan-bundle-port-based.conf",
+          "id": "metro_as_a_service/evo/services/evpn-elan-bundle-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MEF_EVPN_ELAN_PORT_BASED"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:4014"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:4014"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn;\n        }\n        service-type vlan-bundle;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            v-2 {\n                interface $AC_INTF.$UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-bundle;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            v-</span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 333,
+      "lineCount": 16,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-elan-port-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-elan-port-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-port-based.conf",
+      "topic": "Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type mac-vrf",
+        "vlan-id none + no-normalization (port-based bridging)",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge-esi.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge-esi"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_90_4011"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:64011"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4011"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:64011"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                no-control-word;\n            }\n        }\n        service-type vlan-based;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            BD_evpn_group_90_4011 {\n                vlan-id none;\n                interface $AC_INTF.$UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-based;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            BD_evpn_group_90_4011 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id none;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 464,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-elan-type5-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-elan-type5-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5-v2.conf",
+      "topic": "Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "instance-type mac-vrf",
+        "EVPN Type-5 IP-prefix routes (L3 over EVPN)",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge-esi.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge-esi"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae67"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_60_4075"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$RD_1",
+          "example": "10.0.0.6:14075"
+        },
+        {
+          "name": "$RD_2",
+          "example": "61000:13075"
+        },
+        {
+          "name": "$ROUTER_ID",
+          "example": "10.0.0.6"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4075"
+        },
+        {
+          "name": "$VRF_TARGET_1",
+          "example": "61535:14075"
+        },
+        {
+          "name": "$VRF_TARGET_2",
+          "example": "61535:13075"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n                normalization;\n                no-control-word;\n            }\n        }\n        service-type vlan-based;\n        route-distinguisher $RD_1;\n        vrf-target target:$VRF_TARGET_1;\n        vlans {\n            V4000 {\n                vlan-id $VLAN;\n                interface $AC_INTF.$UNIT;\n                l3-interface irb.$IRB_UNIT;\n            }\n        }\n    }\n    METRO_L3VPN_4075 {\n        instance-type vrf;\n        routing-options {\n            router-id $ROUTER_ID;\n        }\n        protocols {\n            evpn {\n                ip-prefix-routes {\n                    advertise direct-nexthop;\n                    encapsulation mpls;\n                }\n            }\n        }\n        interface irb.$IRB_UNIT;\n        route-distinguisher $RD_2;\n        vrf-import PS-METRO_L3VPN_4075-IMPORT;\n        vrf-export PS-METRO_L3VPN_4075-EXPORT;\n        vrf-target target:$VRF_TARGET_2;\n        vrf-table-label;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                normalization;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-based;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            V4000 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                l3-interface irb.$IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    METRO_L3VPN_4075 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            router-id $ROUTER_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ip-prefix-routes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise direct-nexthop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface irb.$IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-import PS-METRO_L3VPN_4075-IMPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> PS-METRO_L3VPN_4075-</span><span style=\"color:#79C0FF\">EXPORT</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1134,
+      "lineCount": 43,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-elan-type5",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-elan-type5",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5.conf",
+      "topic": "Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type mac-vrf",
+        "EVPN Type-5 IP-prefix routes (L3 over EVPN)",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_60_4075"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$RD_1",
+          "example": "10.0.0.2:14075"
+        },
+        {
+          "name": "$RD_2",
+          "example": "63000:13075"
+        },
+        {
+          "name": "$ROUTER_ID",
+          "example": "10.0.0.2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4075"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "61535:14075"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n                normalization;\n                no-control-word;\n            }\n        }\n        service-type vlan-based;\n        route-distinguisher $RD_1;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            V4000 {\n                vlan-id $VLAN;\n                interface $AC_INTF.$UNIT;\n                l3-interface irb.$IRB_UNIT;\n            }\n        }\n    }\n    METRO_L3VPN_4075 {\n        instance-type vrf;\n        routing-options {\n            router-id $ROUTER_ID;\n        }\n        protocols {\n            evpn {\n                ip-prefix-routes {\n                    advertise direct-nexthop;\n                    encapsulation mpls;\n                }\n            }\n        }\n        interface irb.$IRB_UNIT;\n        route-distinguisher $RD_2;\n        vrf-import PS-METRO_L3VPN_4075-IMPORT;\n        vrf-export PS-METRO_L3VPN_4075-EXPORT;\n        vrf-table-label;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                normalization;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-based;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            V4000 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                l3-interface irb.$IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    METRO_L3VPN_4075 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            router-id $ROUTER_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ip-prefix-routes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise direct-nexthop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface irb.$IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-import PS-METRO_L3VPN_4075-IMPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> PS-METRO_L3VPN_4075-</span><span style=\"color:#79C0FF\">EXPORT</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1091,
+      "lineCount": 42,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-elan-vlan-bundle",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-elan-vlan-bundle",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-bundle.conf",
+      "topic": "Service instance: evpn elan vlan bundle (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type mac-vrf",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge-bundle.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge-bundle"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge-esi-bundle.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-bridge-esi-bundle"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_80_4013"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:4013"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4013"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:4013"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type mac-vrf;\n        protocols {\n            evpn {\n                encapsulation mpls;\n            }\n        }\n        service-type vlan-bundle;\n        route-distinguisher $RD;\n        vrf-export $INSTANCE_NAME;\n        vrf-target target:$VRF_TARGET;\n        vlans {\n            BD_evpn_group_80_4013 {\n                interface $AC_INTF.$UNIT;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type mac-vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        service-type vlan-bundle;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> $INSTANCE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlans {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            BD_evpn_group_80_4013 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 437,
+      "lineCount": 19,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-fxc-vlan-aware",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-fxc-vlan-aware",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware.conf",
+      "topic": "Service instance: evpn fxc vlan aware (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "EVPN-VPWS attachment-circuit with local/remote service-id",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-esi-2-units"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae67"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_vpws_fxc_aware"
+        },
+        {
+          "name": "$LOCAL_VID",
+          "example": "1"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.6:5501"
+        },
+        {
+          "name": "$REMOTE_VID",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "4001"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4002"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63536:55100"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF.$UNIT_1 {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n                interface $AC_INTF.$UNIT_2 {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n                flexible-cross-connect-vlan-aware;\n            }\n        }\n        interface $AC_INTF.$UNIT_1;\n        interface $AC_INTF.$UNIT_2;\n        route-distinguisher $RD;\n        vrf-export $INSTANCE_NAME;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-cross-connect-vlan-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> $INSTANCE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 792,
+      "lineCount": 27,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-fxc-vlan-unaware",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-fxc-vlan-unaware",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-unaware.conf",
+      "topic": "Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-2-units.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-2-units"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_4007"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:40001"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "4007"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4008"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:40001"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                flexible-cross-connect-vlan-unaware;\n                group fxc {\n                    interface $AC_INTF.$UNIT_1;\n                    interface $AC_INTF.$UNIT_2;\n                    service-id {\n                        local 1;\n                        remote 2;\n                    }\n                }\n            }\n        }\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-cross-connect-vlan-unaware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group fxc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 533,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-vpws-lsw",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vpws-lsw",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-lsw.conf",
+      "topic": "Service instance: evpn vpws lsw (MEF E-Access)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "EVPN-VPWS attachment-circuit with local/remote service-id",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF_1",
+          "example": "et-0/0/0"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "et-0/0/51"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "lsw_evpn_vpws_group_90_4082"
+        },
+        {
+          "name": "$LOCAL_VID",
+          "example": "22"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.15:4082"
+        },
+        {
+          "name": "$REMOTE_VID",
+          "example": "11"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "2500"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4082"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63533:4082"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF_1.$UNIT_1 {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n                interface $AC_INTF_2.$UNIT_2 {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n                control-word;\n            }\n        }\n        interface $AC_INTF_1.$UNIT_1;\n        interface $AC_INTF_2.$UNIT_2;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_1.$UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF_2.$UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_1.$UNIT_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_2.$UNIT_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 744,
+      "lineCount": 26,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-vpws-port-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vpws-port-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-port-based.conf",
+      "topic": "Service instance: evpn vpws port based (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "EVPN-VPWS attachment-circuit with local/remote service-id",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind-l2cp.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind-l2cp"
+        },
+        {
+          "raw": "evo/interfaces/ethernet-ccc.conf",
+          "id": "metro_as_a_service/evo/interfaces/ethernet-ccc"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MEF_EVPN_VPWS_PORT_BASED"
+        },
+        {
+          "name": "$LOCAL_VID",
+          "example": "1"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:55555"
+        },
+        {
+          "name": "$REMOTE_VID",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:55555"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF.$UNIT {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 457,
+      "lineCount": 18,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vpws-vlan-based-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based-v2.conf",
+      "topic": "Service instance: evpn vpws vlan based (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "EVPN-VPWS attachment-circuit with local/remote service-id",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-esi-2-units"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map-esi.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-esi"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_30_4009"
+        },
+        {
+          "name": "$LOCAL_VID",
+          "example": "1"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:4999"
+        },
+        {
+          "name": "$REMOTE_VID",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4009"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:4999"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF.$UNIT {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 457,
+      "lineCount": 18,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/evpn-vpws-vlan-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "evpn-vpws-vlan-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based.conf",
+      "topic": "Service instance: evpn vpws vlan based (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "EVPN-VPWS attachment-circuit with local/remote service-id",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-esi.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-esi"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_edge_4000"
+        },
+        {
+          "name": "$LOCAL_VID",
+          "example": "1"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.2:33300"
+        },
+        {
+          "name": "$REMOTE_VID",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4000"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:33300"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF.$UNIT {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-export $INSTANCE_NAME;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> $INSTANCE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 492,
+      "lineCount": 19,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/l2circuit-floating-pw",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "l2circuit-floating-pw",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf",
+      "topic": "Service instance: l2circuit floating pw (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "Static targeted-LDP L2-circuit pseudowire (no routing-instance required)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/12"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4004"
+        },
+        {
+          "name": "$VC_ID",
+          "example": "10120"
+        }
+      ],
+      "body": "protocols {\n    l2circuit {\n        neighbor 1.1.10.10 {\n            interface $AC_INTF.$UNIT {\n                static {\n                    incoming-label 1000022;\n                    outgoing-label 1000022;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 351,
+      "lineCount": 14,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/l2circuit-hot-standby-backup",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "l2circuit-hot-standby-backup",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-backup.conf",
+      "topic": "Service instance: l2circuit hot standby backup (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MEG1"
+        ]
+      },
+      "highlights": [
+        "Static targeted-LDP L2-circuit pseudowire (no routing-instance required)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/28:2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4006"
+        },
+        {
+          "name": "$VC_ID",
+          "example": "2006"
+        }
+      ],
+      "body": "protocols {\n    l2circuit {\n        neighbor 10.0.0.2 {\n            interface $AC_INTF.$UNIT {\n                virtual-circuit-id $VC_ID;\n                control-word;\n                flow-label-transmit;\n                flow-label-receive;\n                encapsulation-type ethernet-vlan;\n                ignore-encapsulation-mismatch;\n                ignore-mtu-mismatch;\n                pseudowire-status-tlv {\n                    hot-standby-vc-on;\n                }\n            }\n        }\n    }",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ignore-encapsulation-mismatch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ignore-mtu-mismatch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                pseudowire-status-tlv {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    hot-standby-vc-</span><span style=\"color:#79C0FF\">on</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span></code></pre>",
+      "bytes": 501,
+      "lineCount": 17,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/l2circuit-hot-standby-primary",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "l2circuit-hot-standby-primary",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-primary.conf",
+      "topic": "Service instance: l2circuit hot standby primary (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "Static targeted-LDP L2-circuit pseudowire (no routing-instance required)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4006"
+        },
+        {
+          "name": "$VC_ID_1",
+          "example": "2006"
+        },
+        {
+          "name": "$VC_ID_2",
+          "example": "3333"
+        }
+      ],
+      "body": "protocols {\n    l2circuit {\n        neighbor 10.0.0.6 {\n            interface $AC_INTF.$UNIT {\n                virtual-circuit-id $VC_ID_1;\n                control-word;\n                flow-label-transmit;\n                flow-label-receive;\n                encapsulation-type ethernet-vlan;\n                ignore-mtu-mismatch;\n                pseudowire-status-tlv;\n                backup-neighbor 10.0.0.7 {\n                    virtual-circuit-id $VC_ID_2;\n                    hot-standby;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">6</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ignore-mtu-mismatch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                pseudowire-status-tlv;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                backup-neighbor </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">7</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    virtual-circuit-id $VC_ID_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    hot-standby;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 543,
+      "lineCount": 19,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/l2circuit-lsw",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "l2circuit-lsw",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-lsw.conf",
+      "topic": "Service instance: l2circuit lsw (MEF E-Access)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA3"
+        ]
+      },
+      "highlights": [
+        "Static targeted-LDP L2-circuit pseudowire (no routing-instance required)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF_1",
+          "example": "et-0/0/0"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "et-0/0/51"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "2500"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4082"
+        }
+      ],
+      "body": "protocols {\n    l2circuit {\n        local-switching {\n            interface $AC_INTF_1.$UNIT_1 {\n                end-interface {\n                    interface $AC_INTF_2.$UNIT_2;\n                }\n                ignore-mtu-mismatch;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        local-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF_1.$UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                end-interface {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF_2.$UNIT_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ignore-mtu-mismatch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 265,
+      "lineCount": 12,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/l2vpn-kompella-port-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "l2vpn-kompella-port-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-port-based.conf",
+      "topic": "Service instance: l2vpn kompella port based (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type l2vpn",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/ethernet-ccc.conf",
+          "id": "metro_as_a_service/evo/interfaces/ethernet-ccc"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MEF_L2VPN_PORT_BASED"
+        },
+        {
+          "name": "$RD",
+          "example": "63535:110000"
+        },
+        {
+          "name": "$REMOTE_SITE_ID",
+          "example": "1119"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "1102"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:100000"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type l2vpn;\n        protocols {\n            l2vpn {\n                site r19 {\n                    interface $AC_INTF.$UNIT {\n                        remote-site-id $REMOTE_SITE_ID;\n                    }\n                    site-identifier $SITE_ID;\n                }\n                encapsulation-type ethernet;\n                no-control-word;\n                flow-label-transmit;\n                flow-label-receive;\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type l2vpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            l2vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site r19 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote-site-id $REMOTE_SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 614,
+      "lineCount": 22,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/services/l2vpn-kompella-vlan-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "services",
+      "name": "l2vpn-kompella-vlan-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-vlan-based.conf",
+      "topic": "Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "AN3"
+        ]
+      },
+      "highlights": [
+        "instance-type l2vpn",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/cos/classifiers.conf",
+          "id": "metro_as_a_service/evo/cos/classifiers"
+        },
+        {
+          "raw": "evo/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/evo/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "evo/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/evo/cos/rewrite-rules"
+        },
+        {
+          "raw": "evo/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/evo/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "evo/interfaces/physical-mtu.conf",
+          "id": "metro_as_a_service/evo/interfaces/physical-mtu"
+        },
+        {
+          "raw": "evo/interfaces/vlan-ccc.conf",
+          "id": "metro_as_a_service/evo/interfaces/vlan-ccc"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/13"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "l2vpn_group_200"
+        },
+        {
+          "name": "$RD",
+          "example": "63535:102000"
+        },
+        {
+          "name": "$REMOTE_SITE_ID",
+          "example": "1119"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "1102"
+        },
+        {
+          "name": "$UNIT",
+          "example": "200"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type l2vpn;\n        protocols {\n            l2vpn {\n                site r2 {\n                    interface $AC_INTF.$UNIT {\n                        remote-site-id $REMOTE_SITE_ID;\n                    }\n                    site-identifier $SITE_ID;\n                }\n                encapsulation-type ethernet-vlan;\n                no-control-word;\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$RD;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type l2vpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            l2vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site r2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote-site-id $REMOTE_SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 537,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/apply-groups/mef-testing",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "apply-groups",
+      "name": "mef-testing",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/apply-groups/mef-testing.conf",
+      "topic": "Apply-group: mef testing (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN2"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Lab/test apply-group — staging-only knobs (not for production rollout)"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "system {\n    packet-forwarding-options {\n        firewall-profile {\n            mef-profile;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">system {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    packet-forwarding-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        firewall-profile {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            mef-profile;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 110,
+      "lineCount": 7,
+      "techFamily": "Apply-groups",
+      "subfamily": "Apply Groups",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/classifiers",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "classifiers",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/classifiers.conf",
+      "topic": "Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Forwarding-class definitions / classifier mapping"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "classifiers {\n    dscp CL-DSCP {\n        import default;\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-points cs6;\n            loss-priority high code-points cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-points [ cs4 af41 ];\n            loss-priority medium-high code-points af42;\n            loss-priority high code-points af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-points ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-points [ cs3 af31 ];\n            loss-priority medium-high code-points af32;\n            loss-priority high code-points af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-points cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points [ cs2 af21 ];\n            loss-priority medium-high code-points af22;\n            loss-priority high code-points af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points [ cs1 af11 ];\n            loss-priority medium-high code-points af12;\n            loss-priority high code-points af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority high code-points be;\n        }\n    }\n    dscp-ipv6 CL-DSCP-IPV6 {\n        import default;\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-points cs6;\n            loss-priority high code-points cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-points [ cs4 af41 ];\n            loss-priority medium-high code-points af42;\n            loss-priority high code-points af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-points ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-points [ cs3 af31 ];\n            loss-priority medium-high code-points af32;\n            loss-priority high code-points af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-points cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points [ cs2 af21 ];\n            loss-priority medium-high code-points af22;\n            loss-priority high code-points af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points [ cs1 af11 ];\n            loss-priority medium-high code-points af12;\n            loss-priority high code-points af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority high code-points be;\n        }\n    }\n    exp CL-MPLS {\n        import default;\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-points 110;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-points 100;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-points 101;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-points 011;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-points 111;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points 010;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points 001;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-points 000;\n        }\n    }\n    ieee-802.1 CL-8021P {\n        forwarding-class FC-HIGH {\n            loss-priority low code-points [ 101 100 ];\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-points [ 011 010 ];\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-points [ 001 000 ];\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp CL-DSCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        import default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs4 af41 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs3 af31 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs2 af21 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs1 af11 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp-ipv6 CL-DSCP-IPV6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        import default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs4 af41 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs3 af31 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs2 af21 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ cs1 af11 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-points af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-points be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    exp CL-MPLS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        import default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> CL-8021P {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#79C0FF\"> 100</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#79C0FF\"> 010</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-points [ </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#79C0FF\"> 000</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3775,
+      "lineCount": 112,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "cos-binding-ieee8021p",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-ieee8021p.conf",
+      "topic": "Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "L2 CE-facing CoS binding (classify + rewrite IEEE 802.1p)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/forwarding-classes.conf",
+          "id": "metro_as_a_service/junos/cos/forwarding-classes"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/cos/scheduler-map.conf",
+          "id": "metro_as_a_service/junos/cos/scheduler-map"
+        },
+        {
+          "raw": "junos/cos/schedulers.conf",
+          "id": "metro_as_a_service/junos/cos/schedulers"
+        }
+      ],
+      "variables": [],
+      "body": "interfaces {\n    $AC_INTF {\n        scheduler-map SM-5G-SCHEDULER;\n        unit $UNIT {\n            classifiers {\n                ieee-802.1 CL-8021P;\n            }\n            rewrite-rules {\n                ieee-802.1 RR-8021P;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        scheduler-map SM-5G-SCHEDULER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> CL-8021P;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> RR-8021P;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 261,
+      "lineCount": 13,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/cos-binding-mpls",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "cos-binding-mpls",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-mpls.conf",
+      "topic": "Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "MPLS core-facing CoS binding (classify + rewrite EXP)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/forwarding-classes.conf",
+          "id": "metro_as_a_service/junos/cos/forwarding-classes"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/cos/scheduler-map.conf",
+          "id": "metro_as_a_service/junos/cos/scheduler-map"
+        },
+        {
+          "raw": "junos/cos/schedulers.conf",
+          "id": "metro_as_a_service/junos/cos/schedulers"
+        }
+      ],
+      "variables": [],
+      "body": "interfaces {\n    $AC_INTF {\n        scheduler-map SM-5G-SCHEDULER;\n        unit $UNIT {\n            classifiers {\n                exp CL-MPLS;\n            }\n            rewrite-rules {\n                exp RR-MPLS;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        scheduler-map SM-5G-SCHEDULER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            classifiers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                exp CL-MPLS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                exp RR-MPLS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 245,
+      "lineCount": 13,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/forwarding-classes",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "forwarding-classes",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/forwarding-classes.conf",
+      "topic": "Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Forwarding-class definitions / classifier mapping"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "forwarding-classes {\n    class FC-SIGNALING queue-num 7;\n    class FC-LLQ queue-num 6;\n    class FC-REALTIME queue-num 5;\n    class FC-HIGH queue-num 4;\n    class FC-CONTROL queue-num 3;\n    class FC-MEDIUM queue-num 2;\n    class FC-LOW queue-num 1;\n    class FC-BEST-EFFORT queue-num 0;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">forwarding-classes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-SIGNALING queue-num </span><span style=\"color:#79C0FF\">7</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-LLQ queue-num </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-REALTIME queue-num </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-HIGH queue-num </span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-CONTROL queue-num </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-MEDIUM queue-num </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-LOW queue-num </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    class FC-BEST-EFFORT queue-num </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 289,
+      "lineCount": 10,
+      "techFamily": "QoS / CoS",
+      "subfamily": "Cos",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/rewrite-rules",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "rewrite-rules",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/rewrite-rules.conf",
+      "topic": "Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Forwarding-class definitions / classifier mapping",
+        "Rewrite-rules for egress marking"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "rewrite-rules {\n    dscp RR-DSCP {\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-point cs6;\n            loss-priority high code-point cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-point af41;\n            loss-priority medium-high code-point af42;\n            loss-priority high code-point af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-point ef;\n            loss-priority high code-point ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-point af31;\n            loss-priority medium-high code-point af32;\n            loss-priority high code-point af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-point cs7;\n            loss-priority high code-point cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point af21;\n            loss-priority medium-high code-point af22;\n            loss-priority high code-point af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point af11;\n            loss-priority medium-high code-point af12;\n            loss-priority high code-point af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-point be;\n            loss-priority high code-point be;\n        }\n    }\n    dscp-ipv6 RR-DSCP-IPV6 {\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-point cs6;\n            loss-priority high code-point cs5;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-point af41;\n            loss-priority medium-high code-point af42;\n            loss-priority high code-point af43;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-point ef;\n            loss-priority high code-point ef;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-point af31;\n            loss-priority medium-high code-point af32;\n            loss-priority high code-point af33;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-point cs7;\n            loss-priority high code-point cs7;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point af21;\n            loss-priority medium-high code-point af22;\n            loss-priority high code-point af23;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point af11;\n            loss-priority medium-high code-point af12;\n            loss-priority high code-point af13;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-point be;\n            loss-priority high code-point be;\n        }\n    }\n    exp RR-MPLS {\n        forwarding-class FC-SIGNALING {\n            loss-priority low code-point 110;\n            loss-priority high code-point 110;\n        }\n        forwarding-class FC-LLQ {\n            loss-priority low code-point 100;\n            loss-priority medium-high code-point 100;\n            loss-priority high code-point 100;\n        }\n        forwarding-class FC-REALTIME {\n            loss-priority low code-point 101;\n            loss-priority high code-point 101;\n        }\n        forwarding-class FC-HIGH {\n            loss-priority low code-point 011;\n            loss-priority medium-high code-point 011;\n            loss-priority high code-point 011;\n        }\n        forwarding-class FC-CONTROL {\n            loss-priority low code-point 111;\n            loss-priority high code-point 111;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point 010;\n            loss-priority medium-high code-point 010;\n            loss-priority high code-point 010;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point 001;\n            loss-priority medium-high code-point 001;\n            loss-priority high code-point 001;\n        }\n        forwarding-class FC-BEST-EFFORT {\n            loss-priority low code-point 000;\n            loss-priority high code-point 000;\n        }\n    }\n    ieee-802.1 RR-8021P {\n        forwarding-class FC-HIGH {\n            loss-priority low code-point 100;\n        }\n        forwarding-class FC-MEDIUM {\n            loss-priority low code-point 010;\n        }\n        forwarding-class FC-LOW {\n            loss-priority low code-point 000;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">rewrite-rules {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp RR-DSCP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af41;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af31;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af21;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af11;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    dscp-ipv6 RR-DSCP-IPV6 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs6;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs5;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af41;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af42;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af43;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point ef;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af31;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af32;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af33;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point cs7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af21;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af22;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af23;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point af11;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point af12;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point af13;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point be;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    exp RR-MPLS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">110</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">101</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">011</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">111</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority medium-high code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">001</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    ieee-</span><span style=\"color:#79C0FF\">802</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\"> RR-8021P {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">100</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">010</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority low code-point </span><span style=\"color:#79C0FF\">000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 4440,
+      "lineCount": 127,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/scheduler-map",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "scheduler-map",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/scheduler-map.conf",
+      "topic": "Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Scheduler-map binding queues to schedulers",
+        "Forwarding-class definitions / classifier mapping"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "scheduler-maps {\n    SM-5G-SCHEDULER {\n        forwarding-class FC-SIGNALING scheduler SC-SIGNALING;\n        forwarding-class FC-LLQ scheduler SC-LLQ;\n        forwarding-class FC-REALTIME scheduler SC-REALTIME;\n        forwarding-class FC-HIGH scheduler SC-HIGH;\n        forwarding-class FC-CONTROL scheduler SC-CONTROL;\n        forwarding-class FC-MEDIUM scheduler SC-MEDIUM;\n        forwarding-class FC-LOW scheduler SC-LOW;\n        forwarding-class FC-BEST-EFFORT scheduler SC-BEST-EFFORT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">scheduler-maps {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SM-5G-SCHEDULER {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-SIGNALING scheduler SC-SIGNALING;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LLQ scheduler SC-LLQ;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-REALTIME scheduler SC-REALTIME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-HIGH scheduler SC-HIGH;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-CONTROL scheduler SC-CONTROL;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-MEDIUM scheduler SC-MEDIUM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-LOW scheduler SC-LOW;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        forwarding-class FC-BEST-EFFORT scheduler SC-BEST-EFFORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 500,
+      "lineCount": 12,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/schedulers-legacy-acx",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "schedulers-legacy-acx",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-legacy-acx.conf",
+      "topic": "Class-of-service: schedulers legacy acx (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN2"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Per-queue scheduler shaping / buffer / priority"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "schedulers {\n    SC-SIGNALING {\n        shaping-rate percent 5;\n        buffer-size percent 5;\n        priority low;\n    }\n    SC-LLQ {\n        shaping-rate percent 40;\n        buffer-size percent 10;\n        priority strict-high;\n    }\n    SC-REALTIME {\n        shaping-rate percent 30;\n        buffer-size percent 20;\n        priority low;\n    }\n    SC-HIGH {\n        transmit-rate percent 40;\n        buffer-size percent 30;\n        priority low;\n    }\n    SC-CONTROL {\n        shaping-rate percent 5;\n        buffer-size percent 5;\n        priority low;\n    }\n    SC-MEDIUM {\n        transmit-rate percent 30;\n        buffer-size percent 20;\n        priority low;\n    }\n    SC-LOW {\n        transmit-rate percent 20;\n        buffer-size percent 10;\n        priority low;\n    }\n    SC-BEST-EFFORT {\n        transmit-rate {\n            remainder;\n        }\n        buffer-size {\n            remainder;\n        }\n        priority low;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 943,
+      "lineCount": 46,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/schedulers-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "schedulers-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-v2.conf",
+      "topic": "Class-of-service: schedulers (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Per-queue scheduler shaping / buffer / priority"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "schedulers {\n    SC-SIGNALING {\n        shaping-rate percent 5;\n        buffer-size percent 5;\n        priority high;\n    }\n    SC-LLQ {\n        shaping-rate percent 40;\n        buffer-size percent 10;\n        priority strict-high;\n    }\n    SC-REALTIME {\n        shaping-rate percent 30;\n        buffer-size percent 20;\n        priority medium-high;\n    }\n    SC-HIGH {\n        transmit-rate percent 40;\n        buffer-size percent 20;\n        priority low;\n    }\n    SC-CONTROL {\n        shaping-rate percent 5;\n        buffer-size percent 5;\n        priority high;\n    }\n    SC-MEDIUM {\n        transmit-rate percent 30;\n        buffer-size percent 10;\n        priority low;\n    }\n    SC-LOW {\n        transmit-rate percent 20;\n        buffer-size percent 10;\n        priority low;\n    }\n    SC-BEST-EFFORT {\n        transmit-rate {\n            remainder;\n        }\n        buffer-size {\n            remainder;\n        }\n        priority low;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority medium-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">30</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 953,
+      "lineCount": 46,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/cos/schedulers",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "cos",
+      "name": "schedulers",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers.conf",
+      "topic": "Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Per-queue scheduler shaping / buffer / priority"
+      ],
+      "pairWith": [],
+      "variables": [],
+      "body": "schedulers {\n    SC-SIGNALING {\n        transmit-rate percent 5;\n        buffer-size percent 5;\n        priority high;\n    }\n    SC-LLQ {\n        shaping-rate percent 40;\n        buffer-size percent 10;\n        priority strict-high;\n    }\n    SC-REALTIME {\n        transmit-rate percent 15;\n        buffer-size percent 20;\n        priority medium-high;\n    }\n    SC-HIGH {\n        transmit-rate percent 10;\n        buffer-size percent 20;\n        priority high;\n    }\n    SC-CONTROL {\n        transmit-rate percent 5;\n        buffer-size percent 5;\n        priority high;\n    }\n    SC-MEDIUM {\n        transmit-rate percent 10;\n        buffer-size percent 10;\n        priority low;\n    }\n    SC-LOW {\n        transmit-rate percent 10;\n        buffer-size percent 10;\n        priority low;\n    }\n    SC-BEST-EFFORT {\n        transmit-rate {\n            remainder;\n        }\n        buffer-size {\n            remainder;\n        }\n        priority low;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">schedulers {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-SIGNALING {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LLQ {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        shaping-rate percent </span><span style=\"color:#79C0FF\">40</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority strict-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-REALTIME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">15</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority medium-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-HIGH {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-CONTROL {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-MEDIUM {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-LOW {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size percent </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    SC-BEST-EFFORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        transmit-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        buffer-size {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            remainder;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        priority low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 957,
+      "lineCount": 46,
+      "techFamily": "QoS / CoS",
+      "subfamily": "CoS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware-cf0",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-bridge-color-aware-cf0",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-cf0.conf",
+      "topic": "Firewall: filter bridge color aware cf0 (MEF E-Access)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family bridge filter (MX L2 bridging path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-aware policer (honors ingress loss-priority)",
+        "Coupling-flag = 0 behavior (explicitly discards yellow / medium-high)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f-vlan_based_fam_bridge"
+        }
+      ],
+      "body": "firewall {\n    family bridge {\n        filter $FILTER_NAME {\n            interface-specific;\n            term high_class_discard {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count pcp_6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority 4;\n                }\n                then {\n                    count high_pcp4;\n                    loss-priority high;\n                    next term;\n                }\n            }\n            term color-envelop {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count color-envelop;\n                }\n            }\n            term medium_class-3 {\n                from {\n                    learn-vlan-1p-priority 3;\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count med-3;\n                    accept;\n                }\n            }\n            term medium_class-2 {\n                from {\n                    learn-vlan-1p-priority 2;\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count med-2;\n                    next term;\n                }\n            }\n            term CF0-yellow {\n                from {\n                    loss-priority medium-high;\n                    learn-vlan-1p-priority 2;\n                }\n                then {\n                    count CFO-yellow;\n                    discard;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count low_class;\n                }\n            }\n            term deault {\n                then count default_traffic;\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class_discard {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count pcp_6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority </span><span style=\"color:#79C0FF\">4</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_pcp4;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    loss-priority high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    next term;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term color-envelop {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count color-envelop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class-</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count med-</span><span style=\"color:#79C0FF\">3</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class-</span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count med-</span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    next term;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term CF0-yellow {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    loss-priority medium-high;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count CFO-yellow;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count low_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term deault {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then count default_traffic;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3376,
+      "lineCount": 121,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware-l2cp",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-bridge-color-aware-l2cp",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-l2cp.conf",
+      "topic": "Firewall: filter bridge color aware l2cp (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family bridge filter (MX L2 bridging path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-aware policer (honors ingress loss-priority)",
+        "Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)",
+        "Discards L2CP/BPDU destination-mac frames",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_port_based_fam_bridge"
+        }
+      ],
+      "body": "firewall {\n    family bridge {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard-l2cp {\n                from {\n                    destination-mac-address {\n                        01:80:c2:00:00:07/48;\n                        01:80:c2:00:00:0e/48;\n                        01:80:c2:00:00:20/48;\n                        01:80:c2:00:00:21/48;\n                        01:80:c2:00:00:22/48;\n                        01:80:c2:00:00:23/48;\n                        01:80:c2:00:00:2a/48;\n                        01:80:c2:00:00:2d/48;\n                        01:80:c2:00:00:2e/48;\n                        01:80:c2:00:00:2f/48;\n                        01:80:c2:00:00:2b/48;\n                        01:80:c2:00:00:24/48;\n                        01:80:c2:00:00:25/48;\n                        01:80:c2:00:00:26/48;\n                        01:80:c2:00:00:27/48;\n                        01:80:c2:00:00:28/48;\n                        01:80:c2:00:00:29/48;\n                        01:80:c2:00:00:2c/48;\n                    }\n                }\n                then {\n                    count l2cp_discard;\n                    discard;\n                }\n            }\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard-l2cp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-mac-address {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">07</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:0e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">21</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">22</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">23</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2a/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2d/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2f/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2b/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">24</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">25</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">26</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">27</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">28</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">29</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2c/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count l2cp_discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3671,
+      "lineCount": 121,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-bridge-color-aware",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware.conf",
+      "topic": "Firewall: filter bridge color aware (MEF E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family bridge filter (MX L2 bridging path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-aware policer (honors ingress loss-priority)",
+        "Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_vlan_based_fam_bridge_1"
+        }
+      ],
+      "body": "firewall {\n    family bridge {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2578,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-bridge-color-blind",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-bridge-color-blind",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-blind.conf",
+      "topic": "Firewall: filter bridge color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL, E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family bridge filter (MX L2 bridging path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_elan-evpn"
+        }
+      ],
+      "body": "firewall {\n    family bridge {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2578,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-ccc-color-aware-l2cp",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-ccc-color-aware-l2cp",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware-l2cp.conf",
+      "topic": "Firewall: filter ccc color aware l2cp (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-aware policer (honors ingress loss-priority)",
+        "Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)",
+        "Discards L2CP/BPDU destination-mac frames",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_port_based_fam_ccc"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard-l2cp {\n                from {\n                    destination-mac-address {\n                        01:80:c2:00:00:07/48;\n                        01:80:c2:00:00:0e/48;\n                        01:80:c2:00:00:20/48;\n                        01:80:c2:00:00:21/48;\n                        01:80:c2:00:00:22/48;\n                        01:80:c2:00:00:23/48;\n                        01:80:c2:00:00:2a/48;\n                        01:80:c2:00:00:2d/48;\n                        01:80:c2:00:00:2e/48;\n                        01:80:c2:00:00:2f/48;\n                        01:80:c2:00:00:2b/48;\n                        01:80:c2:00:00:24/48;\n                        01:80:c2:00:00:25/48;\n                        01:80:c2:00:00:26/48;\n                        01:80:c2:00:00:27/48;\n                        01:80:c2:00:00:28/48;\n                        01:80:c2:00:00:29/48;\n                        01:80:c2:00:00:2c/48;\n                    }\n                }\n                then {\n                    count l2cp_discard;\n                    discard;\n                }\n            }\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard-l2cp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    destination-mac-address {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">07</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:0e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">20</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">21</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">22</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">23</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2a/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2d/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2e/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2f/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2b/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">24</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">25</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">26</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">27</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">28</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">29</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                        01</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">80</span><span style=\"color:#E6EDF3\">:c2:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">00</span><span style=\"color:#E6EDF3\">:2c/</span><span style=\"color:#79C0FF\">48</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count l2cp_discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 3667,
+      "lineCount": 121,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-ccc-color-aware",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-ccc-color-aware",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware.conf",
+      "topic": "Firewall: filter ccc color aware (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-aware policer (honors ingress loss-priority)",
+        "Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_vlan-based_fam_ccc"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-aware;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-aware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2324,
+      "lineCount": 84,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-ccc-color-blind-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-ccc-color-blind-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v2.conf",
+      "topic": "Firewall: filter ccc color blind (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN2"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_eline-evpn-vpws"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 10k;\n            peak-information-rate 3500000000;\n            peak-burst-size 10125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 20k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 10k;\n            peak-information-rate 7g;\n            peak-burst-size 20k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 10k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">10125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 20k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 10k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 20k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2574,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-ccc-color-blind-v3",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-ccc-color-blind-v3",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v3.conf",
+      "topic": "Firewall: filter ccc color blind (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN4"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_vlan-based_fam_ccc"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2574,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-ccc-color-blind",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-ccc-color-blind",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind.conf",
+      "topic": "Firewall: filter ccc color blind (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family ccc filter (L2 L2CP/PCP handling for CCC)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_vlan_based_fam_bridge"
+        }
+      ],
+      "body": "firewall {\n    family ccc {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    count discard_pcp6_7;\n                    discard;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count high_class;\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                    count class_medium;\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                    count class_low;\n                }\n            }\n            term default {\n                then {\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                    count default;\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 3500000000;\n            peak-burst-size 35125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 1500;\n            peak-information-rate 3500000000;\n            peak-burst-size 35k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 35k;\n            peak-information-rate 7g;\n            peak-burst-size 70k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">35125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">1500</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 35k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 70k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2575,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/firewall/filter-eswitch-color-blind",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "firewall",
+      "name": "filter-eswitch-color-blind",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-eswitch-color-blind.conf",
+      "topic": "Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN2"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "family ethernet-switching filter (Junos/ACX L2 switching path)",
+        "Two-rate three-color marker (TrTCM, RFC 2698)",
+        "Color-blind policer (ignores ingress loss-priority)",
+        "Discards 802.1p priority 6/7 (reserved for network control)"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$FILTER_NAME",
+          "example": "f_elan-evpn"
+        }
+      ],
+      "body": "firewall {\n    family ethernet-switching {\n        filter $FILTER_NAME {\n            interface-specific;\n            term discard_pcp {\n                from {\n                    learn-vlan-1p-priority [ 6 7 ];\n                }\n                then {\n                    discard;\n                    count discard_pcp6_7;\n                }\n            }\n            term high_class {\n                from {\n                    learn-vlan-1p-priority [ 5 4 ];\n                }\n                then {\n                    count high_class;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n            term medium_class {\n                from {\n                    learn-vlan-1p-priority [ 3 2 ];\n                }\n                then {\n                    count class_medium;\n                    three-color-policer {\n                        two-rate medium_policer;\n                    }\n                }\n            }\n            term low_class {\n                from {\n                    learn-vlan-1p-priority [ 0 1 ];\n                }\n                then {\n                    count class_low;\n                    three-color-policer {\n                        two-rate low_policer;\n                    }\n                }\n            }\n            term default {\n                then {\n                    count default;\n                    three-color-policer {\n                        two-rate high_policer;\n                    }\n                }\n            }\n        }\n    }\n    three-color-policer high_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 10k;\n            peak-information-rate 3500000000;\n            peak-burst-size 10125;\n        }\n    }\n    three-color-policer low_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 22k;\n            committed-burst-size 125;\n            peak-information-rate 3500000000;\n            peak-burst-size 20k;\n        }\n    }\n    three-color-policer medium_policer {\n        action {\n            loss-priority high then discard;\n        }\n        two-rate {\n            color-blind;\n            committed-information-rate 3500000000;\n            committed-burst-size 10k;\n            peak-information-rate 7g;\n            peak-burst-size 20k;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">firewall {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    family ethernet-switching {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        filter $FILTER_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface-specific;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term discard_pcp {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">6</span><span style=\"color:#79C0FF\"> 7</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count discard_pcp6_7;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term high_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#79C0FF\"> 4</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count high_class;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term medium_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">3</span><span style=\"color:#79C0FF\"> 2</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_medium;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate medium_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term low_class {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    learn-vlan-1p-priority [ </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#79C0FF\"> 1</span><span style=\"color:#E6EDF3\"> ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count class_low;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate low_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            term default {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    count default;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    three-color-policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        two-rate high_policer;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer high_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 10k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size </span><span style=\"color:#79C0FF\">10125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer low_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate 22k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size </span><span style=\"color:#79C0FF\">125</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 20k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    three-color-policer medium_policer {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        action {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            loss-priority high then discard;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        two-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            color-blind;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-information-rate </span><span style=\"color:#79C0FF\">3500000000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            committed-burst-size 10k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-information-rate 7g;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            peak-burst-size 20k;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 2589,
+      "lineCount": 93,
+      "techFamily": "Firewall",
+      "subfamily": "Firewall",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/ethernet-bridge",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "ethernet-bridge",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-bridge.conf",
+      "topic": "Interface: ethernet bridge (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation ethernet-bridge"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware-l2cp.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware-l2cp"
+        },
+        {
+          "raw": "junos/services/evpn-elan.conf",
+          "id": "metro_as_a_service/junos/services/evpn-elan"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$MTU",
+          "example": "9192"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "$AC_INTF {\n    mtu $MTU;\n    encapsulation ethernet-bridge;\n    unit $UNIT {\n        family bridge {\n            filter {\n                input f_port_based_fam_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation ethernet-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_port_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 200,
+      "lineCount": 11,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/ethernet-ccc",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "ethernet-ccc",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-ccc.conf",
+      "topic": "Interface: ethernet ccc (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation ethernet-ccc"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-ccc-color-aware-l2cp.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-ccc-color-aware-l2cp"
+        },
+        {
+          "raw": "junos/services/l2vpn-kompella-port-based.conf",
+          "id": "metro_as_a_service/junos/services/l2vpn-kompella-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "$AC_INTF {\n    encapsulation ethernet-ccc;\n    unit $UNIT {\n        family ccc {\n            filter {\n                input f_port_based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation ethernet-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_port_based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 177,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/irb-l3",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "irb-l3",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/irb-l3.conf",
+      "topic": "Interface: irb l3 (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "IRB unit for L3 termination"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$IP_ADDRESS",
+          "example": "192.0.2.1/27"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        }
+      ],
+      "body": "irb {\n    unit $UNIT {\n        family inet {\n            address $IP_ADDRESS;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">irb {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family inet {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            address $IP_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 95,
+      "lineCount": 7,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/pseudowire-subscriber",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "pseudowire-subscriber",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf",
+      "topic": "Interface: pseudowire subscriber (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/services/evpn-elan-vlan-based-floating-pw.conf",
+          "id": "metro_as_a_service/junos/services/evpn-elan-vlan-based-floating-pw"
+        },
+        {
+          "raw": "junos/services/l2circuit-floating-pw.conf",
+          "id": "metro_as_a_service/junos/services/l2circuit-floating-pw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$ESI_ID",
+          "example": "00:11:11:11:44:11:11:30:02:0a"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "0"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4004"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4004"
+        }
+      ],
+      "body": "ps22 {\n    anchor-point {\n        lt-0/0/0;\n    }\n    vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT_1 {\n        encapsulation ethernet-ccc;\n    }\n    unit $UNIT_2 {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">ps22 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    anchor-point {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        lt-</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation ethernet-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 328,
+      "lineCount": 18,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi-etree-root",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-esi-etree-root",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-etree-root.conf",
+      "topic": "Interface: vlan bridge esi etree root (MEF E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/services/evpn-etree-vlan-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-etree-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae10"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:10:11:11:40:80:01:62:00:01"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4080"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4080"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family bridge {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n        etree-ac-role root;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        etree-ac-role root;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 306,
+      "lineCount": 16,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-esi-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v2.conf",
+      "topic": "Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [
+          "AN2"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/services/evpn-elan-port-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-elan-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:70:11:40:11:11:11:00:00:64"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4011"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4011"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 162,
+      "lineCount": 10,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi-v3",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-esi-v3",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v3.conf",
+      "topic": "Interface: vlan bridge esi (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/services/evpn-elan-vlan-based-floating-pw.conf",
+          "id": "metro_as_a_service/junos/services/evpn-elan-vlan-based-floating-pw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae10"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:11:11:11:11:44:11:30:01:0a"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4004"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4004"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family bridge {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 278,
+      "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-esi",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi.conf",
+      "topic": "Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [
+          "AN1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/services/evpn-elan-port-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-elan-port-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:70:11:40:11:11:11:00:00:64"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4011"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4011"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family bridge {\n            filter {\n                input f_elan-evpn;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_elan-evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 266,
+      "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-etree-leaf",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-etree-leaf",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-leaf.conf",
+      "topic": "Interface: vlan bridge etree leaf (MEF E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MA4"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware"
+        },
+        {
+          "raw": "junos/services/evpn-etree-vlan-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-etree-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/5"
+        },
+        {
+          "name": "$MTU",
+          "example": "9102"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4080"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4080"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    mtu $MTU;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        family bridge {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n        etree-ac-role leaf;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        etree-ac-role leaf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 324,
+      "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-qinq-stacked-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-qinq-stacked-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked-v2.conf",
+      "topic": "Interface: vlan bridge qinq stacked (MEF E-Access)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware-cf0.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware-cf0"
+        },
+        {
+          "raw": "junos/services/bridge-domain-lsw.conf",
+          "id": "metro_as_a_service/junos/services/bridge-domain-lsw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$MTU",
+          "example": "9102"
+        },
+        {
+          "name": "$OUTER_VID_TPID",
+          "example": "0x88a8.4082"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4082"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    mtu $MTU;\n    encapsulation flexible-ethernet-services;\n    gigether-options {\n        ethernet-switch-profile {\n            tag-protocol-id [ 0x8100 0x88A8 ];\n        }\n    }\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-tags outer $OUTER_VID_TPID;\n        family bridge {\n            filter {\n                input f-vlan_based_fam_bridge;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    gigether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet-switch-profile {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            tag-protocol-id [ 0x8100 0x88A8 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-tags outer $OUTER_VID_TPID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f-vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 434,
+      "lineCount": 19,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-qinq-stacked",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-qinq-stacked",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked.conf",
+      "topic": "Interface: vlan bridge qinq stacked (MEF E-Access)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-bridge"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/services/bridge-domain-lsw.conf",
+          "id": "metro_as_a_service/junos/services/bridge-domain-lsw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/2"
+        },
+        {
+          "name": "$MTU",
+          "example": "9102"
+        },
+        {
+          "name": "$OUTER_VID_TPID",
+          "example": "0x88a8.4082"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4082"
+        }
+      ],
+      "body": "$AC_INTF {\n    mtu $MTU;\n    gigether-options {\n        ethernet-switch-profile {\n            tag-protocol-id [ 0x8100 0x88A8 ];\n        }\n    }\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-tags outer $OUTER_VID_TPID;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    gigether-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        ethernet-switch-profile {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            tag-protocol-id [ 0x8100 0x88A8 ];</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-tags outer $OUTER_VID_TPID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 245,
+      "lineCount": 12,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge.conf",
+      "topic": "Interface: vlan bridge (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware"
+        },
+        {
+          "raw": "junos/services/bgp-vpls-p2p.conf",
+          "id": "metro_as_a_service/junos/services/bgp-vpls-p2p"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4005"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4005"
+        }
+      ],
+      "body": "$AC_INTF {\n    vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        family bridge {\n            filter {\n                input f_vlan_based_fam_bridge_1;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 275,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-ccc-v2",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-v2",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-v2.conf",
+      "topic": "Interface: vlan ccc (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-ccc-color-aware.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-ccc-color-aware"
+        },
+        {
+          "raw": "junos/services/l2vpn-kompella-vlan-based.conf",
+          "id": "metro_as_a_service/junos/services/l2vpn-kompella-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$UNIT",
+          "example": "200"
+        },
+        {
+          "name": "$VLAN",
+          "example": "200"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 273,
+      "lineCount": 13,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-ccc-vlan-map-esi",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-esi",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map-esi.conf",
+      "topic": "Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-ccc",
+        "ESI multihoming"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "junos/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-vpws-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$ESI_ID",
+          "example": "00:10:11:49:30:11:01:00:00:00"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "4094"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4009"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4009"
+        }
+      ],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n        family ccc {\n            filter {\n                input f_eline-evpn-vpws;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_eline-evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 380,
+      "lineCount": 20,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-ccc-vlan-map",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map.conf",
+      "topic": "Interface: vlan ccc vlan map (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN4"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/services/evpn-vpws-vlan-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-vpws-vlan-based"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/0/6"
+        },
+        {
+          "name": "$INPUT_VID",
+          "example": "4080"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4010"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4010"
+        }
+      ],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id $VLAN;\n        input-vlan-map {\n            push;\n            vlan-id $INPUT_VID;\n        }\n        output-vlan-map pop;\n        family ccc {\n            filter {\n                input f_vlan-based_fam_ccc;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        input-vlan-map {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            push;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $INPUT_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        output-vlan-map pop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan-based_fam_ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 387,
+      "lineCount": 18,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-ccc",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc.conf",
+      "topic": "Interface: vlan ccc (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation flexible-ethernet-services"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/0/13:2"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "4007"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4008"
+        },
+        {
+          "name": "$VLAN_1",
+          "example": "4007"
+        },
+        {
+          "name": "$VLAN_2",
+          "example": "4008"
+        }
+      ],
+      "body": "interfaces {\n    $AC_INTF {\n        flexible-vlan-tagging;\n        encapsulation flexible-ethernet-services;\n        unit $UNIT_1 {\n            encapsulation vlan-ccc;\n            vlan-id $VLAN_1;\n            family ccc {\n                filter {\n                    input f_vlan_based_fam_bridge;\n                }\n            }\n        }\n        unit $UNIT_2 {\n            encapsulation vlan-ccc;\n            vlan-id $VLAN_2;\n            family ccc {\n                filter {\n                    input f_vlan_based_fam_bridge;\n                }\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">interfaces {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        unit $UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan-id $VLAN_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            family ccc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 578,
+      "lineCount": 24,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/policy/policy-l3vpn-import-export",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "policy",
+      "name": "policy-l3vpn-import-export",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-l3vpn-import-export.conf",
+      "topic": "Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Community-driven RT policy"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$COMM_RT",
+          "example": "61535:13075"
+        },
+        {
+          "name": "$POLICY_NAME_1",
+          "example": "PS-$VPN_RT_COMM-EXPORT"
+        },
+        {
+          "name": "$POLICY_NAME_2",
+          "example": "PS-$VPN_RT_COMM-IMPORT"
+        },
+        {
+          "name": "$PUBLIC_PREFIX",
+          "example": "192.0.2.1/24"
+        },
+        {
+          "name": "$VPN_RT_COMM",
+          "example": "METRO_L3VPN_4075"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $POLICY_NAME_1 {\n        term tag-public-routes {\n            from {\n                route-filter $PUBLIC_PREFIX orlonger;\n            }\n            then {\n                community add CM-L3VPN-PUB;\n                community add $VPN_RT_COMM;\n                accept;\n            }\n        }\n    }\n    policy-statement $POLICY_NAME_2 {\n        term L3VPN-CUST {\n            from community $VPN_RT_COMM;\n            then accept;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term tag-public-routes {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                route-filter $PUBLIC_PREFIX orlonger;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-L3VPN-PUB;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term L3VPN-CUST {</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">            from</span><span style=\"color:#E6EDF3\"> community $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 535,
+      "lineCount": 21,
+      "techFamily": "Policy & Routing",
+      "subfamily": "L3VPN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/policy/policy-vpn-rt-export-gold",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "policy",
+      "name": "policy-vpn-rt-export-gold",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf",
+      "topic": "Policy: policy vpn rt export gold (MEF E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Community-driven RT policy",
+        "Color-mapping community is OPTIONAL — VPN works with or without it"
+      ],
+      "pairWith": [],
+      "variables": [
+        {
+          "name": "$COMM_RT",
+          "example": "63536:4080"
+        },
+        {
+          "name": "$POLICY_NAME",
+          "example": "evpn_group_80_4080"
+        },
+        {
+          "name": "$VPN_RT_COMM",
+          "example": "evpn_group_80_4080_RT"
+        }
+      ],
+      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2GOLD;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2GOLD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 338,
+      "lineCount": 15,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/bgp-vpls-p2p",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "bgp-vpls-p2p",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls-p2p.conf",
+      "topic": "Service instance: bgp vpls p2p (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type virtual-switch",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)",
+        "Local-switched (LSW) bridge-domain — no MPLS, used in E-Access hand-off scenarios"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware"
+        },
+        {
+          "raw": "junos/interfaces/vlan-bridge.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-bridge"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "vpls_group_4005"
+        },
+        {
+          "name": "$LABEL_BLOCK_SIZE",
+          "example": "2"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.19:44444"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "3"
+        },
+        {
+          "name": "$SITE_NAME",
+          "example": "r19"
+        },
+        {
+          "name": "$SITE_RANGE",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4005"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4005"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "64535:44444"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type virtual-switch;\n        protocols {\n            vpls {\n                site $SITE_NAME {\n                    site-identifier $SITE_ID;\n                }\n                site-range $SITE_RANGE;\n                label-block-size $LABEL_BLOCK_SIZE;\n                no-tunnel-services;\n            }\n        }\n        bridge-domains {\n            vlan4005 {\n                vlan-id $VLAN;\n                interface $AC_INTF.$UNIT;\n                bridge-options {\n                    no-normalization;\n                }\n            }\n        }\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-switch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vpls {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site $SITE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site-range $SITE_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                label-block-size $LABEL_BLOCK_SIZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-tunnel-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        bridge-domains {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            vlan4005 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                bridge-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    no-normalization;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 681,
+      "lineCount": 26,
+      "techFamily": "Service Overlay",
+      "subfamily": "VPLS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/bridge-domain-lsw",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "bridge-domain-lsw",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/bridge-domain-lsw.conf",
+      "topic": "Service instance: bridge domain lsw (MEF E-Access)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Local-switched (LSW) bridge-domain — no MPLS, used in E-Access hand-off scenarios"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware-cf0.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware-cf0"
+        },
+        {
+          "raw": "junos/interfaces/vlan-bridge-qinq-stacked.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-bridge-qinq-stacked"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF_1",
+          "example": "et-0/0/2"
+        },
+        {
+          "name": "$AC_INTF_2",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4082"
+        }
+      ],
+      "body": "bridge-domains {\n    bd_group_lsw_4082 {\n        interface $AC_INTF_1.$UNIT;\n        interface $AC_INTF_2.$UNIT;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">bridge-domains {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    bd_group_lsw_4082 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_1.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF_2.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 120,
+      "lineCount": 6,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-elan-port-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-elan-port-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-port-based.conf",
+      "topic": "Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [
+          "AN1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type evpn",
+        "vlan-id none + no-normalization (port-based bridging)",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-eswitch-color-blind.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-eswitch-color-blind"
+        },
+        {
+          "raw": "junos/interfaces/vlan-bridge-esi.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_90_4011"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.0:64011"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4011"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:64011"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn {\n                encapsulation mpls;\n            }\n        }\n        vlan-id none;\n        no-normalization;\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id none;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        no-normalization;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 329,
+      "lineCount": 15,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-elan-type5",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-elan-type5",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-type5.conf",
+      "topic": "Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type virtual-switch",
+        "EVPN Type-5 IP-prefix routes (L3 over EVPN)",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export",
+        "Local-switched (LSW) bridge-domain — no MPLS, used in E-Access hand-off scenarios"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/0/13:2"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_60_4075"
+        },
+        {
+          "name": "$IRB_UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$RD_1",
+          "example": "10.0.0.10:14075"
+        },
+        {
+          "name": "$RD_2",
+          "example": "63200:13075"
+        },
+        {
+          "name": "$ROUTER_ID",
+          "example": "10.0.0.10"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4075"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4075"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "61535:14075"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type virtual-switch;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n                extended-vlan-list 4075;\n                no-control-word;\n            }\n        }\n        bridge-domains {\n            BD_evpn_group_60_4075 {\n                vlan-id $VLAN;\n                interface $AC_INTF.$UNIT;\n                routing-interface irb.$IRB_UNIT;\n            }\n        }\n        route-distinguisher $RD_1;\n        vrf-target target:$VRF_TARGET;\n    }\n    METRO_L3VPN_4075 {\n        instance-type vrf;\n        routing-options {\n            router-id $ROUTER_ID;\n            auto-export;\n        }\n        protocols {\n            evpn {\n                ip-prefix-routes {\n                    advertise direct-nexthop;\n                    encapsulation mpls;\n                }\n            }\n        }\n        interface irb.$IRB_UNIT;\n        route-distinguisher $RD_2;\n        vrf-import PS-METRO_L3VPN_4075-IMPORT;\n        vrf-export PS-METRO_L3VPN_4075-EXPORT;\n        vrf-table-label;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-switch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                extended-vlan-list </span><span style=\"color:#79C0FF\">4075</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        bridge-domains {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            BD_evpn_group_60_4075 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                routing-interface irb.$IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    METRO_L3VPN_4075 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        routing-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            router-id $ROUTER_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            auto-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                ip-prefix-routes {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    advertise direct-nexthop;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface irb.$IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-import PS-METRO_L3VPN_4075-IMPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> PS-METRO_L3VPN_4075-</span><span style=\"color:#79C0FF\">EXPORT</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 1130,
+      "lineCount": 42,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-elan-vlan-based-floating-pw",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-elan-vlan-based-floating-pw",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf",
+      "topic": "Service instance: evpn elan vlan based floating pw (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type evpn",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/interfaces/pseudowire-subscriber.conf",
+          "id": "metro_as_a_service/junos/interfaces/pseudowire-subscriber"
+        },
+        {
+          "raw": "junos/interfaces/vlan-bridge-esi.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi"
+        },
+        {
+          "raw": "junos/services/l2circuit-floating-pw.conf",
+          "id": "metro_as_a_service/junos/services/l2circuit-floating-pw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae10"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "4004-evpn-floating-pw"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.10:40004"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4004"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4004"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "4004:4004"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn;\n        }\n        vlan-id $VLAN;\n        interface $AC_INTF.$UNIT;\n        interface ps22.4004;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface ps22.</span><span style=\"color:#79C0FF\">4004</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 282,
+      "lineCount": 13,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-elan",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-elan",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan.conf",
+      "topic": "Service instance: evpn elan (MEF E-LAN / EP-LAN)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type evpn",
+        "MPLS encapsulation (SR-MPLS or LDP underlay)",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware-l2cp.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware-l2cp"
+        },
+        {
+          "raw": "junos/interfaces/ethernet-bridge.conf",
+          "id": "metro_as_a_service/junos/interfaces/ethernet-bridge"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MEF_EVPN_ELAN_PORT_BASED"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.19:4014"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:4014"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                no-control-word;\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 314,
+      "lineCount": 14,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-ELAN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-etree-vlan-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-etree-vlan-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-etree-vlan-based.conf",
+      "topic": "Service instance: evpn etree vlan based (MEF E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type evpn",
+        "EVPN E-Tree (root/leaf segregation)",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/cos-binding-mpls.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-mpls"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-aware.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-aware"
+        },
+        {
+          "raw": "junos/interfaces/vlan-bridge-esi-etree-root.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-bridge-esi-etree-root"
+        },
+        {
+          "raw": "junos/interfaces/vlan-bridge-etree-leaf.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-bridge-etree-leaf"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae10"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_80_4080"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.10:4080"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4080"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4080"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63536:4080"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn {\n                interface $AC_INTF.$UNIT;\n                evpn-etree;\n            }\n        }\n        vlan-id $VLAN;\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-export $INSTANCE_NAME;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                evpn-etree;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-</span><span style=\"color:#79C0FF\">export</span><span style=\"color:#E6EDF3\"> $INSTANCE_NAME;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 373,
+      "lineCount": 16,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-fxc-vlan-unaware",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-fxc-vlan-unaware",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-fxc-vlan-unaware.conf",
+      "topic": "Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/0/13:2"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_4007"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.10:40001"
+        },
+        {
+          "name": "$UNIT_1",
+          "example": "4007"
+        },
+        {
+          "name": "$UNIT_2",
+          "example": "4008"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:40001"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                flexible-cross-connect-vlan-unaware;\n                group fxc {\n                    interface $AC_INTF.$UNIT_1;\n                    interface $AC_INTF.$UNIT_2;\n                    service-id {\n                        local 2;\n                        remote 1;\n                    }\n                }\n            }\n        }\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flexible-cross-connect-vlan-unaware;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group fxc {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local </span><span style=\"color:#79C0FF\">2</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 533,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/evpn-vpws-vlan-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "evpn-vpws-vlan-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-vpws-vlan-based.conf",
+      "topic": "Service instance: evpn vpws vlan based (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "AN1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type evpn-vpws",
+        "EVPN-VPWS attachment-circuit with local/remote service-id",
+        "RT-driven import/export"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-ccc-color-blind.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-ccc-color-blind"
+        },
+        {
+          "raw": "junos/interfaces/vlan-ccc-vlan-map-esi.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-ccc-vlan-map-esi"
+        },
+        {
+          "raw": "junos/interfaces/vlan-ccc-vlan-map.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-ccc-vlan-map"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae11"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "evpn_group_30_4009"
+        },
+        {
+          "name": "$LOCAL_VID",
+          "example": "1"
+        },
+        {
+          "name": "$RD",
+          "example": "10.0.0.0:4999"
+        },
+        {
+          "name": "$REMOTE_VID",
+          "example": "2"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4009"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:4999"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn-vpws;\n        protocols {\n            evpn {\n                interface $AC_INTF.$UNIT {\n                    vpws-service-id {\n                        local $LOCAL_VID;\n                        remote $REMOTE_VID;\n                    }\n                }\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn-vpws;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    vpws-service-id {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        local $LOCAL_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote $REMOTE_VID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 457,
+      "lineCount": 18,
+      "techFamily": "Service Overlay",
+      "subfamily": "EVPN-VPWS",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/l2circuit-floating-pw",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "l2circuit-floating-pw",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf",
+      "topic": "Service instance: l2circuit floating pw (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "Static targeted-LDP L2-circuit pseudowire (no routing-instance required)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/interfaces/pseudowire-subscriber.conf",
+          "id": "metro_as_a_service/junos/interfaces/pseudowire-subscriber"
+        },
+        {
+          "raw": "junos/services/evpn-elan-vlan-based-floating-pw.conf",
+          "id": "metro_as_a_service/junos/services/evpn-elan-vlan-based-floating-pw"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$VC_ID",
+          "example": "10120"
+        }
+      ],
+      "body": "protocols {\n    l2circuit {\n        neighbor 10.0.0.18 {\n            interface ps22.0 {\n                static {\n                    incoming-label 1000022;\n                    outgoing-label 1000022;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">18</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface ps22.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 343,
+      "lineCount": 14,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/l2vpn-kompella-port-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "l2vpn-kompella-port-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-port-based.conf",
+      "topic": "Service instance: l2vpn kompella port based (MEF E-Line / EPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type l2vpn",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-ccc-color-aware-l2cp.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-ccc-color-aware-l2cp"
+        },
+        {
+          "raw": "junos/interfaces/ethernet-ccc.conf",
+          "id": "metro_as_a_service/junos/interfaces/ethernet-ccc"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "MEF_L2VPN_PORT_BASED"
+        },
+        {
+          "name": "$RD",
+          "example": "63535:100000"
+        },
+        {
+          "name": "$REMOTE_SITE_ID",
+          "example": "1102"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "1119"
+        },
+        {
+          "name": "$UNIT",
+          "example": "0"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type l2vpn;\n        protocols {\n            l2vpn {\n                site r19 {\n                    interface $AC_INTF.$UNIT {\n                        remote-site-id $REMOTE_SITE_ID;\n                    }\n                    site-identifier $SITE_ID;\n                }\n                encapsulation-type ethernet;\n                no-control-word;\n                flow-label-transmit;\n                flow-label-receive;\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$RD;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type l2vpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            l2vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site r19 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote-site-id $REMOTE_SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-transmit;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                flow-label-receive;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 606,
+      "lineCount": 22,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/services/l2vpn-kompella-vlan-based",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "services",
+      "name": "l2vpn-kompella-vlan-based",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-vlan-based.conf",
+      "topic": "Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)",
+      "seenOn": {
+        "junos": [
+          "MA5"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "instance-type l2vpn",
+        "no-control-word (matches remote PE)",
+        "RT-driven import/export",
+        "VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers"
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p"
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules"
+        },
+        {
+          "raw": "junos/firewall/filter-ccc-color-aware.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-ccc-color-aware"
+        },
+        {
+          "raw": "junos/interfaces/vlan-ccc.conf",
+          "id": "metro_as_a_service/junos/interfaces/vlan-ccc"
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "xe-0/1/0"
+        },
+        {
+          "name": "$INSTANCE_NAME",
+          "example": "l2vpn_group_200"
+        },
+        {
+          "name": "$RD",
+          "example": "63535:112000"
+        },
+        {
+          "name": "$REMOTE_SITE_ID",
+          "example": "1102"
+        },
+        {
+          "name": "$SITE_ID",
+          "example": "1119"
+        },
+        {
+          "name": "$UNIT",
+          "example": "200"
+        },
+        {
+          "name": "$VRF_TARGET",
+          "example": "63535:102000"
+        }
+      ],
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type l2vpn;\n        protocols {\n            l2vpn {\n                site r19 {\n                    interface $AC_INTF.$UNIT {\n                        remote-site-id $REMOTE_SITE_ID;\n                    }\n                    site-identifier $SITE_ID;\n                }\n                encapsulation-type ethernet-vlan;\n                no-control-word;\n            }\n        }\n        interface $AC_INTF.$UNIT;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type l2vpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            l2vpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                site r19 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        remote-site-id $REMOTE_SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    site-identifier $SITE_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 546,
+      "lineCount": 20,
+      "techFamily": "Service Overlay",
+      "subfamily": "Services",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
       "id": "metro_ethernet_business_services/evo/apply-groups/gr-bgp-bcp",
       "jvd": "metro_ethernet_business_services",
       "jvdLabel": "Metro Ethernet Business Services",
@@ -21963,6 +29446,10 @@
     {
       "jvd": "ewan_finance",
       "markdown": "# Variables Glossary\n\nAll `$VARIABLE` placeholders used across the ewan_finance snip library.\nReplace these with site-specific values when deploying.\n\n## Identifiers & Addressing\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$LOCAL_ADDRESS` | BGP local-address (router-id loopback) | `10.200.50.12` |\n| `$LOCAL_AS` | BGP autonomous system number | `64512` |\n| `$ROUTER_ID_ADDRESS` | Primary loopback IPv4 with /32 mask | `10.200.50.13/32` |\n| `$MGMT_LOOPBACK` | Management loopback address | `10.255.163.148/32` |\n| `$ISO_ADDRESS` | IS-IS/CLNS NET address on lo0 | `47.0005.80ff.f800.0000.0108.0001.0102.5516.3148.00` |\n| `$IPV6_ADDRESS` | Primary IPv6 loopback address | `2001:db8::10:255:163:148/128` |\n| `$IPV4_ADDRESS` | Interface IPv4 address with mask | `10.101.23.2/24` |\n| `$ROUTE_DISTINGUISHER` | BGP route-distinguisher (router-id:id) | `10.200.50.12:61` |\n| `$VRF_TARGET` | VPN route-target community | `target:64512:11` |\n\n## Interfaces & LAG\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$INTERFACE_NAME` | Physical interface name | `et-0/0/0` |\n| `$AE_NAME` | Aggregated Ethernet (LAG) name | `ae0` |\n| `$DESCRIPTION` | Interface description string | `Link to P1Node to WANEdge1` |\n| `$MTU` | Interface MTU value | `1522` |\n| `$CORE_IFACE_1` .. `$CORE_IFACE_4` | Core transport interface.unit | `et-0/0/1.0` |\n| `$UNIT_ID` | Logical interface unit number | `1` |\n| `$VLAN_ID` | 802.1Q VLAN identifier | `1` |\n\n## LAG / ESI\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$ESI_ID` | Ethernet Segment Identifier (10 bytes) | `00:11:11:11:11:11:12:12:12:12` |\n| `$DF_PREFERENCE` | Designated-forwarder election preference | `150` |\n| `$LACP_PRIORITY` | LACP system priority | `100` |\n| `$LACP_SYSTEM_ID` | LACP system-id (must match across ESI peers) | `00:00:00:00:00:10` |\n| `$UNIT_ESI` | Per-unit ESI for per-VLAN DF election | `00:01:71:81:11:12:a1:00:00:01` |\n| `$UNIT_DF_PREFERENCE` | Per-unit DF preference value | `150` |\n\n## IRB\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$FILTER_NAME` | Firewall filter applied on IRB input | `mfc-filter` |\n| `$STATIC_MAC` | Static MAC for deterministic gateway | `00:10:94:00:00:01` |\n\n## Chassis\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$DEVICE_COUNT` | Aggregated Ethernet device-count | `25` |\n| `$FPC_SLOT` | FPC slot number | `0` |\n| `$PIC_SLOT` | PIC slot number | `0` |\n| `$TUNNEL_BW` | Tunnel-services bandwidth | `10g` |\n| `$PORT_ID` | Physical port number | `0` |\n| `$PORT_SPEED` | Port speed setting | `100g` |\n| `$BREAKOUT_PORT_ID` | Port to be broken out | `9` |\n| `$BREAKOUT_SPEED` | Per-lane speed after breakout | `10g` |\n| `$BREAKOUT_SUB_PORTS` | Number of breakout sub-ports | `4` |\n\n## BGP Peers\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$NEIGHBOR_1` .. `$NEIGHBOR_5` | iBGP peer addresses | `10.200.50.13` |\n| `$EXPORT_POLICY` | BGP group export policy list | `[ PS-send-ospf PS-BGP-TO-OSPF ]` |\n| `$CE_NEIGHBOR` | CE/TG BGP peer address | `172.16.1.2` |\n| `$CE_PEER_AS` | CE/TG peer autonomous system | `64513` |\n| `$AP_PEER_AS` | AP router peer AS (for CR VRs) | `64512` |\n| `$AP_NEIGHBOR_1` | AP1 peer address in virtual-router | `10.101.49.1` |\n| `$AP_NEIGHBOR_2` | AP2 peer address in virtual-router | `10.101.79.1` |\n| `$IXIA_PEER_AS` | Traffic generator peer AS | `64521` |\n| `$IXIA_NEIGHBOR` | Traffic generator peer address | `10.101.91.2` |\n\n## MPLS / RSVP\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$P2MP_LSP_NAME` | P2MP LSP template name | `P2MP` |\n| `$LSP_NAME_1` .. `$LSP_NAME_3` | Named unicast LSP | `lsp_to_AP1` |\n| `$LSP_DEST_1` .. `$LSP_DEST_3` | LSP destination (peer loopback) | `10.200.50.14` |\n\n## OSPF / BFD\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$BFD_INTERVAL` | BFD minimum-interval (ms) | `10` |\n| `$BFD_MULTIPLIER` | BFD detect-multiplier | `3` |\n\n## Policy\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$DIRECT_POLICY_NAME` | Direct-route redistribution policy | `PS-ADV_DIRECT` |\n| `$BGP_TO_OSPF_NAME` | BGP-to-OSPF leak policy | `PS-BGP-TO-OSPF` |\n| `$OSPF_TO_BGP_NAME` | OSPF-to-BGP export policy | `PS-send-ospf` |\n| `$MED_LOW_NAME` | Low-MED route-filter policy | `PS-med-10` |\n| `$MED_LOW_PREFIX` | Route-filter prefix for low MED | `10.101.0.0/16` |\n| `$MED_LOW_VALUE` | Low MED metric value | `10` |\n| `$MED_HIGH_NAME` | High-MED catch-all policy | `PS-med-30` |\n| `$MED_HIGH_VALUE` | High MED metric value | `30` |\n| `$EXPORT_POLICIES` | VR BGP export policy list | `[ med-10 med-30 ]` |\n\n## CoS\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$INTERFACE_1` .. `$INTERFACE_4` | CoS-applied interfaces | `et-0/0/1` |\n\n## Firewall\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$MCAST_DEST_PREFIX` | Multicast destination prefix to match | `225.0.0.0/16` |\n| `$FORWARDING_CLASS` | Target forwarding class for match | `FC-LLQ` |\n| `$UNICAST_DEST_1` | Unicast destination for VRF filter | `10.8.21.2/32` |\n| `$UNICAST_DEST_2` | Second unicast destination | `10.9.21.2/32` |\n| `$UNICAST_FWD_CLASS` | Forwarding class for unicast match | `FC-HIGH` |\n\n## Multicast / MVPN\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$RESOLVE_RATE` | Multicast PFE resolve-rate (pps) | `1000` |\n| `$MISMATCH_RATE` | RPF mismatch-rate (pps) | `1000` |\n| `$INSTANCE_NAME` | MVPN/VRF routing-instance name | `MVPN_INSTANCE1` |\n| `$CE_LOCAL_ADDRESS` | MVPN VRF local-address for CE peering | `172.16.1.1` |\n| `$MVPN_RT_IMPORT` | MVPN route-target import | `target:64512:101` |\n| `$MVPN_RT_EXPORT` | MVPN route-target export | `target:64512:101` |\n| `$RP_ADDRESS` | PIM Rendezvous Point address | `10.10.47.101` |\n| `$MCAST_GROUP_RANGE` | PIM multicast group-range prefix | `225.0.0.0/22` |\n| `$IRB_UNIT` | IRB interface bound to MVPN | `irb.1` |\n| `$LO_UNIT` | Loopback unit bound to MVPN | `lo0.1` |\n\n## EVPN\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$BD_NAME` | Bridge-domain name | `BD_EVPN_GROUP1` |\n| `$AE_UNIT` | LAG unit in bridge-domain | `ae0.1` |\n| `$IRB_UNIT` | Routing-interface in bridge-domain | `irb.1` |\n\n## L3VPN / Virtual-Router\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$VRF_NAME` | L3VPN VRF instance name | `VRF21` |\n| `$VR_NAME` | Virtual-router instance name | `VIRTUAL-ROUTER-V1` |\n| `$LOCAL_ADDRESS` | VRF eBGP local-address | `172.16.21.1` |\n| `$IFACE_AP1` | AP1-facing interface in VR | `et-5/0/0.1` |\n| `$IFACE_AP2` | AP2-facing interface in VR | `et-5/0/1.1` |\n| `$IFACE_TG` | Traffic-generator interface in VR | `xe-3/0/6.1` |\n\n## TWAMP / OAM\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$VRF_NAME_1` | TWAMP server VRF name | `MVPN_INSTANCE1` |\n| `$VRF_PORT_1` | TWAMP server port for VRF | `862` |\n| `$GLOBAL_PORT` | TWAMP server global port | `1862` |\n| `$CLIENT_LIST_NAME` | TWAMP client-list ACL name | `CR1_1` |\n| `$CLIENT_ADDRESS` | TWAMP client source address | `10.101.48.2/32` |\n| `$CONNECTION_NAME` | TWAMP client control-connection name | `CR24_1` |\n| `$DEST_PORT` | TWAMP client destination port | `862` |\n| `$ROUTING_INSTANCE` | TWAMP client routing-instance | `VIRTUAL-ROUTER-V1` |\n| `$TARGET_ADDRESS` | TWAMP probe target (server) address | `10.101.49.1` |\n| `$TEST_SESSION_NAME` | TWAMP test-session identifier | `T24_1` |\n| `$PROBE_COUNT` | Probes per test-session iteration | `100` |\n| `$PROBE_INTERVAL` | Probe interval in seconds | `1` |\n\n## VLAN Bridge-Domain (L2 Edge)\n\n| Variable | Description | Example |\n|----------|-------------|---------|\n| `$VLAN_NAME` | VLAN definition name | `vlan1` |\n| `$LAG_UNIT` | LAG unit in VLAN membership | `ae0.1` |\n| `$ACCESS_UNIT` | Access port unit in VLAN membership | `et-0/0/47.1` |\n"
+    },
+    {
+      "jvd": "metro_as_a_service",
+      "markdown": "# MaaS snip-library variables\n\nAuto-generated. 49 unique variables across 112 snips.\n\nEach `$VARIABLE` in a snip body is a placeholder that a deployer\nsubstitutes per-instance. Examples below are taken from the source\nJVD configs.\n\n| Variable | Used in | Example |\n|---|---|---|\n| `$AC_INTF` | 65 snip(s) | `et-0/0/13` |\n| `$AC_INTF_1` | 3 snip(s) | `et-0/0/0` |\n| `$AC_INTF_2` | 3 snip(s) | `et-0/0/51` |\n| `$COMM_RT` | 5 snip(s) | `61535:13075` |\n| `$ESI_ID` | 11 snip(s) | `00:81:10:13:10:10:10:00:00:01` |\n| `$ESI_ID_1` | 1 snip(s) | `00:10:44:11:50:12:02:00:00:00` |\n| `$ESI_ID_2` | 1 snip(s) | `00:10:44:11:50:12:01:00:00:00` |\n| `$FILTER_NAME` | 16 snip(s) | `f_port_based_fam_ccc` |\n| `$INPUT_VID` | 9 snip(s) | `3712` |\n| `$INPUT_VID_1` | 1 snip(s) | `3400` |\n| `$INPUT_VID_2` | 1 snip(s) | `3000` |\n| `$INSTANCE_NAME` | 26 snip(s) | `vpls_group_4005` |\n| `$IP_ADDRESS` | 3 snip(s) | `198.51.100.2/27` |\n| `$IRB_UNIT` | 3 snip(s) | `4075` |\n| `$LABEL_BLOCK_SIZE` | 3 snip(s) | `2` |\n| `$LOCAL_VID` | 6 snip(s) | `1` |\n| `$MAC` | 1 snip(s) | `00:01:33:44:11:12` |\n| `$MTU` | 8 snip(s) | `9192` |\n| `$OUTER_VID_TPID` | 3 snip(s) | `0x88a8.4082` |\n| `$POLICY_NAME` | 3 snip(s) | `evpn_group_80_4013` |\n| `$POLICY_NAME_1` | 2 snip(s) | `PS-$VPN_RT_COMM-EXPORT` |\n| `$POLICY_NAME_2` | 2 snip(s) | `PS-$VPN_RT_COMM-IMPORT` |\n| `$PUBLIC_PREFIX` | 2 snip(s) | `203.0.113.0/24` |\n| `$RD` | 23 snip(s) | `10.0.0.18:44444` |\n| `$RD_1` | 3 snip(s) | `10.0.0.6:14075` |\n| `$RD_2` | 3 snip(s) | `61000:13075` |\n| `$REMOTE_SITE_ID` | 4 snip(s) | `1119` |\n| `$REMOTE_VID` | 6 snip(s) | `2` |\n| `$ROUTER_ID` | 3 snip(s) | `10.0.0.6` |\n| `$SITE_ID` | 7 snip(s) | `5` |\n| `$SITE_NAME` | 3 snip(s) | `r18` |\n| `$SITE_RANGE` | 3 snip(s) | `2` |\n| `$UNIT` | 61 snip(s) | `0` |\n| `$UNIT_1` | 10 snip(s) | `4007` |\n| `$UNIT_2` | 10 snip(s) | `4008` |\n| `$VC_ID` | 3 snip(s) | `10120` |\n| `$VC_ID_1` | 1 snip(s) | `2006` |\n| `$VC_ID_2` | 1 snip(s) | `3333` |\n| `$VG_ADDRESS` | 1 snip(s) | `198.51.100.1` |\n| `$VG_MAC` | 1 snip(s) | `00:01:33:44:11:11` |\n| `$VLAN` | 28 snip(s) | `4075` |\n| `$VLAN_1` | 3 snip(s) | `4007` |\n| `$VLAN_2` | 3 snip(s) | `4008` |\n| `$VLAN_LIST_END` | 3 snip(s) | `4014` |\n| `$VLAN_LIST_START` | 3 snip(s) | `4013` |\n| `$VPN_RT_COMM` | 5 snip(s) | `METRO_L3VPN_4075` |\n| `$VRF_TARGET` | 23 snip(s) | `64535:44444` |\n| `$VRF_TARGET_1` | 1 snip(s) | `61535:14075` |\n| `$VRF_TARGET_2` | 1 snip(s) | `61535:13075` |\n"
     },
     {
       "jvd": "metro_ethernet_business_services",

--- a/service_provider/metro_as_a_service/configuration/conf/eaccess_evpn-vpws_lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eaccess_evpn-vpws_lsw.conf
@@ -1047,7 +1047,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/conf/eaccess_l2ckt_lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eaccess_l2ckt_lsw.conf
@@ -1034,7 +1034,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/conf/elan_ep-lan_evpn_elan.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/elan_ep-lan_evpn_elan.conf
@@ -1558,7 +1558,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/conf/eline_epl_l2vpn.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eline_epl_l2vpn.conf
@@ -63,6 +63,7 @@ interfaces {
     }
 }
 firewall {
+    family ccc {
         filter f_port_based_fam_ccc {
             interface-specific;
             term discard-l2cp {
@@ -609,6 +610,7 @@ routing-instances {
 
 regress@rtme-mx-59> show configuration groups MEF_TESTING |no-more
 firewall {
+    family ccc {
         filter f_port_based_fam_ccc {
             interface-specific;
             term discard-l2cp {
@@ -1005,7 +1007,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/conf/eline_evpl_evpn-fxc_aware_mh.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eline_evpl_evpn-fxc_aware_mh.conf
@@ -1854,7 +1854,7 @@ policy-options {
             then reject;
         }
     }
-    community evpn_vpws_fxc_aware_RT members [ target:63536:54100 target:63536:55100 ];
+    community evpn_vpws_fxc_aware_RT members target:63536:55100;
 }
 class-of-service {
     interfaces {

--- a/service_provider/metro_as_a_service/configuration/conf/eline_evpl_evpn_vpws_edge.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eline_evpl_evpn_vpws_edge.conf
@@ -32,6 +32,7 @@ policy-options {
 class-of-service {
     interfaces {
         et-0/0/13 {
+            scheduler-map SM-5G-SCHEDULER;
             unit 4000 {
                 classifiers {
                     ieee-802.1 CL-8021P;

--- a/service_provider/metro_as_a_service/configuration/conf/eline_evpl_evpn_vpws_mh_e2e.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eline_evpl_evpn_vpws_mh_e2e.conf
@@ -539,6 +539,7 @@ class-of-service {
             priority low;
         }
     }
+}
 
 AN2:
 regress@rtme-acx17> show configuration groups MEF_EVPN-VPWS-MH-E2E | no-more

--- a/service_provider/metro_as_a_service/configuration/conf/eline_evpl_l2vpn_e2e.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eline_evpl_l2vpn_e2e.conf
@@ -945,7 +945,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/conf/eline_evpl_vpls_fapm_ring_p2p.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/eline_evpl_vpls_fapm_ring_p2p.conf
@@ -925,7 +925,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/conf/etree_evp-tree_evpn-etree.conf
+++ b/service_provider/metro_as_a_service/configuration/conf/etree_evp-tree_evpn-etree.conf
@@ -2074,7 +2074,7 @@ class-of-service {
         }
         ieee-802.1 RR-8021P {
             forwarding-class FC-HIGH {
-                loss-priority low code-point 101;
+                loss-priority low code-point 100;
             }
             forwarding-class FC-MEDIUM {
                 loss-priority low code-point 010;

--- a/service_provider/metro_as_a_service/configuration/snips/README.md
+++ b/service_provider/metro_as_a_service/configuration/snips/README.md
@@ -1,0 +1,223 @@
+# MaaS Configuration Snip Library
+
+Templated, reusable Junos / EVO configuration building blocks extracted
+from the Metro-as-a-Service JVD's validated configurations.
+Every snip is a real fragment from a deployed JVD device, with values
+replaced by `$VARIABLES` and a 5-section header describing topic, where
+it was observed, design highlights, same-device dependencies, JVD
+service mapping, and variable definitions.
+
+**Snips:** 112 total — 50 Junos + 62 EVO
+
+## Layout
+
+```
+snips/
+├── junos/   — Junos OS (MX, ACX5448, ACX710)
+├── evo/     — Junos EVO (ACX7024, ACX7100, ACX7509)
+└── _variables.md   — global $VARIABLE index
+```
+
+Each OS tree groups snips by category:
+`services/`, `interfaces/`, `firewall/`, `cos/`, `policy/`, `apply-groups/`.
+
+## How to use a snip
+
+1. Open the `.conf` file — the header tells you what the snip does
+   and which other snips it pairs with on the same device.
+2. Substitute every `$VARIABLE` with your deployment value
+   (see [_variables.md](_variables.md) for the full index).
+3. Apply each `Pair with` dependency — these are configuration
+   stanzas that must coexist on the same device for the snip to
+   function (e.g. an EVPN service snip needs its attachment-circuit
+   interface snip and the matching CoS / firewall snips).
+
+Snip headers also list:
+- **Seen on** — devices and platforms where the pattern was observed
+- **Highlights** — design notes worth knowing before deploying
+- **JVD service mapping** — the MEF service group(s) the snip implements
+
+## JUNOS snips
+
+### Services (routing-instances + protocols)
+
+| Snip | Topic |
+|---|---|
+| [`bgp-vpls-p2p.conf`](junos/services/bgp-vpls-p2p.conf) | Service instance: bgp vpls p2p (MEF E-Line / EVPL) |
+| [`bridge-domain-lsw.conf`](junos/services/bridge-domain-lsw.conf) | Service instance: bridge domain lsw (MEF E-Access) |
+| [`evpn-elan.conf`](junos/services/evpn-elan.conf) | Service instance: evpn elan (MEF E-LAN / EP-LAN) |
+| [`evpn-elan-port-based.conf`](junos/services/evpn-elan-port-based.conf) | Service instance: evpn elan port based (MEF E-LAN / EVP-LAN) |
+| [`evpn-elan-type5.conf`](junos/services/evpn-elan-type5.conf) | Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN) |
+| [`evpn-elan-vlan-based-floating-pw.conf`](junos/services/evpn-elan-vlan-based-floating-pw.conf) | Service instance: evpn elan vlan based floating pw (MEF E-Line / EVPL) |
+| [`evpn-etree-vlan-based.conf`](junos/services/evpn-etree-vlan-based.conf) | Service instance: evpn etree vlan based (MEF E-Tree / EVP-Tree) |
+| [`evpn-fxc-vlan-unaware.conf`](junos/services/evpn-fxc-vlan-unaware.conf) | Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL) |
+| [`evpn-vpws-vlan-based.conf`](junos/services/evpn-vpws-vlan-based.conf) | Service instance: evpn vpws vlan based (MEF E-Line / EVPL) |
+| [`l2circuit-floating-pw.conf`](junos/services/l2circuit-floating-pw.conf) | Service instance: l2circuit floating pw (MEF E-Line / EVPL) |
+| [`l2vpn-kompella-port-based.conf`](junos/services/l2vpn-kompella-port-based.conf) | Service instance: l2vpn kompella port based (MEF E-Line / EPL) |
+| [`l2vpn-kompella-vlan-based.conf`](junos/services/l2vpn-kompella-vlan-based.conf) | Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL) |
+
+### Interfaces (attachment circuits)
+
+| Snip | Topic |
+|---|---|
+| [`ethernet-bridge.conf`](junos/interfaces/ethernet-bridge.conf) | Interface: ethernet bridge (MEF E-LAN / EP-LAN) |
+| [`ethernet-ccc.conf`](junos/interfaces/ethernet-ccc.conf) | Interface: ethernet ccc (MEF E-Line / EPL) |
+| [`irb-l3.conf`](junos/interfaces/irb-l3.conf) | Interface: irb l3 (MEF E-LAN / EVP-LAN) |
+| [`pseudowire-subscriber.conf`](junos/interfaces/pseudowire-subscriber.conf) | Interface: pseudowire subscriber (MEF E-Line / EVPL) |
+| [`vlan-bridge.conf`](junos/interfaces/vlan-bridge.conf) | Interface: vlan bridge (MEF E-Line / EVPL) |
+| [`vlan-bridge-esi.conf`](junos/interfaces/vlan-bridge-esi.conf) | Interface: vlan bridge esi (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-esi-etree-root.conf`](junos/interfaces/vlan-bridge-esi-etree-root.conf) | Interface: vlan bridge esi etree root (MEF E-Tree / EVP-Tree) |
+| [`vlan-bridge-esi-v2.conf`](junos/interfaces/vlan-bridge-esi-v2.conf) | Interface: vlan bridge esi (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-esi-v3.conf`](junos/interfaces/vlan-bridge-esi-v3.conf) | Interface: vlan bridge esi (MEF E-Line / EVPL) |
+| [`vlan-bridge-etree-leaf.conf`](junos/interfaces/vlan-bridge-etree-leaf.conf) | Interface: vlan bridge etree leaf (MEF E-Tree / EVP-Tree) |
+| [`vlan-bridge-qinq-stacked.conf`](junos/interfaces/vlan-bridge-qinq-stacked.conf) | Interface: vlan bridge qinq stacked (MEF E-Access) |
+| [`vlan-bridge-qinq-stacked-v2.conf`](junos/interfaces/vlan-bridge-qinq-stacked-v2.conf) | Interface: vlan bridge qinq stacked (MEF E-Access) |
+| [`vlan-ccc.conf`](junos/interfaces/vlan-ccc.conf) | Interface: vlan ccc (MEF E-Line / EVPL) |
+| [`vlan-ccc-v2.conf`](junos/interfaces/vlan-ccc-v2.conf) | Interface: vlan ccc (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map.conf`](junos/interfaces/vlan-ccc-vlan-map.conf) | Interface: vlan ccc vlan map (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map-esi.conf`](junos/interfaces/vlan-ccc-vlan-map-esi.conf) | Interface: vlan ccc vlan map esi (MEF E-Line / EVPL) |
+
+### Firewall filters
+
+| Snip | Topic |
+|---|---|
+| [`filter-bridge-color-aware.conf`](junos/firewall/filter-bridge-color-aware.conf) | Firewall: filter bridge color aware (MEF E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`filter-bridge-color-aware-cf0.conf`](junos/firewall/filter-bridge-color-aware-cf0.conf) | Firewall: filter bridge color aware cf0 (MEF E-Access) |
+| [`filter-bridge-color-aware-l2cp.conf`](junos/firewall/filter-bridge-color-aware-l2cp.conf) | Firewall: filter bridge color aware l2cp (MEF E-LAN / EP-LAN) |
+| [`filter-bridge-color-blind.conf`](junos/firewall/filter-bridge-color-blind.conf) | Firewall: filter bridge color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`filter-ccc-color-aware.conf`](junos/firewall/filter-ccc-color-aware.conf) | Firewall: filter ccc color aware (MEF E-Line / EVPL) |
+| [`filter-ccc-color-aware-l2cp.conf`](junos/firewall/filter-ccc-color-aware-l2cp.conf) | Firewall: filter ccc color aware l2cp (MEF E-Line / EPL) |
+| [`filter-ccc-color-blind.conf`](junos/firewall/filter-ccc-color-blind.conf) | Firewall: filter ccc color blind (MEF E-Line / EVPL) |
+| [`filter-ccc-color-blind-v2.conf`](junos/firewall/filter-ccc-color-blind-v2.conf) | Firewall: filter ccc color blind (MEF E-Line / EVPL) |
+| [`filter-ccc-color-blind-v3.conf`](junos/firewall/filter-ccc-color-blind-v3.conf) | Firewall: filter ccc color blind (MEF E-Line / EVPL) |
+| [`filter-eswitch-color-blind.conf`](junos/firewall/filter-eswitch-color-blind.conf) | Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL) |
+
+### Class-of-service
+
+| Snip | Topic |
+|---|---|
+| [`classifiers.conf`](junos/cos/classifiers.conf) | Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`cos-binding-ieee8021p.conf`](junos/cos/cos-binding-ieee8021p.conf) | Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`cos-binding-mpls.conf`](junos/cos/cos-binding-mpls.conf) | Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`forwarding-classes.conf`](junos/cos/forwarding-classes.conf) | Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`rewrite-rules.conf`](junos/cos/rewrite-rules.conf) | Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`scheduler-map.conf`](junos/cos/scheduler-map.conf) | Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`schedulers.conf`](junos/cos/schedulers.conf) | Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree) |
+| [`schedulers-legacy-acx.conf`](junos/cos/schedulers-legacy-acx.conf) | Class-of-service: schedulers legacy acx (MEF E-LAN / EVP-LAN, E-Line / EVPL) |
+| [`schedulers-v2.conf`](junos/cos/schedulers-v2.conf) | Class-of-service: schedulers (MEF E-LAN / EVP-LAN, E-Line / EVPL) |
+
+### Routing policy
+
+| Snip | Topic |
+|---|---|
+| [`policy-l3vpn-import-export.conf`](junos/policy/policy-l3vpn-import-export.conf) | Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN) |
+| [`policy-vpn-rt-export-gold.conf`](junos/policy/policy-vpn-rt-export-gold.conf) | Policy: policy vpn rt export gold (MEF E-Tree / EVP-Tree) |
+
+### Apply-groups
+
+| Snip | Topic |
+|---|---|
+| [`mef-testing.conf`](junos/apply-groups/mef-testing.conf) | Apply-group: mef testing (MEF E-LAN / EVP-LAN, E-Line / EVPL) |
+
+## EVO snips
+
+### Services (routing-instances + protocols)
+
+| Snip | Topic |
+|---|---|
+| [`bgp-vpls.conf`](evo/services/bgp-vpls.conf) | Service instance: bgp vpls (MEF E-LAN / EVP-LAN) |
+| [`bgp-vpls-p2p.conf`](evo/services/bgp-vpls-p2p.conf) | Service instance: bgp vpls p2p (MEF E-Line / EVPL) |
+| [`evpn-elan-bundle-port-based.conf`](evo/services/evpn-elan-bundle-port-based.conf) | Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN) |
+| [`evpn-elan-bundle-port-based-v2.conf`](evo/services/evpn-elan-bundle-port-based-v2.conf) | Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN) |
+| [`evpn-elan-port-based.conf`](evo/services/evpn-elan-port-based.conf) | Service instance: evpn elan port based (MEF E-LAN / EVP-LAN) |
+| [`evpn-elan-type5.conf`](evo/services/evpn-elan-type5.conf) | Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN) |
+| [`evpn-elan-type5-v2.conf`](evo/services/evpn-elan-type5-v2.conf) | Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN) |
+| [`evpn-elan-vlan-bundle.conf`](evo/services/evpn-elan-vlan-bundle.conf) | Service instance: evpn elan vlan bundle (MEF E-LAN / EVP-LAN) |
+| [`evpn-fxc-vlan-aware.conf`](evo/services/evpn-fxc-vlan-aware.conf) | Service instance: evpn fxc vlan aware (MEF E-Line / EVPL) |
+| [`evpn-fxc-vlan-unaware.conf`](evo/services/evpn-fxc-vlan-unaware.conf) | Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL) |
+| [`evpn-vpws-lsw.conf`](evo/services/evpn-vpws-lsw.conf) | Service instance: evpn vpws lsw (MEF E-Access) |
+| [`evpn-vpws-port-based.conf`](evo/services/evpn-vpws-port-based.conf) | Service instance: evpn vpws port based (MEF E-Line / EPL) |
+| [`evpn-vpws-vlan-based.conf`](evo/services/evpn-vpws-vlan-based.conf) | Service instance: evpn vpws vlan based (MEF E-Line / EVPL) |
+| [`evpn-vpws-vlan-based-v2.conf`](evo/services/evpn-vpws-vlan-based-v2.conf) | Service instance: evpn vpws vlan based (MEF E-Line / EVPL) |
+| [`l2circuit-floating-pw.conf`](evo/services/l2circuit-floating-pw.conf) | Service instance: l2circuit floating pw (MEF E-Line / EVPL) |
+| [`l2circuit-hot-standby-backup.conf`](evo/services/l2circuit-hot-standby-backup.conf) | Service instance: l2circuit hot standby backup (MEF E-Line / EVPL) |
+| [`l2circuit-hot-standby-primary.conf`](evo/services/l2circuit-hot-standby-primary.conf) | Service instance: l2circuit hot standby primary (MEF E-Line / EVPL) |
+| [`l2circuit-lsw.conf`](evo/services/l2circuit-lsw.conf) | Service instance: l2circuit lsw (MEF E-Access) |
+| [`l2vpn-kompella-port-based.conf`](evo/services/l2vpn-kompella-port-based.conf) | Service instance: l2vpn kompella port based (MEF E-Line / EPL) |
+| [`l2vpn-kompella-vlan-based.conf`](evo/services/l2vpn-kompella-vlan-based.conf) | Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL) |
+
+### Interfaces (attachment circuits)
+
+| Snip | Topic |
+|---|---|
+| [`ethernet-bridge.conf`](evo/interfaces/ethernet-bridge.conf) | Interface: ethernet bridge (MEF E-LAN / EP-LAN) |
+| [`ethernet-bridge-v2.conf`](evo/interfaces/ethernet-bridge-v2.conf) | Interface: ethernet bridge (MEF E-LAN / EP-LAN) |
+| [`ethernet-ccc.conf`](evo/interfaces/ethernet-ccc.conf) | Interface: ethernet ccc (MEF E-Line / EPL) |
+| [`ethernet-ccc-v2.conf`](evo/interfaces/ethernet-ccc-v2.conf) | Interface: ethernet ccc (MEF E-Line / EPL) |
+| [`irb-l3.conf`](evo/interfaces/irb-l3.conf) | Interface: irb l3 (MEF E-LAN / EVP-LAN) |
+| [`irb-l3-vga.conf`](evo/interfaces/irb-l3-vga.conf) | Interface: irb l3 vga (MEF E-LAN / EVP-LAN) |
+| [`physical-mtu.conf`](evo/interfaces/physical-mtu.conf) | Interface: physical mtu (MEF E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`vlan-bridge.conf`](evo/interfaces/vlan-bridge.conf) | Interface: vlan bridge (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-bundle.conf`](evo/interfaces/vlan-bridge-bundle.conf) | Interface: vlan bridge bundle (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-esi.conf`](evo/interfaces/vlan-bridge-esi.conf) | Interface: vlan bridge esi (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-esi-bundle.conf`](evo/interfaces/vlan-bridge-esi-bundle.conf) | Interface: vlan bridge esi bundle (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-v2.conf`](evo/interfaces/vlan-bridge-v2.conf) | Interface: vlan bridge (MEF E-Line / EVPL) |
+| [`vlan-bridge-vlan-map.conf`](evo/interfaces/vlan-bridge-vlan-map.conf) | Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN) |
+| [`vlan-bridge-vlan-map-v2.conf`](evo/interfaces/vlan-bridge-vlan-map-v2.conf) | Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN) |
+| [`vlan-ccc.conf`](evo/interfaces/vlan-ccc.conf) | Interface: vlan ccc (MEF E-Line / EVPL) |
+| [`vlan-ccc-2-units.conf`](evo/interfaces/vlan-ccc-2-units.conf) | Interface: vlan ccc 2 units (MEF E-Line / EVPL) |
+| [`vlan-ccc-esi.conf`](evo/interfaces/vlan-ccc-esi.conf) | Interface: vlan ccc esi (MEF E-Line / EVPL) |
+| [`vlan-ccc-qinq-stacked-qinq-tpid.conf`](evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf) | Interface: vlan ccc qinq stacked qinq tpid (MEF E-Access) |
+| [`vlan-ccc-v2.conf`](evo/interfaces/vlan-ccc-v2.conf) | Interface: vlan ccc (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map.conf`](evo/interfaces/vlan-ccc-vlan-map.conf) | Interface: vlan ccc vlan map (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map-bundle-qinq-tpid.conf`](evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf) | Interface: vlan ccc vlan map bundle qinq tpid (MEF E-Access) |
+| [`vlan-ccc-vlan-map-esi.conf`](evo/interfaces/vlan-ccc-vlan-map-esi.conf) | Interface: vlan ccc vlan map esi (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map-esi-2-units.conf`](evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf) | Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map-esi-2-units-v2.conf`](evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf) | Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL) |
+| [`vlan-ccc-vlan-map-v2.conf`](evo/interfaces/vlan-ccc-vlan-map-v2.conf) | Interface: vlan ccc vlan map (MEF E-Line / EVPL) |
+
+### Firewall filters
+
+| Snip | Topic |
+|---|---|
+| [`filter-ccc-color-blind.conf`](evo/firewall/filter-ccc-color-blind.conf) | Firewall: filter ccc color blind (MEF E-Access, E-Line / EVPL) |
+| [`filter-ccc-color-blind-l2cp.conf`](evo/firewall/filter-ccc-color-blind-l2cp.conf) | Firewall: filter ccc color blind l2cp (MEF E-Line / EPL) |
+| [`filter-ccc-color-blind-v2.conf`](evo/firewall/filter-ccc-color-blind-v2.conf) | Firewall: filter ccc color blind (MEF E-Line / EVPL) |
+| [`filter-eswitch-color-blind.conf`](evo/firewall/filter-eswitch-color-blind.conf) | Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL) |
+| [`filter-eswitch-color-blind-l2cp.conf`](evo/firewall/filter-eswitch-color-blind-l2cp.conf) | Firewall: filter eswitch color blind l2cp (MEF E-LAN / EP-LAN) |
+| [`filter-eswitch-color-blind-v2.conf`](evo/firewall/filter-eswitch-color-blind-v2.conf) | Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN) |
+
+### Class-of-service
+
+| Snip | Topic |
+|---|---|
+| [`classifiers.conf`](evo/cos/classifiers.conf) | Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`cos-binding-ieee8021p.conf`](evo/cos/cos-binding-ieee8021p.conf) | Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`cos-binding-mpls.conf`](evo/cos/cos-binding-mpls.conf) | Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`forwarding-classes.conf`](evo/cos/forwarding-classes.conf) | Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`rewrite-rules.conf`](evo/cos/rewrite-rules.conf) | Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`scheduler-map.conf`](evo/cos/scheduler-map.conf) | Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+| [`schedulers.conf`](evo/cos/schedulers.conf) | Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+
+### Routing policy
+
+| Snip | Topic |
+|---|---|
+| [`policy-l3vpn-import-export.conf`](evo/policy/policy-l3vpn-import-export.conf) | Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN) |
+| [`policy-vpn-rt-export-bronze.conf`](evo/policy/policy-vpn-rt-export-bronze.conf) | Policy: policy vpn rt export bronze (MEF E-LAN / EVP-LAN, E-Line / EVPL) |
+| [`policy-vpn-rt-export-gold.conf`](evo/policy/policy-vpn-rt-export-gold.conf) | Policy: policy vpn rt export gold (MEF E-Line / EVPL) |
+
+### Apply-groups
+
+| Snip | Topic |
+|---|---|
+| [`mef-forwarding-profile.conf`](evo/apply-groups/mef-forwarding-profile.conf) | Apply-group: mef forwarding profile (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL) |
+
+## Provenance
+
+Source configurations: [`configuration/conf/`](../conf/) (per-service,
+per-device hierarchical Junos and EVO captures from the MaaS lab).
+Snips were derived by detecting recurring stanzas across devices and
+service variants, templating instance-specific values into
+`$VARIABLES`, and recording cross-snip pair-with edges from the same
+device's configuration tree.

--- a/service_provider/metro_as_a_service/configuration/snips/_variables.md
+++ b/service_provider/metro_as_a_service/configuration/snips/_variables.md
@@ -1,0 +1,59 @@
+# MaaS snip-library variables
+
+Auto-generated. 49 unique variables across 112 snips.
+
+Each `$VARIABLE` in a snip body is a placeholder that a deployer
+substitutes per-instance. Examples below are taken from the source
+JVD configs.
+
+| Variable | Used in | Example |
+|---|---|---|
+| `$AC_INTF` | 65 snip(s) | `et-0/0/13` |
+| `$AC_INTF_1` | 3 snip(s) | `et-0/0/0` |
+| `$AC_INTF_2` | 3 snip(s) | `et-0/0/51` |
+| `$COMM_RT` | 5 snip(s) | `61535:13075` |
+| `$ESI_ID` | 11 snip(s) | `00:81:10:13:10:10:10:00:00:01` |
+| `$ESI_ID_1` | 1 snip(s) | `00:10:44:11:50:12:02:00:00:00` |
+| `$ESI_ID_2` | 1 snip(s) | `00:10:44:11:50:12:01:00:00:00` |
+| `$FILTER_NAME` | 16 snip(s) | `f_port_based_fam_ccc` |
+| `$INPUT_VID` | 9 snip(s) | `3712` |
+| `$INPUT_VID_1` | 1 snip(s) | `3400` |
+| `$INPUT_VID_2` | 1 snip(s) | `3000` |
+| `$INSTANCE_NAME` | 26 snip(s) | `vpls_group_4005` |
+| `$IP_ADDRESS` | 3 snip(s) | `198.51.100.2/27` |
+| `$IRB_UNIT` | 3 snip(s) | `4075` |
+| `$LABEL_BLOCK_SIZE` | 3 snip(s) | `2` |
+| `$LOCAL_VID` | 6 snip(s) | `1` |
+| `$MAC` | 1 snip(s) | `00:01:33:44:11:12` |
+| `$MTU` | 8 snip(s) | `9192` |
+| `$OUTER_VID_TPID` | 3 snip(s) | `0x88a8.4082` |
+| `$POLICY_NAME` | 3 snip(s) | `evpn_group_80_4013` |
+| `$POLICY_NAME_1` | 2 snip(s) | `PS-$VPN_RT_COMM-EXPORT` |
+| `$POLICY_NAME_2` | 2 snip(s) | `PS-$VPN_RT_COMM-IMPORT` |
+| `$PUBLIC_PREFIX` | 2 snip(s) | `203.0.113.0/24` |
+| `$RD` | 23 snip(s) | `10.0.0.18:44444` |
+| `$RD_1` | 3 snip(s) | `10.0.0.6:14075` |
+| `$RD_2` | 3 snip(s) | `61000:13075` |
+| `$REMOTE_SITE_ID` | 4 snip(s) | `1119` |
+| `$REMOTE_VID` | 6 snip(s) | `2` |
+| `$ROUTER_ID` | 3 snip(s) | `10.0.0.6` |
+| `$SITE_ID` | 7 snip(s) | `5` |
+| `$SITE_NAME` | 3 snip(s) | `r18` |
+| `$SITE_RANGE` | 3 snip(s) | `2` |
+| `$UNIT` | 61 snip(s) | `0` |
+| `$UNIT_1` | 10 snip(s) | `4007` |
+| `$UNIT_2` | 10 snip(s) | `4008` |
+| `$VC_ID` | 3 snip(s) | `10120` |
+| `$VC_ID_1` | 1 snip(s) | `2006` |
+| `$VC_ID_2` | 1 snip(s) | `3333` |
+| `$VG_ADDRESS` | 1 snip(s) | `198.51.100.1` |
+| `$VG_MAC` | 1 snip(s) | `00:01:33:44:11:11` |
+| `$VLAN` | 28 snip(s) | `4075` |
+| `$VLAN_1` | 3 snip(s) | `4007` |
+| `$VLAN_2` | 3 snip(s) | `4008` |
+| `$VLAN_LIST_END` | 3 snip(s) | `4014` |
+| `$VLAN_LIST_START` | 3 snip(s) | `4013` |
+| `$VPN_RT_COMM` | 5 snip(s) | `METRO_L3VPN_4075` |
+| `$VRF_TARGET` | 23 snip(s) | `64535:44444` |
+| `$VRF_TARGET_1` | 1 snip(s) | `61535:14075` |
+| `$VRF_TARGET_2` | 1 snip(s) | `61535:13075` |

--- a/service_provider/metro_as_a_service/configuration/snips/evo/apply-groups/mef-forwarding-profile.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/apply-groups/mef-forwarding-profile.conf
@@ -1,0 +1,21 @@
+/*
+ * Topic:
+ *   Apply-group: mef forwarding profile (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Enables MEF forwarding profile system-wide
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+system {
+    packet-forwarding-options {
+        mef-forwarding-profile;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/apply-groups/mef-forwarding-profile.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/apply-groups/mef-forwarding-profile.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Apply-group: mef forwarding profile (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Apply-group: mef forwarding profile (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/classifiers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/classifiers.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/classifiers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/classifiers.conf
@@ -1,0 +1,128 @@
+/*
+ * Topic:
+ *   Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Forwarding-class definitions / classifier mapping
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+classifiers {
+    dscp CL-DSCP {
+        import default;
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-points cs6;
+            loss-priority high code-points cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-points [ cs4 af41 ];
+            loss-priority medium-high code-points af42;
+            loss-priority high code-points af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-points ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-points [ cs3 af31 ];
+            loss-priority medium-high code-points af32;
+            loss-priority high code-points af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-points cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points [ cs2 af21 ];
+            loss-priority medium-high code-points af22;
+            loss-priority high code-points af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points [ cs1 af11 ];
+            loss-priority medium-high code-points af12;
+            loss-priority high code-points af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority high code-points be;
+        }
+    }
+    dscp-ipv6 CL-DSCP-IPV6 {
+        import default;
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-points cs6;
+            loss-priority high code-points cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-points [ cs4 af41 ];
+            loss-priority medium-high code-points af42;
+            loss-priority high code-points af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-points ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-points [ cs3 af31 ];
+            loss-priority medium-high code-points af32;
+            loss-priority high code-points af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-points cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points [ cs2 af21 ];
+            loss-priority medium-high code-points af22;
+            loss-priority high code-points af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points [ cs1 af11 ];
+            loss-priority medium-high code-points af12;
+            loss-priority high code-points af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority high code-points be;
+        }
+    }
+    exp CL-MPLS {
+        import default;
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-points 110;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-points 100;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-points 101;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-points 011;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-points 111;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points 010;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points 001;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-points 000;
+        }
+    }
+    ieee-802.1 CL-8021P {
+        forwarding-class FC-HIGH {
+            loss-priority low code-points [ 101 100 ];
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points [ 011 010 ];
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points [ 001 000 ];
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-ieee8021p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-ieee8021p.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-ieee8021p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-ieee8021p.conf
@@ -1,0 +1,34 @@
+/*
+ * Topic:
+ *   Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - L2 CE-facing CoS binding (classify + rewrite IEEE 802.1p)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/forwarding-classes.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/cos/scheduler-map.conf
+ *   - evo/cos/schedulers.conf
+ *
+ * Variables:
+ *   (none)
+ */
+interfaces {
+    $AC_INTF {
+        scheduler-map SM-5G-SCHEDULER;
+        unit $UNIT {
+            classifiers {
+                ieee-802.1 CL-8021P;
+            }
+            rewrite-rules {
+                ieee-802.1 RR-8021P;
+            }
+        }
+    }
+}
+

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-mpls.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-mpls.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-mpls.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/cos-binding-mpls.conf
@@ -1,0 +1,34 @@
+/*
+ * Topic:
+ *   Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - MPLS core-facing CoS binding (classify + rewrite EXP)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/forwarding-classes.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/cos/scheduler-map.conf
+ *   - evo/cos/schedulers.conf
+ *
+ * Variables:
+ *   (none)
+ */
+interfaces {
+    $AC_INTF {
+        scheduler-map SM-5G-SCHEDULER;
+        unit $UNIT {
+            classifiers {
+                exp CL-MPLS;
+            }
+            rewrite-rules {
+                exp RR-MPLS;
+            }
+        }
+    }
+}
+

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/forwarding-classes.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/forwarding-classes.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/forwarding-classes.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/forwarding-classes.conf
@@ -1,0 +1,26 @@
+/*
+ * Topic:
+ *   Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Forwarding-class definitions / classifier mapping
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+forwarding-classes {
+    class FC-SIGNALING queue-num 7;
+    class FC-LLQ queue-num 6;
+    class FC-REALTIME queue-num 5;
+    class FC-HIGH queue-num 4;
+    class FC-CONTROL queue-num 3;
+    class FC-MEDIUM queue-num 2;
+    class FC-LOW queue-num 1;
+    class FC-BEST-EFFORT queue-num 0;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/rewrite-rules.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/rewrite-rules.conf
@@ -1,0 +1,144 @@
+/*
+ * Topic:
+ *   Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Forwarding-class definitions / classifier mapping
+ *   - Rewrite-rules for egress marking
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+rewrite-rules {
+    dscp RR-DSCP {
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-point cs6;
+            loss-priority high code-point cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-point af41;
+            loss-priority medium-high code-point af42;
+            loss-priority high code-point af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-point ef;
+            loss-priority high code-point ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-point af31;
+            loss-priority medium-high code-point af32;
+            loss-priority high code-point af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-point cs7;
+            loss-priority high code-point cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point af21;
+            loss-priority medium-high code-point af22;
+            loss-priority high code-point af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point af11;
+            loss-priority medium-high code-point af12;
+            loss-priority high code-point af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-point be;
+            loss-priority high code-point be;
+        }
+    }
+    dscp-ipv6 RR-DSCP-IPV6 {
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-point cs6;
+            loss-priority high code-point cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-point af41;
+            loss-priority medium-high code-point af42;
+            loss-priority high code-point af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-point ef;
+            loss-priority high code-point ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-point af31;
+            loss-priority medium-high code-point af32;
+            loss-priority high code-point af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-point cs7;
+            loss-priority high code-point cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point af21;
+            loss-priority medium-high code-point af22;
+            loss-priority high code-point af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point af11;
+            loss-priority medium-high code-point af12;
+            loss-priority high code-point af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-point be;
+            loss-priority high code-point be;
+        }
+    }
+    exp RR-MPLS {
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-point 110;
+            loss-priority high code-point 110;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-point 100;
+            loss-priority medium-high code-point 100;
+            loss-priority high code-point 100;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-point 101;
+            loss-priority high code-point 101;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-point 011;
+            loss-priority medium-high code-point 011;
+            loss-priority high code-point 011;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-point 111;
+            loss-priority high code-point 111;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point 010;
+            loss-priority medium-high code-point 010;
+            loss-priority high code-point 010;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point 001;
+            loss-priority medium-high code-point 001;
+            loss-priority high code-point 001;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-point 000;
+            loss-priority high code-point 000;
+        }
+    }
+    ieee-802.1 RR-8021P {
+        forwarding-class FC-HIGH {
+            loss-priority low code-point 100;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point 010;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point 000;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/rewrite-rules.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/rewrite-rules.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/scheduler-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/scheduler-map.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/scheduler-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/scheduler-map.conf
@@ -1,0 +1,29 @@
+/*
+ * Topic:
+ *   Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Scheduler-map binding queues to schedulers
+ *   - Forwarding-class definitions / classifier mapping
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+scheduler-maps {
+    SM-5G-SCHEDULER {
+        forwarding-class FC-SIGNALING scheduler SC-SIGNALING;
+        forwarding-class FC-LLQ scheduler SC-LLQ;
+        forwarding-class FC-REALTIME scheduler SC-REALTIME;
+        forwarding-class FC-HIGH scheduler SC-HIGH;
+        forwarding-class FC-CONTROL scheduler SC-CONTROL;
+        forwarding-class FC-MEDIUM scheduler SC-MEDIUM;
+        forwarding-class FC-LOW scheduler SC-LOW;
+        forwarding-class FC-BEST-EFFORT scheduler SC-BEST-EFFORT;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/schedulers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/schedulers.conf
@@ -1,0 +1,62 @@
+/*
+ * Topic:
+ *   Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Per-queue scheduler shaping / buffer / priority
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+schedulers {
+    SC-SIGNALING {
+        shaping-rate percent 5;
+        buffer-size percent 5;
+        priority strict-high;
+    }
+    SC-LLQ {
+        shaping-rate percent 40;
+        buffer-size percent 10;
+        priority low-latency;
+    }
+    SC-REALTIME {
+        shaping-rate percent 30;
+        buffer-size percent 20;
+        priority medium-high;
+    }
+    SC-HIGH {
+        transmit-rate percent 40;
+        buffer-size percent 30;
+        priority low;
+    }
+    SC-CONTROL {
+        shaping-rate percent 5;
+        buffer-size percent 5;
+        priority high;
+    }
+    SC-MEDIUM {
+        transmit-rate percent 30;
+        buffer-size percent 20;
+        priority low;
+    }
+    SC-LOW {
+        transmit-rate percent 20;
+        buffer-size percent 10;
+        priority low;
+    }
+    SC-BEST-EFFORT {
+        transmit-rate {
+            remainder;
+        }
+        buffer-size {
+            remainder;
+        }
+        priority low;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/cos/schedulers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/cos/schedulers.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-l2cp.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color blind l2cp (MEF E-Line / EPL)
+ * Topic:   Firewall: filter ccc color blind l2cp (MEF E-Line / EPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-l2cp.conf
@@ -1,0 +1,144 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color blind l2cp (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards L2CP/BPDU destination-mac frames
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Junos: MA5 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_port_based_fam_ccc
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard-l2cp {
+                from {
+                    destination-mac-address {
+                        01:80:c2:00:00:07/48;
+                        01:80:c2:00:00:0e/48;
+                        01:80:c2:00:00:20/48;
+                        01:80:c2:00:00:21/48;
+                        01:80:c2:00:00:22/48;
+                        01:80:c2:00:00:23/48;
+                        01:80:c2:00:00:2a/48;
+                        01:80:c2:00:00:2d/48;
+                        01:80:c2:00:00:2e/48;
+                        01:80:c2:00:00:2f/48;
+                        01:80:c2:00:00:2b/48;
+                        01:80:c2:00:00:24/48;
+                        01:80:c2:00:00:25/48;
+                        01:80:c2:00:00:26/48;
+                        01:80:c2:00:00:27/48;
+                        01:80:c2:00:00:28/48;
+                        01:80:c2:00:00:29/48;
+                        01:80:c2:00:00:2c/48;
+                    }
+                }
+                then {
+                    count l2cp_discard;
+                    discard;
+                }
+            }
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-v2.conf
@@ -1,0 +1,116 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA1.1 (ACX7024), AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.2 (ACX7024)
+ *   Junos: MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MA5 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_vlan-based_fam_ccc
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ * Topic:   Firewall: filter ccc color blind (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA1.1 (ACX7024), AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind.conf
@@ -1,0 +1,116 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color blind (MEF E-Access, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: MA1.1 (ACX7024), AN3 (ACX7100-48L)
+ *   Junos: MA5 (MX204), AN1 (MX204), AN2 (ACX5448), MSE1 (MX304), MSE2 (MX304)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_vlan-based_fam_ccc
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-ccc-color-blind.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color blind (MEF E-Access, E-Line / EVPL)
+ * Topic:   Firewall: filter ccc color blind (MEF E-Access, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-l2cp.conf
@@ -1,0 +1,144 @@
+/*
+ * Topic:
+ *   Firewall: filter eswitch color blind l2cp (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - family ethernet-switching filter (Junos/ACX L2 switching path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards L2CP/BPDU destination-mac frames
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Junos: MA5 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_epl_bridge
+ */
+firewall {
+    family ethernet-switching {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard-l2cp {
+                from {
+                    destination-mac-address {
+                        01:80:c2:00:00:07/48;
+                        01:80:c2:00:00:0e/48;
+                        01:80:c2:00:00:20/48;
+                        01:80:c2:00:00:21/48;
+                        01:80:c2:00:00:22/48;
+                        01:80:c2:00:00:23/48;
+                        01:80:c2:00:00:2a/48;
+                        01:80:c2:00:00:2d/48;
+                        01:80:c2:00:00:2e/48;
+                        01:80:c2:00:00:2f/48;
+                        01:80:c2:00:00:2b/48;
+                        01:80:c2:00:00:24/48;
+                        01:80:c2:00:00:25/48;
+                        01:80:c2:00:00:26/48;
+                        01:80:c2:00:00:27/48;
+                        01:80:c2:00:00:28/48;
+                        01:80:c2:00:00:29/48;
+                        01:80:c2:00:00:2c/48;
+                    }
+                }
+                then {
+                    discard;
+                    count l2cp_discard;
+                }
+            }
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    discard;
+                    count discard_pcp6_7;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    count high_class;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    count class_medium;
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    count class_low;
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                }
+            }
+            term default {
+                then {
+                    count default;
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-l2cp.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter eswitch color blind l2cp (MEF E-LAN / EP-LAN)
+ * Topic:   Firewall: filter eswitch color blind l2cp (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-v2.conf
@@ -1,0 +1,106 @@
+/*
+ * Topic:
+ *   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - family ethernet-switching filter (Junos/ACX L2 switching path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024)
+ *   Junos: MSE1 (MX304), AN1 (MX204), AN2 (ACX5448)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_elan-evpn
+ */
+firewall {
+    family ethernet-switching {
+        filter $FILTER_NAME {
+            interface-specific;
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    count high_class;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    count class_medium;
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    count class_low;
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                }
+            }
+            term default {
+                then {
+                    count default;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN)
+ * Topic:   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind.conf
@@ -1,0 +1,115 @@
+/*
+ * Topic:
+ *   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - family ethernet-switching filter (Junos/ACX L2 switching path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Junos: MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), MA5 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_elan-evpn
+ */
+firewall {
+    family ethernet-switching {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    discard;
+                    count discard_pcp6_7;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    count high_class;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    count class_medium;
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    count class_low;
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                }
+            }
+            term default {
+                then {
+                    count default;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/firewall/filter-eswitch-color-blind.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ * Topic:   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge-v2.conf
@@ -1,0 +1,33 @@
+/*
+ * Topic:
+ *   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation ethernet-bridge
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind-l2cp.conf
+ *   - evo/services/evpn-elan-bundle-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $MTU      e.g. 9192
+ *   $UNIT     e.g. 0
+ */
+$AC_INTF {
+    mtu $MTU;
+    encapsulation ethernet-bridge;
+    unit $UNIT {
+        family ethernet-switching {
+            filter {
+                input f_epl_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
+ * Topic:   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Evo: MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge.conf
@@ -1,0 +1,31 @@
+/*
+ * Topic:
+ *   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation ethernet-bridge
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind-l2cp.conf
+ *   - evo/services/evpn-elan-bundle-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT     e.g. 0
+ */
+$AC_INTF {
+    encapsulation ethernet-bridge;
+    unit $UNIT {
+        family ethernet-switching {
+            filter {
+                input f_epl_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-bridge.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
+ * Topic:   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: ethernet ccc (MEF E-Line / EPL)
+ * Topic:   Interface: ethernet ccc (MEF E-Line / EPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc-v2.conf
@@ -1,0 +1,31 @@
+/*
+ * Topic:
+ *   Interface: ethernet ccc (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation ethernet-ccc
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/l2vpn-kompella-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT     e.g. 0
+ */
+$AC_INTF {
+    encapsulation ethernet-ccc;
+    unit $UNIT {
+        family ccc {
+            filter {
+                input f_eline-evpn-vpws;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: ethernet ccc (MEF E-Line / EPL)
+ * Topic:   Interface: ethernet ccc (MEF E-Line / EPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/ethernet-ccc.conf
@@ -1,0 +1,31 @@
+/*
+ * Topic:
+ *   Interface: ethernet ccc (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation ethernet-ccc
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind-l2cp.conf
+ *   - evo/services/evpn-vpws-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT     e.g. 0
+ */
+$AC_INTF {
+    encapsulation ethernet-ccc;
+    unit $UNIT {
+        family ccc {
+            filter {
+                input f_port_based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3-vga.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3-vga.conf
@@ -1,0 +1,30 @@
+/*
+ * Topic:
+ *   Interface: irb l3 vga (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - IRB unit for L3 termination
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   $IP_ADDRESS  e.g. 198.51.100.2/27
+ *   $UNIT        e.g. 4075
+ *   $VG_ADDRESS  e.g. 198.51.100.1
+ *   $VG_MAC      e.g. 00:01:33:44:11:11
+ */
+irb {
+    unit $UNIT {
+        virtual-gateway-accept-data;
+        family inet {
+            address $IP_ADDRESS {
+                virtual-gateway-address $VG_ADDRESS;
+            }
+        }
+        virtual-gateway-v4-mac $VG_MAC;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3-vga.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3-vga.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: irb l3 vga (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: irb l3 vga (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3.conf
@@ -1,0 +1,26 @@
+/*
+ * Topic:
+ *   Interface: irb l3 (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - IRB unit for L3 termination
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   $IP_ADDRESS  e.g. 203.0.113.1/27
+ *   $MAC         e.g. 00:01:33:44:11:12
+ *   $UNIT        e.g. 4075
+ */
+irb {
+    unit $UNIT {
+        family inet {
+            address $IP_ADDRESS;
+        }
+        mac $MAC;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/irb-l3.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: irb l3 (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: irb l3 (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/physical-mtu.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/physical-mtu.conf
@@ -1,0 +1,36 @@
+/*
+ * Topic:
+ *   Interface: physical mtu (MEF E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - (no auto-generated highlights)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind-l2cp.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/firewall/filter-eswitch-color-blind-l2cp.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/bgp-vpls.conf
+ *   - evo/services/evpn-elan-bundle-port-based.conf
+ *   - evo/services/evpn-elan-type5.conf
+ *   - evo/services/evpn-elan-vlan-bundle.conf
+ *   - evo/services/evpn-fxc-vlan-unaware.conf
+ *   - evo/services/evpn-vpws-port-based.conf
+ *   - evo/services/evpn-vpws-vlan-based.conf
+ *   - evo/services/l2circuit-hot-standby-primary.conf
+ *   - evo/services/l2vpn-kompella-port-based.conf
+ *   - evo/services/l2vpn-kompella-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $MTU      e.g. 9102
+ */
+$AC_INTF {
+    mtu $MTU;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/physical-mtu.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/physical-mtu.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: physical mtu (MEF E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
+ * Topic:   Interface: physical mtu (MEF E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-bundle.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-bundle.conf
@@ -1,0 +1,36 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge bundle (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/evpn-elan-vlan-bundle.conf
+ *
+ * Variables:
+ *   $AC_INTF          e.g. et-0/0/13
+ *   $UNIT             e.g. 4013
+ *   $VLAN_LIST_END    e.g. 4014
+ *   $VLAN_LIST_START  e.g. 4013
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;
+        family ethernet-switching {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-bundle.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-bundle.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge bundle (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge bundle (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi-bundle.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi-bundle.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge esi bundle (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge esi bundle (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi-bundle.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi-bundle.conf
@@ -1,0 +1,40 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge esi bundle (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/evpn-elan-vlan-bundle.conf
+ *
+ * Variables:
+ *   $AC_INTF          e.g. ae67
+ *   $ESI_ID           e.g. 00:81:10:13:10:10:10:00:00:01
+ *   $UNIT             e.g. 4013
+ *   $VLAN_LIST_END    e.g. 4014
+ *   $VLAN_LIST_START  e.g. 4013
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ethernet-switching {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi.conf
@@ -1,0 +1,40 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), AN3 (ACX7100-48L), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/evpn-elan-port-based.conf
+ *   - evo/services/evpn-elan-type5.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae67
+ *   $ESI_ID   e.g. 00:22:11:77:11:12:a1:00:00:01
+ *   $UNIT     e.g. 4075
+ *   $VLAN     e.g. 4075
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ethernet-switching {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-esi.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), AN3 (ACX7100-48L), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan bridge (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-v2.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/bgp-vpls-p2p.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/12
+ *   $UNIT     e.g. 4005
+ *   $VLAN     e.g. 4005
+ */
+$AC_INTF {
+    vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        family ethernet-switching {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: MEG2 (ACX7509), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map-v2.conf
@@ -1,0 +1,39 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: MEG2 (ACX7509), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/bgp-vpls.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. et-2/0/4
+ *   $INPUT_VID  e.g. 3712
+ *   $UNIT       e.g. 4012
+ *   $VLAN       e.g. 4012
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        family ethernet-switching {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge-vlan-map.conf
@@ -1,0 +1,41 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge vlan map (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/bgp-vpls.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. et-0/0/13
+ *   $INPUT_VID  e.g. 3712
+ *   $UNIT       e.g. 4012
+ *   $VLAN       e.g. 4012
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        family ethernet-switching {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/evpn-elan-type5.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT     e.g. 4075
+ *   $VLAN     e.g. 4075
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        family ethernet-switching {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-2-units.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-2-units.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc 2 units (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc 2 units (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-2-units.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-2-units.conf
@@ -1,0 +1,46 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc 2 units (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/services/evpn-fxc-vlan-unaware.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT_1   e.g. 4007
+ *   $UNIT_2   e.g. 4008
+ *   $VLAN_1   e.g. 4007
+ *   $VLAN_2   e.g. 4008
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT_1 {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN_1;
+        family ccc {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+    }
+    unit $UNIT_2 {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN_2;
+        family ccc {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi.conf
@@ -1,0 +1,39 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc esi (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-vpws-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae67
+ *   $ESI_ID   e.g. 00:40:11:11:21:22:01:00:00:01
+ *   $UNIT     e.g. 4000
+ *   $VLAN     e.g. 4000
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc esi (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc esi (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf
@@ -1,0 +1,36 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc qinq stacked qinq tpid (MEF E-Access)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/cos-binding-mpls.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/services/evpn-vpws-lsw.conf
+ *   - evo/services/l2circuit-lsw.conf
+ *
+ * Variables:
+ *   $AC_INTF         e.g. et-0/0/51
+ *   $MTU             e.g. 9102
+ *   $OUTER_VID_TPID  e.g. 0x88a8.4082
+ *   $UNIT            e.g. 4082
+ */
+$AC_INTF {
+    mtu $MTU;
+    ether-options {
+        ethernet-switch-profile {
+            tag-protocol-id [ 0x8100 0x88a8 ];
+        }
+    }
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-tags outer $OUTER_VID_TPID;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc qinq stacked qinq tpid (MEF E-Access)
+ * Topic:   Interface: vlan ccc qinq stacked qinq tpid (MEF E-Access)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA1.2 (ACX7024), AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-v2.conf
@@ -1,0 +1,36 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024), AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/l2circuit-floating-pw.conf
+ *   - evo/services/l2vpn-kompella-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/12
+ *   $UNIT     e.g. 4004
+ *   $VLAN     e.g. 4004
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map bundle qinq tpid (MEF E-Access)
+ * Topic:   Interface: vlan ccc vlan map bundle qinq tpid (MEF E-Access)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf
@@ -1,0 +1,51 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map bundle qinq tpid (MEF E-Access)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-vpws-lsw.conf
+ *   - evo/services/l2circuit-lsw.conf
+ *
+ * Variables:
+ *   $AC_INTF          e.g. et-0/0/0
+ *   $INPUT_VID        e.g. 4082
+ *   $MTU              e.g. 9102
+ *   $UNIT             e.g. 2500
+ *   $VLAN_LIST_END    e.g. 2599
+ *   $VLAN_LIST_START  e.g. 2500
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    mtu $MTU;
+    encapsulation flexible-ethernet-services;
+    ether-options {
+        ethernet-switch-profile {
+            tag-protocol-id [ 0x8100 0x88a8 ];
+        }
+    }
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;
+        input-vlan-map {
+            push;
+            tag-protocol-id 0x88a8;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf
@@ -1,0 +1,49 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-vpws-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. ae12
+ *   $ESI_ID     e.g. 00:10:11:49:30:12:01:00:00:00
+ *   $INPUT_VID  e.g. 4094
+ *   $UNIT_1     e.g. 200
+ *   $UNIT_2     e.g. 4009
+ *   $VLAN       e.g. 4009
+ */
+$AC_INTF {
+    unit $UNIT_1 {
+        input-vlan-map vlan-id $VLAN;
+    }
+    unit $UNIT_2 {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input f_eline-evpn-vpws;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf
@@ -1,0 +1,67 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map esi 2 units (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-fxc-vlan-aware.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. ae67
+ *   $ESI_ID_1     e.g. 00:10:44:11:50:12:02:00:00:00
+ *   $ESI_ID_2     e.g. 00:10:44:11:50:12:01:00:00:00
+ *   $INPUT_VID_1  e.g. 3400
+ *   $INPUT_VID_2  e.g. 3000
+ *   $UNIT_1       e.g. 4002
+ *   $UNIT_2       e.g. 4001
+ *   $VLAN_1       e.g. 4002
+ *   $VLAN_2       e.g. 4001
+ */
+$AC_INTF {
+    unit $UNIT_1 {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN_1;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID_1;
+        }
+        output-vlan-map pop;
+        esi {
+            $ESI_ID_1;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+    unit $UNIT_2 {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN_2;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID_2;
+        }
+        output-vlan-map pop;
+        esi {
+            $ESI_ID_2;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi.conf
@@ -1,0 +1,45 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-vpws-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. ae11
+ *   $ESI_ID     e.g. 00:10:11:49:30:11:01:00:00:00
+ *   $INPUT_VID  e.g. 4094
+ *   $UNIT       e.g. 4009
+ *   $VLAN       e.g. 4009
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input f_eline-evpn-vpws;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-v2.conf
@@ -1,0 +1,39 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. et-0/0/28:2
+ *   $INPUT_VID  e.g. 1000
+ *   $UNIT       e.g. 4006
+ *   $VLAN       e.g. 4006
+ */
+interfaces {
+    $AC_INTF {
+        flexible-vlan-tagging;
+        encapsulation flexible-ethernet-services;
+        unit $UNIT {
+            encapsulation vlan-ccc;
+            vlan-id $VLAN;
+            input-vlan-map {
+                push;
+                vlan-id $INPUT_VID;
+            }
+            output-vlan-map pop;
+            family ccc {
+                filter {
+                    input f_vlan-based_fam_ccc;
+                }
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map.conf
@@ -1,0 +1,43 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-vpws-vlan-based.conf
+ *   - evo/services/l2circuit-hot-standby-backup.conf
+ *   - evo/services/l2circuit-hot-standby-primary.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. et-0/0/13
+ *   $INPUT_VID  e.g. 4080
+ *   $UNIT       e.g. 4010
+ *   $VLAN       e.g. 4010
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc.conf
@@ -1,0 +1,33 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-vpws-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT     e.g. 4000
+ *   $VLAN     e.g. 4000
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-l3vpn-import-export.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-l3vpn-import-export.conf
@@ -1,0 +1,44 @@
+/*
+ * Topic:
+ *   Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - Community-driven RT policy
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Junos: MSE1 (MX304)
+ *
+ * Variables:
+ *   $COMM_RT        e.g. 61535:13075
+ *   $POLICY_NAME_1  e.g. PS-$VPN_RT_COMM-EXPORT
+ *   $POLICY_NAME_2  e.g. PS-$VPN_RT_COMM-IMPORT
+ *   $PUBLIC_PREFIX  e.g. 203.0.113.0/24
+ *   $VPN_RT_COMM    e.g. METRO_L3VPN_4075
+ */
+policy-options {
+    policy-statement $POLICY_NAME_1 {
+        term tag-public-routes {
+            from {
+                route-filter $PUBLIC_PREFIX orlonger;
+            }
+            then {
+                community add CM-L3VPN-PUB;
+                community add $VPN_RT_COMM;
+                accept;
+            }
+        }
+    }
+    policy-statement $POLICY_NAME_2 {
+        term L3VPN-CUST {
+            from community $VPN_RT_COMM;
+            then accept;
+        }
+    }
+    community $VPN_RT_COMM members target:$COMM_RT;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-l3vpn-import-export.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-l3vpn-import-export.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)
+ * Topic:   Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Policy: policy vpn rt export bronze (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ * Topic:   Policy: policy vpn rt export bronze (MEF E-LAN / EVP-LAN, E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.2 (ACX7024), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf
@@ -1,0 +1,37 @@
+/*
+ * Topic:
+ *   Policy: policy vpn rt export bronze (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.2 (ACX7024), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - Community-driven RT policy
+ *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   (none — single-device snip)
+ *
+ * Variables:
+ *   $COMM_RT      e.g. 63535:4013
+ *   $POLICY_NAME  e.g. evpn_group_80_4013
+ *   $VPN_RT_COMM  e.g. evpn_group_80_4013_RT
+ */
+policy-options {
+    policy-statement $POLICY_NAME {
+        term a {
+            then {
+                community add $VPN_RT_COMM;
+                community add CM-TC-MAP2BRONZE;
+                accept;
+            }
+        }
+        term b {
+            then reject;
+        }
+    }
+    community $VPN_RT_COMM members target:$COMM_RT;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf
@@ -1,0 +1,37 @@
+/*
+ * Topic:
+ *   Policy: policy vpn rt export gold (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - Community-driven RT policy
+ *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   (none — single-device snip)
+ *
+ * Variables:
+ *   $COMM_RT      e.g. 63535:33300
+ *   $POLICY_NAME  e.g. evpn_group_edge_4000
+ *   $VPN_RT_COMM  e.g. evpn_group_edge_4000_RT
+ */
+policy-options {
+    policy-statement $POLICY_NAME {
+        term a {
+            then {
+                community add $VPN_RT_COMM;
+                community add CM-TC-MAP2GOLD;
+                accept;
+            }
+        }
+        term b {
+            then reject;
+        }
+    }
+    community $VPN_RT_COMM members target:$COMM_RT;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Policy: policy vpn rt export gold (MEF E-Line / EVPL)
+ * Topic:   Policy: policy vpn rt export gold (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls-p2p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls-p2p.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: bgp vpls p2p (MEF E-Line / EVPL)
+ * Topic:   Service instance: bgp vpls p2p (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls-p2p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls-p2p.conf
@@ -1,0 +1,58 @@
+/*
+ * Topic:
+ *   Service instance: bgp vpls p2p (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type virtual-switch
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/vlan-bridge.conf
+ *
+ * JVD service mapping:
+ *   vpls_group_4005 (eline_evpl_vpls_fapm_ring_p2p.conf):
+ *     PEs (Evo): MA1.2 (ACX7024)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF           e.g. et-0/0/12
+ *   $INSTANCE_NAME     e.g. vpls_group_4005
+ *   $LABEL_BLOCK_SIZE  e.g. 2
+ *   $RD                e.g. 10.0.0.18:44444
+ *   $SITE_ID           e.g. 5
+ *   $SITE_NAME         e.g. r18
+ *   $SITE_RANGE        e.g. 2
+ *   $UNIT              e.g. 4005
+ *   $VRF_TARGET        e.g. 64535:44444
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type virtual-switch;
+        protocols {
+            vpls {
+                site $SITE_NAME {
+                    site-identifier $SITE_ID;
+                }
+                service-type single;
+                site-range $SITE_RANGE;
+                label-block-size $LABEL_BLOCK_SIZE;
+                no-tunnel-services;
+            }
+        }
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            vlan4005 {
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls.conf
@@ -1,0 +1,59 @@
+/*
+ * Topic:
+ *   Service instance: bgp vpls (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG2 (ACX7509), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type virtual-switch
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-bridge-vlan-map.conf
+ *
+ * JVD service mapping:
+ *   vpls_group_103_4012 (elan_evp-lan_vpls_e2e_ms.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.2 (ACX7024), MEG2 (ACX7509)
+ *
+ * Variables:
+ *   $AC_INTF           e.g. et-0/0/13
+ *   $INSTANCE_NAME     e.g. vpls_group_103_4012
+ *   $LABEL_BLOCK_SIZE  e.g. 8
+ *   $RD                e.g. 63535:1894012
+ *   $SITE_ID           e.g. 1
+ *   $SITE_NAME         e.g. r2
+ *   $SITE_RANGE        e.g. 10
+ *   $UNIT              e.g. 4012
+ *   $VRF_TARGET        e.g. 63535:1094012
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type virtual-switch;
+        protocols {
+            vpls {
+                site $SITE_NAME {
+                    site-identifier $SITE_ID;
+                }
+                service-type single;
+                site-range $SITE_RANGE;
+                label-block-size $LABEL_BLOCK_SIZE;
+                no-tunnel-services;
+            }
+        }
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            vlan4012 {
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: bgp vpls (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: bgp vpls (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG2 (ACX7509), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based-v2.conf
@@ -1,0 +1,50 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind-l2cp.conf
+ *   - evo/interfaces/ethernet-bridge.conf
+ *   - evo/services/evpn-elan-bundle-port-based.conf
+ *
+ * JVD service mapping:
+ *   MEF_EVPN_ELAN_PORT_BASED (elan_ep-lan_evpn_elan.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. MEF_EVPN_ELAN_PORT_BASED
+ *   $RD             e.g. 10.0.0.18:4014
+ *   $UNIT           e.g. 0
+ *   $VRF_TARGET     e.g. 63535:4014
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn {
+                no-control-word;
+            }
+        }
+        service-type vlan-bundle;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            v-2 {
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)
+ * Topic:   Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Evo: MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)
+ * Topic:   Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-bundle-port-based.conf
@@ -1,0 +1,48 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan bundle port based (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind-l2cp.conf
+ *   - evo/interfaces/ethernet-bridge.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/services/evpn-elan-bundle-port-based.conf
+ *
+ * JVD service mapping:
+ *   MEF_EVPN_ELAN_PORT_BASED (elan_ep-lan_evpn_elan.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. MEF_EVPN_ELAN_PORT_BASED
+ *   $RD             e.g. 10.0.0.2:4014
+ *   $UNIT           e.g. 0
+ *   $VRF_TARGET     e.g. 63535:4014
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn;
+        }
+        service-type vlan-bundle;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            v-2 {
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-port-based.conf
@@ -1,0 +1,53 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf
+ *   - vlan-id none + no-normalization (port-based bridging)
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/vlan-bridge-esi.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_90_4011 (elan_evp-lan_evpn-elan_vlan-based.conf):
+ *     A-A Multihoming: AN1 (MX204), AN2 (ACX5448)
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG1 (ACX7509)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae11
+ *   $INSTANCE_NAME  e.g. evpn_group_90_4011
+ *   $RD             e.g. 10.0.0.2:64011
+ *   $UNIT           e.g. 4011
+ *   $VRF_TARGET     e.g. 63535:64011
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                no-control-word;
+            }
+        }
+        service-type vlan-based;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            BD_evpn_group_90_4011 {
+                vlan-id none;
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-port-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5-v2.conf
@@ -1,0 +1,84 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf
+ *   - EVPN Type-5 IP-prefix routes (L3 over EVPN)
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/vlan-bridge-esi.conf
+ *
+ * JVD service mapping:
+ *   METRO_L3VPN_4075 (elan_evp-lan_evpn-elan_type-5.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Junos): MSE1 (MX304)
+ *   evpn_group_60_4075 (elan_evp-lan_evpn-elan_type-5.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Junos): MSE1 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae67
+ *   $INSTANCE_NAME  e.g. evpn_group_60_4075
+ *   $IRB_UNIT       e.g. 4075
+ *   $RD_1           e.g. 10.0.0.6:14075
+ *   $RD_2           e.g. 61000:13075
+ *   $ROUTER_ID      e.g. 10.0.0.6
+ *   $UNIT           e.g. 4075
+ *   $VLAN           e.g. 4075
+ *   $VRF_TARGET_1   e.g. 61535:14075
+ *   $VRF_TARGET_2   e.g. 61535:13075
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                default-gateway do-not-advertise;
+                normalization;
+                no-control-word;
+            }
+        }
+        service-type vlan-based;
+        route-distinguisher $RD_1;
+        vrf-target target:$VRF_TARGET_1;
+        vlans {
+            V4000 {
+                vlan-id $VLAN;
+                interface $AC_INTF.$UNIT;
+                l3-interface irb.$IRB_UNIT;
+            }
+        }
+    }
+    METRO_L3VPN_4075 {
+        instance-type vrf;
+        routing-options {
+            router-id $ROUTER_ID;
+        }
+        protocols {
+            evpn {
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation mpls;
+                }
+            }
+        }
+        interface irb.$IRB_UNIT;
+        route-distinguisher $RD_2;
+        vrf-import PS-METRO_L3VPN_4075-IMPORT;
+        vrf-export PS-METRO_L3VPN_4075-EXPORT;
+        vrf-target target:$VRF_TARGET_2;
+        vrf-table-label;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5.conf
@@ -1,0 +1,83 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf
+ *   - EVPN Type-5 IP-prefix routes (L3 over EVPN)
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-bridge.conf
+ *
+ * JVD service mapping:
+ *   METRO_L3VPN_4075 (elan_evp-lan_evpn-elan_type-5.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Junos): MSE1 (MX304)
+ *   evpn_group_60_4075 (elan_evp-lan_evpn-elan_type-5.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Junos): MSE1 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. evpn_group_60_4075
+ *   $IRB_UNIT       e.g. 4075
+ *   $RD_1           e.g. 10.0.0.2:14075
+ *   $RD_2           e.g. 63000:13075
+ *   $ROUTER_ID      e.g. 10.0.0.2
+ *   $UNIT           e.g. 4075
+ *   $VLAN           e.g. 4075
+ *   $VRF_TARGET     e.g. 61535:14075
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                default-gateway do-not-advertise;
+                normalization;
+                no-control-word;
+            }
+        }
+        service-type vlan-based;
+        route-distinguisher $RD_1;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            V4000 {
+                vlan-id $VLAN;
+                interface $AC_INTF.$UNIT;
+                l3-interface irb.$IRB_UNIT;
+            }
+        }
+    }
+    METRO_L3VPN_4075 {
+        instance-type vrf;
+        routing-options {
+            router-id $ROUTER_ID;
+        }
+        protocols {
+            evpn {
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation mpls;
+                }
+            }
+        }
+        interface irb.$IRB_UNIT;
+        route-distinguisher $RD_2;
+        vrf-import PS-METRO_L3VPN_4075-IMPORT;
+        vrf-export PS-METRO_L3VPN_4075-EXPORT;
+        vrf-table-label;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-bundle.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-bundle.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan vlan bundle (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan vlan bundle (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-bundle.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-bundle.conf
@@ -1,0 +1,51 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan vlan bundle (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-bridge-bundle.conf
+ *   - evo/interfaces/vlan-bridge-esi-bundle.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_80_4013 (elan_evp-lan_evpn-elan_bundle.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. evpn_group_80_4013
+ *   $RD             e.g. 10.0.0.2:4013
+ *   $UNIT           e.g. 4013
+ *   $VRF_TARGET     e.g. 63535:4013
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn {
+                encapsulation mpls;
+            }
+        }
+        service-type vlan-bundle;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            BD_evpn_group_80_4013 {
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware.conf
@@ -1,0 +1,61 @@
+/*
+ * Topic:
+ *   Service instance: evpn fxc vlan aware (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - EVPN-VPWS attachment-circuit with local/remote service-id
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf
+ *
+ * JVD service mapping:
+ *   evpn_vpws_fxc_aware (eline_evpl_evpn-fxc_aware_mh.conf):
+ *     A-A Multihoming: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     A-A Multihoming: MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae67
+ *   $INSTANCE_NAME  e.g. evpn_vpws_fxc_aware
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.6:5501
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT_1         e.g. 4001
+ *   $UNIT_2         e.g. 4002
+ *   $VRF_TARGET     e.g. 63536:55100
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT_1 {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+                interface $AC_INTF.$UNIT_2 {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+                flexible-cross-connect-vlan-aware;
+            }
+        }
+        interface $AC_INTF.$UNIT_1;
+        interface $AC_INTF.$UNIT_2;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn fxc vlan aware (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn fxc vlan aware (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-unaware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-unaware.conf
@@ -1,0 +1,52 @@
+/*
+ * Topic:
+ *   Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-ccc-2-units.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_4007 (eline_evpl_evpn-fxc_unaware_sh.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): MSE1 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. evpn_group_4007
+ *   $RD             e.g. 10.0.0.2:40001
+ *   $UNIT_1         e.g. 4007
+ *   $UNIT_2         e.g. 4008
+ *   $VRF_TARGET     e.g. 63535:40001
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                flexible-cross-connect-vlan-unaware;
+                group fxc {
+                    interface $AC_INTF.$UNIT_1;
+                    interface $AC_INTF.$UNIT_2;
+                    service-id {
+                        local 1;
+                        remote 2;
+                    }
+                }
+            }
+        }
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-unaware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-unaware.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-lsw.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn vpws lsw (MEF E-Access)
+ * Topic:   Service instance: evpn vpws lsw (MEF E-Access)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-lsw.conf
@@ -1,0 +1,62 @@
+/*
+ * Topic:
+ *   Service instance: evpn vpws lsw (MEF E-Access)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - EVPN-VPWS attachment-circuit with local/remote service-id
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/cos-binding-mpls.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf
+ *
+ * JVD service mapping:
+ *   lsw_evpn_vpws_group_90_4082 (eaccess_evpn-vpws_lsw.conf):
+ *     PEs (Evo): MA3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $AC_INTF_1      e.g. et-0/0/0
+ *   $AC_INTF_2      e.g. et-0/0/51
+ *   $INSTANCE_NAME  e.g. lsw_evpn_vpws_group_90_4082
+ *   $LOCAL_VID      e.g. 22
+ *   $RD             e.g. 10.0.0.15:4082
+ *   $REMOTE_VID     e.g. 11
+ *   $UNIT_1         e.g. 2500
+ *   $UNIT_2         e.g. 4082
+ *   $VRF_TARGET     e.g. 63533:4082
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF_1.$UNIT_1 {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+                interface $AC_INTF_2.$UNIT_2 {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+                control-word;
+            }
+        }
+        interface $AC_INTF_1.$UNIT_1;
+        interface $AC_INTF_2.$UNIT_2;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-port-based.conf
@@ -1,0 +1,51 @@
+/*
+ * Topic:
+ *   Service instance: evpn vpws port based (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - EVPN-VPWS attachment-circuit with local/remote service-id
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind-l2cp.conf
+ *   - evo/interfaces/ethernet-ccc.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *
+ * JVD service mapping:
+ *   MEF_EVPN_VPWS_PORT_BASED (eline_epl_evpn_vpws.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.1 (ACX7024)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. MEF_EVPN_VPWS_PORT_BASED
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.2:55555
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT           e.g. 0
+ *   $VRF_TARGET     e.g. 63535:55555
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-port-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn vpws port based (MEF E-Line / EPL)
+ * Topic:   Service instance: evpn vpws port based (MEF E-Line / EPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based-v2.conf
@@ -1,0 +1,57 @@
+/*
+ * Topic:
+ *   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - EVPN-VPWS attachment-circuit with local/remote service-id
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map-esi-2-units.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map-esi.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_30_4009 (eline_evpl_evpn_vpws_mh_e2e.conf):
+ *     A-A Multihoming: AN1 (MX204), AN2 (ACX5448), AN3 (ACX7100-48L)
+ *     A-A Multihoming: MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *   evpn_group_20_4010 (eline_evpl_evpn_vpws_sh_fabric.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): AN4 (ACX710)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae11
+ *   $INSTANCE_NAME  e.g. evpn_group_30_4009
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.2:4999
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT           e.g. 4009
+ *   $VRF_TARGET     e.g. 63535:4999
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-vpws-vlan-based.conf
@@ -1,0 +1,54 @@
+/*
+ * Topic:
+ *   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - EVPN-VPWS attachment-circuit with local/remote service-id
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-ccc-esi.conf
+ *   - evo/interfaces/vlan-ccc.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_edge_4000 (eline_evpl_evpn_vpws_edge.conf):
+ *     A-A Multihoming: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. evpn_group_edge_4000
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.2:33300
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT           e.g. 4000
+ *   $VRF_TARGET     e.g. 63535:33300
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
@@ -1,0 +1,43 @@
+/*
+ * Topic:
+ *   Service instance: l2circuit floating pw (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - Static targeted-LDP L2-circuit pseudowire (no routing-instance required)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc.conf
+ *
+ * JVD service mapping:
+ *   l2circuit (eline_evpl_floating_pw.conf):
+ *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
+ *   l2ckt-vc10120 (eline_evpl_floating_pw.conf):
+ *     PEs (Evo): MA1.2 (ACX7024)
+ *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/12
+ *   $UNIT     e.g. 4004
+ *   $VC_ID    e.g. 10120
+ */
+protocols {
+    l2circuit {
+        neighbor 1.1.10.10 {
+            interface $AC_INTF.$UNIT {
+                static {
+                    incoming-label 1000022;
+                    outgoing-label 1000022;
+                }
+                virtual-circuit-id $VC_ID;
+                encapsulation-type ethernet-vlan;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2circuit floating pw (MEF E-Line / EVPL)
+ * Topic:   Service instance: l2circuit floating pw (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MA1.2 (ACX7024)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-backup.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-backup.conf
@@ -1,0 +1,45 @@
+/*
+ * Topic:
+ *   Service instance: l2circuit hot standby backup (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - Static targeted-LDP L2-circuit pseudowire (no routing-instance required)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map.conf
+ *
+ * JVD service mapping:
+ *   l2ckt-vc2006 (eline_evpl_l2ckt_hsb.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C)
+ *   l2ckt-vc3333 (eline_evpl_l2ckt_hsb.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG2 (ACX7509)
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/28:2
+ *   $UNIT     e.g. 4006
+ *   $VC_ID    e.g. 2006
+ */
+protocols {
+    l2circuit {
+        neighbor 10.0.0.2 {
+            interface $AC_INTF.$UNIT {
+                virtual-circuit-id $VC_ID;
+                control-word;
+                flow-label-transmit;
+                flow-label-receive;
+                encapsulation-type ethernet-vlan;
+                ignore-encapsulation-mismatch;
+                ignore-mtu-mismatch;
+                pseudowire-status-tlv {
+                    hot-standby-vc-on;
+                }
+            }
+        }
+    }

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-backup.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-backup.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2circuit hot standby backup (MEF E-Line / EVPL)
+ * Topic:   Service instance: l2circuit hot standby backup (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-primary.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-primary.conf
@@ -1,0 +1,49 @@
+/*
+ * Topic:
+ *   Service instance: l2circuit hot standby primary (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - Static targeted-LDP L2-circuit pseudowire (no routing-instance required)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map.conf
+ *
+ * JVD service mapping:
+ *   l2ckt-vc2006 (eline_evpl_l2ckt_hsb.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C)
+ *   l2ckt-vc3333 (eline_evpl_l2ckt_hsb.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG2 (ACX7509)
+ *
+ * Variables:
+ *   $AC_INTF  e.g. et-0/0/13
+ *   $UNIT     e.g. 4006
+ *   $VC_ID_1  e.g. 2006
+ *   $VC_ID_2  e.g. 3333
+ */
+protocols {
+    l2circuit {
+        neighbor 10.0.0.6 {
+            interface $AC_INTF.$UNIT {
+                virtual-circuit-id $VC_ID_1;
+                control-word;
+                flow-label-transmit;
+                flow-label-receive;
+                encapsulation-type ethernet-vlan;
+                ignore-mtu-mismatch;
+                pseudowire-status-tlv;
+                backup-neighbor 10.0.0.7 {
+                    virtual-circuit-id $VC_ID_2;
+                    hot-standby;
+                }
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-primary.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-hot-standby-primary.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2circuit hot standby primary (MEF E-Line / EVPL)
+ * Topic:   Service instance: l2circuit hot standby primary (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-lsw.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2circuit lsw (MEF E-Access)
+ * Topic:   Service instance: l2circuit lsw (MEF E-Access)
  *
  * Seen on:
  *   Evo: MA3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-lsw.conf
@@ -1,0 +1,41 @@
+/*
+ * Topic:
+ *   Service instance: l2circuit lsw (MEF E-Access)
+ *
+ * Seen on:
+ *   Evo: MA3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - Static targeted-LDP L2-circuit pseudowire (no routing-instance required)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/cos-binding-mpls.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf
+ *
+ * JVD service mapping:
+ *   l2ckt (eaccess_l2ckt_lsw.conf):
+ *     PEs (Evo): MA3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $AC_INTF_1  e.g. et-0/0/0
+ *   $AC_INTF_2  e.g. et-0/0/51
+ *   $UNIT_1     e.g. 2500
+ *   $UNIT_2     e.g. 4082
+ */
+protocols {
+    l2circuit {
+        local-switching {
+            interface $AC_INTF_1.$UNIT_1 {
+                end-interface {
+                    interface $AC_INTF_2.$UNIT_2;
+                }
+                ignore-mtu-mismatch;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-port-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2vpn kompella port based (MEF E-Line / EPL)
+ * Topic:   Service instance: l2vpn kompella port based (MEF E-Line / EPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-port-based.conf
@@ -1,0 +1,57 @@
+/*
+ * Topic:
+ *   Service instance: l2vpn kompella port based (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - instance-type l2vpn
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/ethernet-ccc.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *
+ * JVD service mapping:
+ *   MEF_L2VPN_PORT_BASED (eline_epl_l2vpn.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF         e.g. et-0/0/13
+ *   $INSTANCE_NAME   e.g. MEF_L2VPN_PORT_BASED
+ *   $RD              e.g. 63535:110000
+ *   $REMOTE_SITE_ID  e.g. 1119
+ *   $SITE_ID         e.g. 1102
+ *   $UNIT            e.g. 0
+ *   $VRF_TARGET      e.g. 63535:100000
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type l2vpn;
+        protocols {
+            l2vpn {
+                site r19 {
+                    interface $AC_INTF.$UNIT {
+                        remote-site-id $REMOTE_SITE_ID;
+                    }
+                    site-identifier $SITE_ID;
+                }
+                encapsulation-type ethernet;
+                no-control-word;
+                flow-label-transmit;
+                flow-label-receive;
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-vlan-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)
+ * Topic:   Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Evo: AN3 (ACX7100-48L)

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2vpn-kompella-vlan-based.conf
@@ -1,0 +1,54 @@
+/*
+ * Topic:
+ *   Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - instance-type l2vpn
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/physical-mtu.conf
+ *   - evo/interfaces/vlan-ccc.conf
+ *
+ * JVD service mapping:
+ *   l2vpn_group_200 (eline_evpl_l2vpn_e2e.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF         e.g. et-0/0/13
+ *   $INSTANCE_NAME   e.g. l2vpn_group_200
+ *   $RD              e.g. 63535:102000
+ *   $REMOTE_SITE_ID  e.g. 1119
+ *   $SITE_ID         e.g. 1102
+ *   $UNIT            e.g. 200
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type l2vpn;
+        protocols {
+            l2vpn {
+                site r2 {
+                    interface $AC_INTF.$UNIT {
+                        remote-site-id $REMOTE_SITE_ID;
+                    }
+                    site-identifier $SITE_ID;
+                }
+                encapsulation-type ethernet-vlan;
+                no-control-word;
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$RD;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/apply-groups/mef-testing.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/apply-groups/mef-testing.conf
@@ -1,0 +1,23 @@
+/*
+ * Topic:
+ *   Apply-group: mef testing (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN2 (ACX5448)
+ *
+ * Highlights:
+ *   - Lab/test apply-group — staging-only knobs (not for production rollout)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+system {
+    packet-forwarding-options {
+        firewall-profile {
+            mef-profile;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/apply-groups/mef-testing.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/apply-groups/mef-testing.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Apply-group: mef testing (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ * Topic:   Apply-group: mef testing (MEF E-LAN / EVP-LAN, E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN2 (ACX5448)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/classifiers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/classifiers.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/classifiers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/classifiers.conf
@@ -1,0 +1,128 @@
+/*
+ * Topic:
+ *   Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - Forwarding-class definitions / classifier mapping
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+classifiers {
+    dscp CL-DSCP {
+        import default;
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-points cs6;
+            loss-priority high code-points cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-points [ cs4 af41 ];
+            loss-priority medium-high code-points af42;
+            loss-priority high code-points af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-points ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-points [ cs3 af31 ];
+            loss-priority medium-high code-points af32;
+            loss-priority high code-points af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-points cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points [ cs2 af21 ];
+            loss-priority medium-high code-points af22;
+            loss-priority high code-points af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points [ cs1 af11 ];
+            loss-priority medium-high code-points af12;
+            loss-priority high code-points af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority high code-points be;
+        }
+    }
+    dscp-ipv6 CL-DSCP-IPV6 {
+        import default;
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-points cs6;
+            loss-priority high code-points cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-points [ cs4 af41 ];
+            loss-priority medium-high code-points af42;
+            loss-priority high code-points af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-points ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-points [ cs3 af31 ];
+            loss-priority medium-high code-points af32;
+            loss-priority high code-points af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-points cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points [ cs2 af21 ];
+            loss-priority medium-high code-points af22;
+            loss-priority high code-points af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points [ cs1 af11 ];
+            loss-priority medium-high code-points af12;
+            loss-priority high code-points af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority high code-points be;
+        }
+    }
+    exp CL-MPLS {
+        import default;
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-points 110;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-points 100;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-points 101;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-points 011;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-points 111;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points 010;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points 001;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-points 000;
+        }
+    }
+    ieee-802.1 CL-8021P {
+        forwarding-class FC-HIGH {
+            loss-priority low code-points [ 101 100 ];
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-points [ 011 010 ];
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-points [ 001 000 ];
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-ieee8021p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-ieee8021p.conf
@@ -1,0 +1,34 @@
+/*
+ * Topic:
+ *   Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - L2 CE-facing CoS binding (classify + rewrite IEEE 802.1p)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/forwarding-classes.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/cos/scheduler-map.conf
+ *   - junos/cos/schedulers.conf
+ *
+ * Variables:
+ *   (none)
+ */
+interfaces {
+    $AC_INTF {
+        scheduler-map SM-5G-SCHEDULER;
+        unit $UNIT {
+            classifiers {
+                ieee-802.1 CL-8021P;
+            }
+            rewrite-rules {
+                ieee-802.1 RR-8021P;
+            }
+        }
+    }
+}
+

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-ieee8021p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-ieee8021p.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-mpls.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-mpls.conf
@@ -1,0 +1,34 @@
+/*
+ * Topic:
+ *   Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - MPLS core-facing CoS binding (classify + rewrite EXP)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/forwarding-classes.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/cos/scheduler-map.conf
+ *   - junos/cos/schedulers.conf
+ *
+ * Variables:
+ *   (none)
+ */
+interfaces {
+    $AC_INTF {
+        scheduler-map SM-5G-SCHEDULER;
+        unit $UNIT {
+            classifiers {
+                exp CL-MPLS;
+            }
+            rewrite-rules {
+                exp RR-MPLS;
+            }
+        }
+    }
+}
+

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-mpls.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/cos-binding-mpls.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/forwarding-classes.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/forwarding-classes.conf
@@ -1,0 +1,26 @@
+/*
+ * Topic:
+ *   Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - Forwarding-class definitions / classifier mapping
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+forwarding-classes {
+    class FC-SIGNALING queue-num 7;
+    class FC-LLQ queue-num 6;
+    class FC-REALTIME queue-num 5;
+    class FC-HIGH queue-num 4;
+    class FC-CONTROL queue-num 3;
+    class FC-MEDIUM queue-num 2;
+    class FC-LOW queue-num 1;
+    class FC-BEST-EFFORT queue-num 0;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/forwarding-classes.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/forwarding-classes.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/rewrite-rules.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/rewrite-rules.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/rewrite-rules.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/rewrite-rules.conf
@@ -1,0 +1,144 @@
+/*
+ * Topic:
+ *   Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - Forwarding-class definitions / classifier mapping
+ *   - Rewrite-rules for egress marking
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+rewrite-rules {
+    dscp RR-DSCP {
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-point cs6;
+            loss-priority high code-point cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-point af41;
+            loss-priority medium-high code-point af42;
+            loss-priority high code-point af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-point ef;
+            loss-priority high code-point ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-point af31;
+            loss-priority medium-high code-point af32;
+            loss-priority high code-point af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-point cs7;
+            loss-priority high code-point cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point af21;
+            loss-priority medium-high code-point af22;
+            loss-priority high code-point af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point af11;
+            loss-priority medium-high code-point af12;
+            loss-priority high code-point af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-point be;
+            loss-priority high code-point be;
+        }
+    }
+    dscp-ipv6 RR-DSCP-IPV6 {
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-point cs6;
+            loss-priority high code-point cs5;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-point af41;
+            loss-priority medium-high code-point af42;
+            loss-priority high code-point af43;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-point ef;
+            loss-priority high code-point ef;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-point af31;
+            loss-priority medium-high code-point af32;
+            loss-priority high code-point af33;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-point cs7;
+            loss-priority high code-point cs7;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point af21;
+            loss-priority medium-high code-point af22;
+            loss-priority high code-point af23;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point af11;
+            loss-priority medium-high code-point af12;
+            loss-priority high code-point af13;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-point be;
+            loss-priority high code-point be;
+        }
+    }
+    exp RR-MPLS {
+        forwarding-class FC-SIGNALING {
+            loss-priority low code-point 110;
+            loss-priority high code-point 110;
+        }
+        forwarding-class FC-LLQ {
+            loss-priority low code-point 100;
+            loss-priority medium-high code-point 100;
+            loss-priority high code-point 100;
+        }
+        forwarding-class FC-REALTIME {
+            loss-priority low code-point 101;
+            loss-priority high code-point 101;
+        }
+        forwarding-class FC-HIGH {
+            loss-priority low code-point 011;
+            loss-priority medium-high code-point 011;
+            loss-priority high code-point 011;
+        }
+        forwarding-class FC-CONTROL {
+            loss-priority low code-point 111;
+            loss-priority high code-point 111;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point 010;
+            loss-priority medium-high code-point 010;
+            loss-priority high code-point 010;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point 001;
+            loss-priority medium-high code-point 001;
+            loss-priority high code-point 001;
+        }
+        forwarding-class FC-BEST-EFFORT {
+            loss-priority low code-point 000;
+            loss-priority high code-point 000;
+        }
+    }
+    ieee-802.1 RR-8021P {
+        forwarding-class FC-HIGH {
+            loss-priority low code-point 100;
+        }
+        forwarding-class FC-MEDIUM {
+            loss-priority low code-point 010;
+        }
+        forwarding-class FC-LOW {
+            loss-priority low code-point 000;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/scheduler-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/scheduler-map.conf
@@ -1,0 +1,29 @@
+/*
+ * Topic:
+ *   Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - Scheduler-map binding queues to schedulers
+ *   - Forwarding-class definitions / classifier mapping
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+scheduler-maps {
+    SM-5G-SCHEDULER {
+        forwarding-class FC-SIGNALING scheduler SC-SIGNALING;
+        forwarding-class FC-LLQ scheduler SC-LLQ;
+        forwarding-class FC-REALTIME scheduler SC-REALTIME;
+        forwarding-class FC-HIGH scheduler SC-HIGH;
+        forwarding-class FC-CONTROL scheduler SC-CONTROL;
+        forwarding-class FC-MEDIUM scheduler SC-MEDIUM;
+        forwarding-class FC-LOW scheduler SC-LOW;
+        forwarding-class FC-BEST-EFFORT scheduler SC-BEST-EFFORT;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/scheduler-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/scheduler-map.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), AN1 (MX204), AN2 (ACX5448), AN4 (ACX710), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-legacy-acx.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-legacy-acx.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: schedulers legacy acx (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ * Topic:   Class-of-service: schedulers legacy acx (MEF E-LAN / EVP-LAN, E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN2 (ACX5448), AN4 (ACX710)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-legacy-acx.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-legacy-acx.conf
@@ -1,0 +1,62 @@
+/*
+ * Topic:
+ *   Class-of-service: schedulers legacy acx (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN2 (ACX5448), AN4 (ACX710)
+ *
+ * Highlights:
+ *   - Per-queue scheduler shaping / buffer / priority
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+schedulers {
+    SC-SIGNALING {
+        shaping-rate percent 5;
+        buffer-size percent 5;
+        priority low;
+    }
+    SC-LLQ {
+        shaping-rate percent 40;
+        buffer-size percent 10;
+        priority strict-high;
+    }
+    SC-REALTIME {
+        shaping-rate percent 30;
+        buffer-size percent 20;
+        priority low;
+    }
+    SC-HIGH {
+        transmit-rate percent 40;
+        buffer-size percent 30;
+        priority low;
+    }
+    SC-CONTROL {
+        shaping-rate percent 5;
+        buffer-size percent 5;
+        priority low;
+    }
+    SC-MEDIUM {
+        transmit-rate percent 30;
+        buffer-size percent 20;
+        priority low;
+    }
+    SC-LOW {
+        transmit-rate percent 20;
+        buffer-size percent 10;
+        priority low;
+    }
+    SC-BEST-EFFORT {
+        transmit-rate {
+            remainder;
+        }
+        buffer-size {
+            remainder;
+        }
+        priority low;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: schedulers (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ * Topic:   Class-of-service: schedulers (MEF E-LAN / EVP-LAN, E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN1 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers-v2.conf
@@ -1,0 +1,62 @@
+/*
+ * Topic:
+ *   Class-of-service: schedulers (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN1 (MX204)
+ *
+ * Highlights:
+ *   - Per-queue scheduler shaping / buffer / priority
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+schedulers {
+    SC-SIGNALING {
+        shaping-rate percent 5;
+        buffer-size percent 5;
+        priority high;
+    }
+    SC-LLQ {
+        shaping-rate percent 40;
+        buffer-size percent 10;
+        priority strict-high;
+    }
+    SC-REALTIME {
+        shaping-rate percent 30;
+        buffer-size percent 20;
+        priority medium-high;
+    }
+    SC-HIGH {
+        transmit-rate percent 40;
+        buffer-size percent 20;
+        priority low;
+    }
+    SC-CONTROL {
+        shaping-rate percent 5;
+        buffer-size percent 5;
+        priority high;
+    }
+    SC-MEDIUM {
+        transmit-rate percent 30;
+        buffer-size percent 10;
+        priority low;
+    }
+    SC-LOW {
+        transmit-rate percent 20;
+        buffer-size percent 10;
+        priority low;
+    }
+    SC-BEST-EFFORT {
+        transmit-rate {
+            remainder;
+        }
+        buffer-size {
+            remainder;
+        }
+        priority low;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers.conf
@@ -1,0 +1,62 @@
+/*
+ * Topic:
+ *   Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204), MSE1 (MX304), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - Per-queue scheduler shaping / buffer / priority
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   (none)
+ */
+schedulers {
+    SC-SIGNALING {
+        transmit-rate percent 5;
+        buffer-size percent 5;
+        priority high;
+    }
+    SC-LLQ {
+        shaping-rate percent 40;
+        buffer-size percent 10;
+        priority strict-high;
+    }
+    SC-REALTIME {
+        transmit-rate percent 15;
+        buffer-size percent 20;
+        priority medium-high;
+    }
+    SC-HIGH {
+        transmit-rate percent 10;
+        buffer-size percent 20;
+        priority high;
+    }
+    SC-CONTROL {
+        transmit-rate percent 5;
+        buffer-size percent 5;
+        priority high;
+    }
+    SC-MEDIUM {
+        transmit-rate percent 10;
+        buffer-size percent 10;
+        priority low;
+    }
+    SC-LOW {
+        transmit-rate percent 10;
+        buffer-size percent 10;
+        priority low;
+    }
+    SC-BEST-EFFORT {
+        transmit-rate {
+            remainder;
+        }
+        buffer-size {
+            remainder;
+        }
+        priority low;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/cos/schedulers.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204), MSE1 (MX304), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-cf0.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-cf0.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter bridge color aware cf0 (MEF E-Access)
+ * Topic:   Firewall: filter bridge color aware cf0 (MEF E-Access)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-cf0.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-cf0.conf
@@ -1,0 +1,143 @@
+/*
+ * Topic:
+ *   Firewall: filter bridge color aware cf0 (MEF E-Access)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - family bridge filter (MX L2 bridging path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-aware policer (honors ingress loss-priority)
+ *   - Coupling-flag = 0 behavior (explicitly discards yellow / medium-high)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: MA3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f-vlan_based_fam_bridge
+ */
+firewall {
+    family bridge {
+        filter $FILTER_NAME {
+            interface-specific;
+            term high_class_discard {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count pcp_6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority 4;
+                }
+                then {
+                    count high_pcp4;
+                    loss-priority high;
+                    next term;
+                }
+            }
+            term color-envelop {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count color-envelop;
+                }
+            }
+            term medium_class-3 {
+                from {
+                    learn-vlan-1p-priority 3;
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count med-3;
+                    accept;
+                }
+            }
+            term medium_class-2 {
+                from {
+                    learn-vlan-1p-priority 2;
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count med-2;
+                    next term;
+                }
+            }
+            term CF0-yellow {
+                from {
+                    loss-priority medium-high;
+                    learn-vlan-1p-priority 2;
+                }
+                then {
+                    count CFO-yellow;
+                    discard;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count low_class;
+                }
+            }
+            term deault {
+                then count default_traffic;
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-l2cp.conf
@@ -1,0 +1,145 @@
+/*
+ * Topic:
+ *   Firewall: filter bridge color aware l2cp (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - family bridge filter (MX L2 bridging path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-aware policer (honors ingress loss-priority)
+ *   - Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)
+ *   - Discards L2CP/BPDU destination-mac frames
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_port_based_fam_bridge
+ */
+firewall {
+    family bridge {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard-l2cp {
+                from {
+                    destination-mac-address {
+                        01:80:c2:00:00:07/48;
+                        01:80:c2:00:00:0e/48;
+                        01:80:c2:00:00:20/48;
+                        01:80:c2:00:00:21/48;
+                        01:80:c2:00:00:22/48;
+                        01:80:c2:00:00:23/48;
+                        01:80:c2:00:00:2a/48;
+                        01:80:c2:00:00:2d/48;
+                        01:80:c2:00:00:2e/48;
+                        01:80:c2:00:00:2f/48;
+                        01:80:c2:00:00:2b/48;
+                        01:80:c2:00:00:24/48;
+                        01:80:c2:00:00:25/48;
+                        01:80:c2:00:00:26/48;
+                        01:80:c2:00:00:27/48;
+                        01:80:c2:00:00:28/48;
+                        01:80:c2:00:00:29/48;
+                        01:80:c2:00:00:2c/48;
+                    }
+                }
+                then {
+                    count l2cp_discard;
+                    discard;
+                }
+            }
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware-l2cp.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter bridge color aware l2cp (MEF E-LAN / EP-LAN)
+ * Topic:   Firewall: filter bridge color aware l2cp (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware.conf
@@ -1,0 +1,117 @@
+/*
+ * Topic:
+ *   Firewall: filter bridge color aware (MEF E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - family bridge filter (MX L2 bridging path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-aware policer (honors ingress loss-priority)
+ *   - Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: MA1.2 (ACX7024)
+ *   Junos: MSE1 (MX304), MSE2 (MX304), MA4 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge_1
+ */
+firewall {
+    family bridge {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-aware.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter bridge color aware (MEF E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Firewall: filter bridge color aware (MEF E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-blind.conf
@@ -1,0 +1,116 @@
+/*
+ * Topic:
+ *   Firewall: filter bridge color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL, E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), AN1 (MX204), MSE2 (MX304), MA4 (MX204)
+ *
+ * Highlights:
+ *   - family bridge filter (MX L2 bridging path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *   Junos: AN2 (ACX5448), MA5 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_elan-evpn
+ */
+firewall {
+    family bridge {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-bridge-color-blind.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter bridge color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL, E-Tree / EVP-Tree)
+ * Topic:   Firewall: filter bridge color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL, E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), AN1 (MX204), MSE2 (MX304), MA4 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware-l2cp.conf
@@ -1,0 +1,145 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color aware l2cp (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-aware policer (honors ingress loss-priority)
+ *   - Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)
+ *   - Discards L2CP/BPDU destination-mac frames
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_port_based_fam_ccc
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard-l2cp {
+                from {
+                    destination-mac-address {
+                        01:80:c2:00:00:07/48;
+                        01:80:c2:00:00:0e/48;
+                        01:80:c2:00:00:20/48;
+                        01:80:c2:00:00:21/48;
+                        01:80:c2:00:00:22/48;
+                        01:80:c2:00:00:23/48;
+                        01:80:c2:00:00:2a/48;
+                        01:80:c2:00:00:2d/48;
+                        01:80:c2:00:00:2e/48;
+                        01:80:c2:00:00:2f/48;
+                        01:80:c2:00:00:2b/48;
+                        01:80:c2:00:00:24/48;
+                        01:80:c2:00:00:25/48;
+                        01:80:c2:00:00:26/48;
+                        01:80:c2:00:00:27/48;
+                        01:80:c2:00:00:28/48;
+                        01:80:c2:00:00:29/48;
+                        01:80:c2:00:00:2c/48;
+                    }
+                }
+                then {
+                    count l2cp_discard;
+                    discard;
+                }
+            }
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware-l2cp.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware-l2cp.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color aware l2cp (MEF E-Line / EPL)
+ * Topic:   Firewall: filter ccc color aware l2cp (MEF E-Line / EPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware.conf
@@ -1,0 +1,106 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color aware (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-aware policer (honors ingress loss-priority)
+ *   - Coupling-flag = 1 behavior (MX/ACX default; yellow re-uses green budget)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_vlan-based_fam_ccc
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-aware;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-aware.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color aware (MEF E-Line / EVPL)
+ * Topic:   Firewall: filter ccc color aware (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v2.conf
@@ -1,0 +1,116 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN2 (ACX5448)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *   Junos: AN1 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_eline-evpn-vpws
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 10k;
+            peak-information-rate 3500000000;
+            peak-burst-size 10125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 20k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 10k;
+            peak-information-rate 7g;
+            peak-burst-size 20k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ * Topic:   Firewall: filter ccc color blind (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN2 (ACX5448)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v3.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ * Topic:   Firewall: filter ccc color blind (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN4 (ACX710)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind-v3.conf
@@ -1,0 +1,115 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN4 (ACX710)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_vlan-based_fam_ccc
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ * Topic:   Firewall: filter ccc color blind (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), AN1 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-ccc-color-blind.conf
@@ -1,0 +1,116 @@
+/*
+ * Topic:
+ *   Firewall: filter ccc color blind (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), AN1 (MX204)
+ *
+ * Highlights:
+ *   - family ccc filter (L2 L2CP/PCP handling for CCC)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *   Junos: AN2 (ACX5448)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ */
+firewall {
+    family ccc {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    count discard_pcp6_7;
+                    discard;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count high_class;
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                    count class_medium;
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                    count class_low;
+                }
+            }
+            term default {
+                then {
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                    count default;
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 3500000000;
+            peak-burst-size 35125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 1500;
+            peak-information-rate 3500000000;
+            peak-burst-size 35k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 35k;
+            peak-information-rate 7g;
+            peak-burst-size 70k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-eswitch-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-eswitch-color-blind.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ * Topic:   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN2 (ACX5448)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-eswitch-color-blind.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/firewall/filter-eswitch-color-blind.conf
@@ -1,0 +1,116 @@
+/*
+ * Topic:
+ *   Firewall: filter eswitch color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN2 (ACX5448)
+ *
+ * Highlights:
+ *   - family ethernet-switching filter (Junos/ACX L2 switching path)
+ *   - Two-rate three-color marker (TrTCM, RFC 2698)
+ *   - Color-blind policer (ignores ingress loss-priority)
+ *   - Discards 802.1p priority 6/7 (reserved for network control)
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *   Junos: AN1 (MX204)
+ *
+ * Variables:
+ *   $FILTER_NAME  e.g. f_elan-evpn
+ */
+firewall {
+    family ethernet-switching {
+        filter $FILTER_NAME {
+            interface-specific;
+            term discard_pcp {
+                from {
+                    learn-vlan-1p-priority [ 6 7 ];
+                }
+                then {
+                    discard;
+                    count discard_pcp6_7;
+                }
+            }
+            term high_class {
+                from {
+                    learn-vlan-1p-priority [ 5 4 ];
+                }
+                then {
+                    count high_class;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+            term medium_class {
+                from {
+                    learn-vlan-1p-priority [ 3 2 ];
+                }
+                then {
+                    count class_medium;
+                    three-color-policer {
+                        two-rate medium_policer;
+                    }
+                }
+            }
+            term low_class {
+                from {
+                    learn-vlan-1p-priority [ 0 1 ];
+                }
+                then {
+                    count class_low;
+                    three-color-policer {
+                        two-rate low_policer;
+                    }
+                }
+            }
+            term default {
+                then {
+                    count default;
+                    three-color-policer {
+                        two-rate high_policer;
+                    }
+                }
+            }
+        }
+    }
+    three-color-policer high_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 10k;
+            peak-information-rate 3500000000;
+            peak-burst-size 10125;
+        }
+    }
+    three-color-policer low_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 22k;
+            committed-burst-size 125;
+            peak-information-rate 3500000000;
+            peak-burst-size 20k;
+        }
+    }
+    three-color-policer medium_policer {
+        action {
+            loss-priority high then discard;
+        }
+        two-rate {
+            color-blind;
+            committed-information-rate 3500000000;
+            committed-burst-size 10k;
+            peak-information-rate 7g;
+            peak-burst-size 20k;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-bridge.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
+ * Topic:   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-bridge.conf
@@ -1,0 +1,33 @@
+/*
+ * Topic:
+ *   Interface: ethernet bridge (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation ethernet-bridge
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware-l2cp.conf
+ *   - junos/services/evpn-elan.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. xe-0/1/0
+ *   $MTU      e.g. 9192
+ *   $UNIT     e.g. 0
+ */
+$AC_INTF {
+    mtu $MTU;
+    encapsulation ethernet-bridge;
+    unit $UNIT {
+        family bridge {
+            filter {
+                input f_port_based_fam_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-ccc.conf
@@ -1,0 +1,31 @@
+/*
+ * Topic:
+ *   Interface: ethernet ccc (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation ethernet-ccc
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-aware-l2cp.conf
+ *   - junos/services/l2vpn-kompella-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. xe-0/1/0
+ *   $UNIT     e.g. 0
+ */
+$AC_INTF {
+    encapsulation ethernet-ccc;
+    unit $UNIT {
+        family ccc {
+            filter {
+                input f_port_based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/ethernet-ccc.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: ethernet ccc (MEF E-Line / EPL)
+ * Topic:   Interface: ethernet ccc (MEF E-Line / EPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/irb-l3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/irb-l3.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: irb l3 (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: irb l3 (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Junos: MSE1 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/irb-l3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/irb-l3.conf
@@ -1,0 +1,24 @@
+/*
+ * Topic:
+ *   Interface: irb l3 (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - IRB unit for L3 termination
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   $IP_ADDRESS  e.g. 192.0.2.1/27
+ *   $UNIT        e.g. 4075
+ */
+irb {
+    unit $UNIT {
+        family inet {
+            address $IP_ADDRESS;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf
@@ -1,0 +1,39 @@
+/*
+ * Topic:
+ *   Interface: pseudowire subscriber (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/services/evpn-elan-vlan-based-floating-pw.conf
+ *   - junos/services/l2circuit-floating-pw.conf
+ *
+ * Variables:
+ *   $ESI_ID  e.g. 00:11:11:11:44:11:11:30:02:0a
+ *   $UNIT_1  e.g. 0
+ *   $UNIT_2  e.g. 4004
+ *   $VLAN    e.g. 4004
+ */
+ps22 {
+    anchor-point {
+        lt-0/0/0;
+    }
+    vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT_1 {
+        encapsulation ethernet-ccc;
+    }
+    unit $UNIT_2 {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: pseudowire subscriber (MEF E-Line / EVPL)
+ * Topic:   Interface: pseudowire subscriber (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-etree-root.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-etree-root.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge esi etree root (MEF E-Tree / EVP-Tree)
+ * Topic:   Interface: vlan bridge esi etree root (MEF E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-etree-root.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-etree-root.conf
@@ -1,0 +1,40 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge esi etree root (MEF E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/cos-binding-mpls.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/services/evpn-etree-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae10
+ *   $ESI_ID   e.g. 00:10:11:11:40:80:01:62:00:01
+ *   $UNIT     e.g. 4080
+ *   $VLAN     e.g. 4080
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family bridge {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+        etree-ac-role root;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v2.conf
@@ -1,0 +1,33 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: AN2 (ACX5448)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/services/evpn-elan-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae11
+ *   $ESI_ID   e.g. 00:70:11:40:11:11:11:00:00:64
+ *   $UNIT     e.g. 4011
+ *   $VLAN     e.g. 4011
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Junos: AN2 (ACX5448)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v3.conf
@@ -1,0 +1,39 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge esi (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/cos-binding-mpls.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/services/evpn-elan-vlan-based-floating-pw.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae10
+ *   $ESI_ID   e.g. 00:11:11:11:11:44:11:30:01:0a
+ *   $UNIT     e.g. 4004
+ *   $VLAN     e.g. 4004
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family bridge {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v3.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi-v3.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge esi (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan bridge esi (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi.conf
@@ -1,0 +1,38 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: AN1 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/services/evpn-elan-port-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae11
+ *   $ESI_ID   e.g. 00:70:11:40:11:11:11:00:00:64
+ *   $UNIT     e.g. 4011
+ *   $VLAN     e.g. 4011
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family bridge {
+            filter {
+                input f_elan-evpn;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-esi.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
+ * Topic:   Interface: vlan bridge esi (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Junos: AN1 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-leaf.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-leaf.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge etree leaf (MEF E-Tree / EVP-Tree)
+ * Topic:   Interface: vlan bridge etree leaf (MEF E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MA4 (MX204), MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-leaf.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-leaf.conf
@@ -1,0 +1,38 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge etree leaf (MEF E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MA4 (MX204), MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware.conf
+ *   - junos/services/evpn-etree-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. xe-0/1/5
+ *   $MTU      e.g. 9102
+ *   $UNIT     e.g. 4080
+ *   $VLAN     e.g. 4080
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    mtu $MTU;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        family bridge {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+        etree-ac-role leaf;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge qinq stacked (MEF E-Access)
+ * Topic:   Interface: vlan bridge qinq stacked (MEF E-Access)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked-v2.conf
@@ -1,0 +1,42 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge qinq stacked (MEF E-Access)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware-cf0.conf
+ *   - junos/services/bridge-domain-lsw.conf
+ *
+ * Variables:
+ *   $AC_INTF         e.g. xe-0/1/0
+ *   $MTU             e.g. 9102
+ *   $OUTER_VID_TPID  e.g. 0x88a8.4082
+ *   $UNIT            e.g. 4082
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    mtu $MTU;
+    encapsulation flexible-ethernet-services;
+    gigether-options {
+        ethernet-switch-profile {
+            tag-protocol-id [ 0x8100 0x88A8 ];
+        }
+    }
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-tags outer $OUTER_VID_TPID;
+        family bridge {
+            filter {
+                input f-vlan_based_fam_bridge;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge qinq stacked (MEF E-Access)
+ * Topic:   Interface: vlan bridge qinq stacked (MEF E-Access)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-qinq-stacked.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge qinq stacked (MEF E-Access)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/cos-binding-mpls.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/services/bridge-domain-lsw.conf
+ *
+ * Variables:
+ *   $AC_INTF         e.g. et-0/0/2
+ *   $MTU             e.g. 9102
+ *   $OUTER_VID_TPID  e.g. 0x88a8.4082
+ *   $UNIT            e.g. 4082
+ */
+$AC_INTF {
+    mtu $MTU;
+    gigether-options {
+        ethernet-switch-profile {
+            tag-protocol-id [ 0x8100 0x88A8 ];
+        }
+    }
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-tags outer $OUTER_VID_TPID;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:
+ *   Interface: vlan bridge (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware.conf
+ *   - junos/services/bgp-vpls-p2p.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. xe-0/1/0
+ *   $UNIT     e.g. 4005
+ *   $VLAN     e.g. 4005
+ */
+$AC_INTF {
+    vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        family bridge {
+            filter {
+                input f_vlan_based_fam_bridge_1;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan bridge (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan bridge (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-v2.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-aware.conf
+ *   - junos/services/l2vpn-kompella-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. xe-0/1/0
+ *   $UNIT     e.g. 200
+ *   $VLAN     e.g. 200
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-v2.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-v2.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map-esi.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN1 (MX204), AN2 (ACX5448)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map-esi.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map-esi.conf
@@ -1,0 +1,45 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN1 (MX204), AN2 (ACX5448)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-blind.conf
+ *   - junos/services/evpn-vpws-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. ae11
+ *   $ESI_ID     e.g. 00:10:11:49:30:11:01:00:00:00
+ *   $INPUT_VID  e.g. 4094
+ *   $UNIT       e.g. 4009
+ *   $VLAN       e.g. 4009
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input f_eline-evpn-vpws;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map.conf
@@ -1,0 +1,40 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN4 (ACX710)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/services/evpn-vpws-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF    e.g. xe-0/0/6
+ *   $INPUT_VID  e.g. 4080
+ *   $UNIT       e.g. 4010
+ *   $VLAN       e.g. 4010
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        family ccc {
+            filter {
+                input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-vlan-map.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc vlan map (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN4 (ACX710)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Interface: vlan ccc (MEF E-Line / EVPL)
+ * Topic:   Interface: vlan ccc (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc.conf
@@ -1,0 +1,44 @@
+/*
+ * Topic:
+ *   Interface: vlan ccc (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * Variables:
+ *   $AC_INTF  e.g. xe-0/0/13:2
+ *   $UNIT_1   e.g. 4007
+ *   $UNIT_2   e.g. 4008
+ *   $VLAN_1   e.g. 4007
+ *   $VLAN_2   e.g. 4008
+ */
+interfaces {
+    $AC_INTF {
+        flexible-vlan-tagging;
+        encapsulation flexible-ethernet-services;
+        unit $UNIT_1 {
+            encapsulation vlan-ccc;
+            vlan-id $VLAN_1;
+            family ccc {
+                filter {
+                    input f_vlan_based_fam_bridge;
+                }
+            }
+        }
+        unit $UNIT_2 {
+            encapsulation vlan-ccc;
+            vlan-id $VLAN_2;
+            family ccc {
+                filter {
+                    input f_vlan_based_fam_bridge;
+                }
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-l3vpn-import-export.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-l3vpn-import-export.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)
+ * Topic:   Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Junos: MSE1 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-l3vpn-import-export.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-l3vpn-import-export.conf
@@ -1,0 +1,44 @@
+/*
+ * Topic:
+ *   Policy: policy l3vpn import export (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - Community-driven RT policy
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Variables:
+ *   $COMM_RT        e.g. 61535:13075
+ *   $POLICY_NAME_1  e.g. PS-$VPN_RT_COMM-EXPORT
+ *   $POLICY_NAME_2  e.g. PS-$VPN_RT_COMM-IMPORT
+ *   $PUBLIC_PREFIX  e.g. 192.0.2.1/24
+ *   $VPN_RT_COMM    e.g. METRO_L3VPN_4075
+ */
+policy-options {
+    policy-statement $POLICY_NAME_1 {
+        term tag-public-routes {
+            from {
+                route-filter $PUBLIC_PREFIX orlonger;
+            }
+            then {
+                community add CM-L3VPN-PUB;
+                community add $VPN_RT_COMM;
+                accept;
+            }
+        }
+    }
+    policy-statement $POLICY_NAME_2 {
+        term L3VPN-CUST {
+            from community $VPN_RT_COMM;
+            then accept;
+        }
+    }
+    community $VPN_RT_COMM members target:$COMM_RT;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Policy: policy vpn rt export gold (MEF E-Tree / EVP-Tree)
+ * Topic:   Policy: policy vpn rt export gold (MEF E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304), MA4 (MX204), MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf
@@ -1,0 +1,37 @@
+/*
+ * Topic:
+ *   Policy: policy vpn rt export gold (MEF E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304), MA4 (MX204), MA5 (MX204)
+ *
+ * Highlights:
+ *   - Community-driven RT policy
+ *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *
+ * Pair with (same-device dependencies):
+ *   (none derived)
+ *
+ * JVD peer devices (observed interop):
+ *   (none — single-device snip)
+ *
+ * Variables:
+ *   $COMM_RT      e.g. 63536:4080
+ *   $POLICY_NAME  e.g. evpn_group_80_4080
+ *   $VPN_RT_COMM  e.g. evpn_group_80_4080_RT
+ */
+policy-options {
+    policy-statement $POLICY_NAME {
+        term a {
+            then {
+                community add $VPN_RT_COMM;
+                community add CM-TC-MAP2GOLD;
+                accept;
+            }
+        }
+        term b {
+            then reject;
+        }
+    }
+    community $VPN_RT_COMM members target:$COMM_RT;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls-p2p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls-p2p.conf
@@ -1,0 +1,63 @@
+/*
+ * Topic:
+ *   Service instance: bgp vpls p2p (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - instance-type virtual-switch
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *   - Local-switched (LSW) bridge-domain — no MPLS, used in E-Access hand-off scenarios
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware.conf
+ *   - junos/interfaces/vlan-bridge.conf
+ *
+ * JVD service mapping:
+ *   vpls_group_4005 (eline_evpl_vpls_fapm_ring_p2p.conf):
+ *     PEs (Evo): MA1.2 (ACX7024)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF           e.g. xe-0/1/0
+ *   $INSTANCE_NAME     e.g. vpls_group_4005
+ *   $LABEL_BLOCK_SIZE  e.g. 2
+ *   $RD                e.g. 10.0.0.19:44444
+ *   $SITE_ID           e.g. 3
+ *   $SITE_NAME         e.g. r19
+ *   $SITE_RANGE        e.g. 2
+ *   $UNIT              e.g. 4005
+ *   $VLAN              e.g. 4005
+ *   $VRF_TARGET        e.g. 64535:44444
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type virtual-switch;
+        protocols {
+            vpls {
+                site $SITE_NAME {
+                    site-identifier $SITE_ID;
+                }
+                site-range $SITE_RANGE;
+                label-block-size $LABEL_BLOCK_SIZE;
+                no-tunnel-services;
+            }
+        }
+        bridge-domains {
+            vlan4005 {
+                vlan-id $VLAN;
+                interface $AC_INTF.$UNIT;
+                bridge-options {
+                    no-normalization;
+                }
+            }
+        }
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls-p2p.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls-p2p.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: bgp vpls p2p (MEF E-Line / EVPL)
+ * Topic:   Service instance: bgp vpls p2p (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/bridge-domain-lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/bridge-domain-lsw.conf
@@ -1,0 +1,35 @@
+/*
+ * Topic:
+ *   Service instance: bridge domain lsw (MEF E-Access)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - Local-switched (LSW) bridge-domain — no MPLS, used in E-Access hand-off scenarios
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/cos-binding-mpls.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware-cf0.conf
+ *   - junos/interfaces/vlan-bridge-qinq-stacked.conf
+ *
+ * JVD service mapping:
+ *   lsw_evpn_vpws_group_90_4082 (eaccess_evpn-vpws_lsw.conf):
+ *     PEs (Evo): MA3 (ACX7100-48L)
+ *   l2ckt (eaccess_l2ckt_lsw.conf):
+ *     PEs (Evo): MA3 (ACX7100-48L)
+ *
+ * Variables:
+ *   $AC_INTF_1  e.g. et-0/0/2
+ *   $AC_INTF_2  e.g. xe-0/1/0
+ *   $UNIT       e.g. 4082
+ */
+bridge-domains {
+    bd_group_lsw_4082 {
+        interface $AC_INTF_1.$UNIT;
+        interface $AC_INTF_2.$UNIT;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/bridge-domain-lsw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/bridge-domain-lsw.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: bridge domain lsw (MEF E-Access)
+ * Topic:   Service instance: bridge domain lsw (MEF E-Access)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-port-based.conf
@@ -1,0 +1,47 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: AN1 (MX204), AN2 (ACX5448)
+ *
+ * Highlights:
+ *   - instance-type evpn
+ *   - vlan-id none + no-normalization (port-based bridging)
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-eswitch-color-blind.conf
+ *   - junos/interfaces/vlan-bridge-esi.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_90_4011 (elan_evp-lan_evpn-elan_vlan-based.conf):
+ *     A-A Multihoming: AN1 (MX204), AN2 (ACX5448)
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG1 (ACX7509)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae11
+ *   $INSTANCE_NAME  e.g. evpn_group_90_4011
+ *   $RD             e.g. 10.0.0.0:64011
+ *   $UNIT           e.g. 4011
+ *   $VRF_TARGET     e.g. 63535:64011
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn;
+        protocols {
+            evpn {
+                encapsulation mpls;
+            }
+        }
+        vlan-id none;
+        no-normalization;
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-port-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Junos: AN1 (MX204), AN2 (ACX5448)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-type5.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-type5.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
  *
  * Seen on:
  *   Junos: MSE1 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-type5.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-type5.conf
@@ -1,0 +1,81 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan type5 (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - instance-type virtual-switch
+ *   - EVPN Type-5 IP-prefix routes (L3 over EVPN)
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *   - Local-switched (LSW) bridge-domain — no MPLS, used in E-Access hand-off scenarios
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *
+ * JVD service mapping:
+ *   METRO_L3VPN_4075 (elan_evp-lan_evpn-elan_type-5.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Junos): MSE1 (MX304)
+ *   evpn_group_60_4075 (elan_evp-lan_evpn-elan_type-5.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *     PEs (Junos): MSE1 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. xe-0/0/13:2
+ *   $INSTANCE_NAME  e.g. evpn_group_60_4075
+ *   $IRB_UNIT       e.g. 4075
+ *   $RD_1           e.g. 10.0.0.10:14075
+ *   $RD_2           e.g. 63200:13075
+ *   $ROUTER_ID      e.g. 10.0.0.10
+ *   $UNIT           e.g. 4075
+ *   $VLAN           e.g. 4075
+ *   $VRF_TARGET     e.g. 61535:14075
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type virtual-switch;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                default-gateway do-not-advertise;
+                extended-vlan-list 4075;
+                no-control-word;
+            }
+        }
+        bridge-domains {
+            BD_evpn_group_60_4075 {
+                vlan-id $VLAN;
+                interface $AC_INTF.$UNIT;
+                routing-interface irb.$IRB_UNIT;
+            }
+        }
+        route-distinguisher $RD_1;
+        vrf-target target:$VRF_TARGET;
+    }
+    METRO_L3VPN_4075 {
+        instance-type vrf;
+        routing-options {
+            router-id $ROUTER_ID;
+            auto-export;
+        }
+        protocols {
+            evpn {
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation mpls;
+                }
+            }
+        }
+        interface irb.$IRB_UNIT;
+        route-distinguisher $RD_2;
+        vrf-import PS-METRO_L3VPN_4075-IMPORT;
+        vrf-export PS-METRO_L3VPN_4075-EXPORT;
+        vrf-table-label;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
@@ -1,0 +1,48 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan vlan based floating pw (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)
+ *
+ * Highlights:
+ *   - instance-type evpn
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/cos-binding-mpls.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/interfaces/pseudowire-subscriber.conf
+ *   - junos/interfaces/vlan-bridge-esi.conf
+ *   - junos/services/l2circuit-floating-pw.conf
+ *
+ * JVD service mapping:
+ *   l2circuit (eline_evpl_floating_pw.conf):
+ *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
+ *   l2ckt-vc10120 (eline_evpl_floating_pw.conf):
+ *     PEs (Evo): MA1.2 (ACX7024)
+ *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae10
+ *   $INSTANCE_NAME  e.g. 4004-evpn-floating-pw
+ *   $RD             e.g. 10.0.0.10:40004
+ *   $UNIT           e.g. 4004
+ *   $VLAN           e.g. 4004
+ *   $VRF_TARGET     e.g. 4004:4004
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn;
+        protocols {
+            evpn;
+        }
+        vlan-id $VLAN;
+        interface $AC_INTF.$UNIT;
+        interface ps22.4004;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan vlan based floating pw (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn elan vlan based floating pw (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn elan (MEF E-LAN / EP-LAN)
+ * Topic:   Service instance: evpn elan (MEF E-LAN / EP-LAN)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan.conf
@@ -1,0 +1,46 @@
+/*
+ * Topic:
+ *   Service instance: evpn elan (MEF E-LAN / EP-LAN)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - instance-type evpn
+ *   - MPLS encapsulation (SR-MPLS or LDP underlay)
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware-l2cp.conf
+ *   - junos/interfaces/ethernet-bridge.conf
+ *
+ * JVD service mapping:
+ *   MEF_EVPN_ELAN_PORT_BASED (elan_ep-lan_evpn_elan.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L), MA1.2 (ACX7024)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. xe-0/1/0
+ *   $INSTANCE_NAME  e.g. MEF_EVPN_ELAN_PORT_BASED
+ *   $RD             e.g. 10.0.0.19:4014
+ *   $UNIT           e.g. 0
+ *   $VRF_TARGET     e.g. 63535:4014
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                no-control-word;
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-etree-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-etree-vlan-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn etree vlan based (MEF E-Tree / EVP-Tree)
+ * Topic:   Service instance: evpn etree vlan based (MEF E-Tree / EVP-Tree)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304), MA4 (MX204), MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-etree-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-etree-vlan-based.conf
@@ -1,0 +1,50 @@
+/*
+ * Topic:
+ *   Service instance: evpn etree vlan based (MEF E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304), MA4 (MX204), MA5 (MX204)
+ *
+ * Highlights:
+ *   - instance-type evpn
+ *   - EVPN E-Tree (root/leaf segregation)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/cos-binding-mpls.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-aware.conf
+ *   - junos/interfaces/vlan-bridge-esi-etree-root.conf
+ *   - junos/interfaces/vlan-bridge-etree-leaf.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_80_4080 (etree_evp-tree_evpn-etree.conf):
+ *     A-A Multihoming: MSE1 (MX304), MSE2 (MX304)
+ *     PEs (Junos): MA4 (MX204), MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae10
+ *   $INSTANCE_NAME  e.g. evpn_group_80_4080
+ *   $RD             e.g. 10.0.0.10:4080
+ *   $UNIT           e.g. 4080
+ *   $VLAN           e.g. 4080
+ *   $VRF_TARGET     e.g. 63536:4080
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT;
+                evpn-etree;
+            }
+        }
+        vlan-id $VLAN;
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-fxc-vlan-unaware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-fxc-vlan-unaware.conf
@@ -1,0 +1,49 @@
+/*
+ * Topic:
+ *   Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_4007 (eline_evpl_evpn-fxc_unaware_sh.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): MSE1 (MX304)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. xe-0/0/13:2
+ *   $INSTANCE_NAME  e.g. evpn_group_4007
+ *   $RD             e.g. 10.0.0.10:40001
+ *   $UNIT_1         e.g. 4007
+ *   $UNIT_2         e.g. 4008
+ *   $VRF_TARGET     e.g. 63535:40001
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                flexible-cross-connect-vlan-unaware;
+                group fxc {
+                    interface $AC_INTF.$UNIT_1;
+                    interface $AC_INTF.$UNIT_2;
+                    service-id {
+                        local 2;
+                        remote 1;
+                    }
+                }
+            }
+        }
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-fxc-vlan-unaware.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-fxc-vlan-unaware.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn fxc vlan unaware (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-vpws-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-vpws-vlan-based.conf
@@ -1,0 +1,55 @@
+/*
+ * Topic:
+ *   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: AN1 (MX204), AN2 (ACX5448), AN4 (ACX710)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - EVPN-VPWS attachment-circuit with local/remote service-id
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-blind.conf
+ *   - junos/interfaces/vlan-ccc-vlan-map-esi.conf
+ *   - junos/interfaces/vlan-ccc-vlan-map.conf
+ *
+ * JVD service mapping:
+ *   evpn_group_30_4009 (eline_evpl_evpn_vpws_mh_e2e.conf):
+ *     A-A Multihoming: AN1 (MX204), AN2 (ACX5448), AN3 (ACX7100-48L)
+ *     A-A Multihoming: MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *   evpn_group_20_4010 (eline_evpl_evpn_vpws_sh_fabric.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): AN4 (ACX710)
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae11
+ *   $INSTANCE_NAME  e.g. evpn_group_30_4009
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.0:4999
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT           e.g. 4009
+ *   $VRF_TARGET     e.g. 63535:4999
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-vpws-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-vpws-vlan-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
+ * Topic:   Service instance: evpn vpws vlan based (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: AN1 (MX204), AN2 (ACX5448), AN4 (ACX710)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2circuit floating pw (MEF E-Line / EVPL)
+ * Topic:   Service instance: l2circuit floating pw (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MSE1 (MX304), MSE2 (MX304)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf
@@ -1,0 +1,38 @@
+/*
+ * Topic:
+ *   Service instance: l2circuit floating pw (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)
+ *
+ * Highlights:
+ *   - Static targeted-LDP L2-circuit pseudowire (no routing-instance required)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/interfaces/pseudowire-subscriber.conf
+ *   - junos/services/evpn-elan-vlan-based-floating-pw.conf
+ *
+ * JVD service mapping:
+ *   l2circuit (eline_evpl_floating_pw.conf):
+ *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
+ *   l2ckt-vc10120 (eline_evpl_floating_pw.conf):
+ *     PEs (Evo): MA1.2 (ACX7024)
+ *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
+ *
+ * Variables:
+ *   $VC_ID  e.g. 10120
+ */
+protocols {
+    l2circuit {
+        neighbor 10.0.0.18 {
+            interface ps22.0 {
+                static {
+                    incoming-label 1000022;
+                    outgoing-label 1000022;
+                }
+                virtual-circuit-id $VC_ID;
+                encapsulation-type ethernet-vlan;
+            }
+        }
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-port-based.conf
@@ -1,0 +1,55 @@
+/*
+ * Topic:
+ *   Service instance: l2vpn kompella port based (MEF E-Line / EPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - instance-type l2vpn
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-aware-l2cp.conf
+ *   - junos/interfaces/ethernet-ccc.conf
+ *
+ * JVD service mapping:
+ *   MEF_L2VPN_PORT_BASED (eline_epl_l2vpn.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF         e.g. xe-0/1/0
+ *   $INSTANCE_NAME   e.g. MEF_L2VPN_PORT_BASED
+ *   $RD              e.g. 63535:100000
+ *   $REMOTE_SITE_ID  e.g. 1102
+ *   $SITE_ID         e.g. 1119
+ *   $UNIT            e.g. 0
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type l2vpn;
+        protocols {
+            l2vpn {
+                site r19 {
+                    interface $AC_INTF.$UNIT {
+                        remote-site-id $REMOTE_SITE_ID;
+                    }
+                    site-identifier $SITE_ID;
+                }
+                encapsulation-type ethernet;
+                no-control-word;
+                flow-label-transmit;
+                flow-label-receive;
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$RD;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-port-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-port-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2vpn kompella port based (MEF E-Line / EPL)
+ * Topic:   Service instance: l2vpn kompella port based (MEF E-Line / EPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-vlan-based.conf
@@ -1,0 +1,54 @@
+/*
+ * Topic:
+ *   Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - instance-type l2vpn
+ *   - no-control-word (matches remote PE)
+ *   - RT-driven import/export
+ *   - VPLS $SITE_ID is per-domain — use contiguous IDs across PEs (1,2,3,...)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-aware.conf
+ *   - junos/interfaces/vlan-ccc.conf
+ *
+ * JVD service mapping:
+ *   l2vpn_group_200 (eline_evpl_l2vpn_e2e.conf):
+ *     PEs (Evo): AN3 (ACX7100-48L)
+ *     PEs (Junos): MA5 (MX204)
+ *
+ * Variables:
+ *   $AC_INTF         e.g. xe-0/1/0
+ *   $INSTANCE_NAME   e.g. l2vpn_group_200
+ *   $RD              e.g. 63535:112000
+ *   $REMOTE_SITE_ID  e.g. 1102
+ *   $SITE_ID         e.g. 1119
+ *   $UNIT            e.g. 200
+ *   $VRF_TARGET      e.g. 63535:102000
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type l2vpn;
+        protocols {
+            l2vpn {
+                site r19 {
+                    interface $AC_INTF.$UNIT {
+                        remote-site-id $REMOTE_SITE_ID;
+                    }
+                    site-identifier $SITE_ID;
+                }
+                encapsulation-type ethernet-vlan;
+                no-control-word;
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-vlan-based.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2vpn-kompella-vlan-based.conf
@@ -1,6 +1,5 @@
 /*
- * Topic:
- *   Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)
+ * Topic:   Service instance: l2vpn kompella vlan based (MEF E-Line / EVPL)
  *
  * Seen on:
  *   Junos: MA5 (MX204)


### PR DESCRIPTION
## What's New

Publishes the first reusable configuration-snippet library for the
Metro-as-a-Service (MaaS) JVD — 112 templated `.conf` snippets covering
the full MEF service portfolio across both Junos and Junos EVO, and
wires the new library into the JVD Portal Snip Browser.

- 50 Junos templates (MX, ACX5448, ACX710) + 62 EVO templates
  (ACX7024, ACX7100, ACX7509) in parallel `junos/` and `evo/` trees
- Six categories per OS: `services/`, `interfaces/`, `firewall/`,
  `cos/`, `policy/`, `apply-groups/`
- Coverage spans E-Line (EPL, EVPL), E-LAN (EP-LAN, EVP-LAN),
  E-Tree (EP-Tree, EVP-Tree), and E-Access — including
  EVPN E-LAN Type-5, EVPN E-Tree, EVPN FXC (vlan-aware/unaware),
  L2VPN Kompella, and Pseudowire Headend Termination via
  `l2circuit-floating-pw`
- Snip-library [`README.md`](service_provider/metro_as_a_service/configuration/snips/README.md)
  and [`_variables.md`](service_provider/metro_as_a_service/configuration/snips/_variables.md)
  glossary for all 49 placeholders
- Browse the new templates on the
  [JVD Portal Snip Library](https://juniper.github.io/jvd/portal/#snips)
  (filterable by JVD, technology, and use case)

## Why

Source MaaS captures under `configuration/conf/` are full per-device,
per-service files. The new snip library lets a deployer pull just the
stanzas they need for a chosen service shape and OS, with each snip's
header listing the other same-device snips that must coexist for the
configuration to function. Sibling Junos and EVO trees make per-platform
selection straightforward.

## Details

**`feat(maas): publish config snip library (112 templates, junos+evo)`**
- New tree under [`service_provider/metro_as_a_service/configuration/snips/`](service_provider/metro_as_a_service/configuration/snips/)
  containing 112 `.conf` files plus `README.md` and `_variables.md`
- Each snip carries the standard five-section header: `Topic`,
  `Seen on`, `Highlights`, `Pair with`, `JVD service mapping`,
  `Variables`
- Instance-specific values (instance names, RDs, RTs, ESIs, VLAN
  tags, interface names, site IDs) replaced by `$VARIABLE`
  placeholders
- `Pair with` cross-references are scoped to same-device dependencies
  observed in the source JVD configurations, so the dependency
  closure is reconstructable

**`chore(maas): update source configurations`**
- Ten files under [`configuration/conf/`](service_provider/metro_as_a_service/configuration/conf/)
  refreshed for accuracy:
  - CoS `FC-HIGH` `ieee-802.1p` code-point corrected from `101` to
    `100` in eight per-service captures (the `101` value collided
    with the FC-LOW pattern and was inconsistent with all other
    devices)
  - Restored a missing `family ccc { ... }` wrapper around a firewall
    filter in `eline_epl_l2vpn.conf`
  - Added a missing `scheduler-map SM-5G-SCHEDULER;` binding under an
    EVPN-VPWS edge interface in `eline_evpl_evpn_vpws_edge.conf`
  - Repaired an unbalanced `class-of-service` brace in
    `eline_evpl_evpn_vpws_mh_e2e.conf`

**`feat(portal): wire MaaS snip library into snip browser`**
- Adds `metro_as_a_service` to `portal/scripts/jvd-usecase-map.json`
  (Service Provider / Metro / Business Services / MEF) so the JVD
  appears in the portal's "Use Case" browse mode
- Collapses the multi-line `Topic:` block in every MaaS snip onto
  a single line to match the portal's snip-header parser convention
- Regenerates `portal/src/data/snips.json` so the 112 new MaaS snips
  show up at https://juniper.github.io/jvd/portal/#snips
- Refreshes a small amount of pre-existing drift in the MEBS BYOAI
  manifest that the same generator script regenerates as a side-effect

## Testing

- 112 snip files round-trip-reconstruct the relevant stanzas in the
  source captures (validated locally)
- Snip-library `README.md` and `_variables.md` regenerated from snip
  headers and verified to list all 49 placeholders
- `node portal/scripts/generate-snips.mjs --check` exits OK (432 snips,
  8 JVDs, 0 warnings)
- `CHANGELOG.md` updated with a new `## 2026-05-28` entry; previous
  `## 2026-05-21` entry left intact

## Notes

Will squash-merge to one commit on `main`.
