### PR TITLE
fix(maas): expand BYOAI TIERS catalog with FXC, E-Tree, L3VPN-bgp/ospf, floating-pw, lsw, slim anchor

### DIFF
--- a/portal/public/byoai/metro_ethernet_business_services/TIERS.md
+++ b/portal/public/byoai/metro_ethernet_business_services/TIERS.md
@@ -48,10 +48,18 @@ If the user picks `minimum` and the AI cannot tell whether the overlay activatio
 
 ---
 
-## L3VPN-VRF
+## L3VPN (PE-CE eBGP or PE-CE OSPF)
+
+Two PE-CE protocol variants — pick the snip that matches what the
+user asked for (default to eBGP if unspecified):
+
+- **L3VPN with PE-CE eBGP** (`as-override`):
+  - `services/l3vpn-bgp.conf` (Junos and EVO)
+- **L3VPN with PE-CE OSPF** (area 0, `interface-type p2p`):
+  - `services/l3vpn-ospf.conf` (Junos and EVO)
 
 **minimum** (just the service + per-VRF policy)
-- `services/l3vpn-vrf.conf`
+- `services/l3vpn-bgp.conf` **or** `services/l3vpn-ospf.conf`
 - `policy/l3vpn-export-import.conf`
 - `policy/communities.conf` (only the per-VRF target community — NOT topology tags or BGP-CT colors)
 - `interfaces/edge-vlan-normalization.conf` (PE-CE AC unit)
@@ -196,6 +204,102 @@ Tiers (apply to whichever of the three the user asked for):
   LDP-VPLS does not need this — it relies on LDP targeted sessions)
 - **as-deployed** = + transport underlay + full apply-group baseline
   + CoS + OAM + BGP-CT
+
+---
+
+## EVPN-FXC (Flexible Cross-Connect)
+
+EVPN-FXC bundles multiple VLAN-tagged UNIs under a single
+`evpn-vpws` routing-instance via an FXC collector group. Use this
+when the customer hands off many service-delimited VLANs on the
+same port and you want one PW per VLAN without one routing-instance
+per VLAN.
+
+**minimum** (just the service)
+- `services/evpn-fxc.conf` (Junos and EVO — `instance-type evpn-vpws` with `flexible-cross-connect`)
+- `junos/interfaces/edge-vlan-normalization.conf` (the per-VLAN AC units that join the FXC group)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-VPWS above (transport + apply-groups + CoS + OAM + FAT-PW)
+
+---
+
+## EVPN E-Tree
+
+MEF E-Tree (root / leaf isolation) on a Junos `mac-vrf` with
+`etree-ac-role` on each UNI. Junos-only in this JVD.
+
+**minimum** (just the service)
+- `junos/services/evpn-etree.conf`
+- `junos/interfaces/ethernet-bridge.conf` (E-Tree leaf/root UNI)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-ELAN above
+
+---
+
+## L2Circuit floating pseudowire
+
+Static-label L2Circuit pseudowire landing on a `ps<N>`
+pseudowire-subscriber anchor (decouples the PW from a physical AC).
+
+**minimum** (just the service)
+- `services/l2circuit-floating-pw.conf` (Junos and EVO)
+- `junos/interfaces/pseudowire-subscriber.conf` (the `ps<N>` anchor)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (L2Circuit relies on targeted LDP, not BGP — overlay is informational)
+
+**as-deployed** (= with-overlay +)
+- same baseline as L2CIRCUIT above
+
+---
+
+## L2Circuit local-switching (cross-connect on one PE)
+
+Port-to-port hairpin on a single PE via `end-interface`. EVO-only
+in this JVD.
+
+**minimum** (just the service)
+- `evo/services/l2circuit-lsw.conf`
+- `interfaces/edge-vlan-normalization.conf` (both AC units that get cross-connected)
+
+**with-overlay** — not applicable (no MP signaling required)
+
+**as-deployed** (= minimum +)
+- transport underlay + edge apply-groups + CoS + OAM + firewall policers
+
+---
+
+## Slim L3VPN IRB-anchor VRF (host /32s ride RT-2)
+
+A Type-5 anchor VRF that pairs with an EVPN-ELAN MAC-VRF for
+L2 + L3 IRB services. No explicit `ip-prefix-routes` block —
+host /32s are advertised via the MAC-VRF's RT-2. Use this instead
+of `services/evpn-type5.conf` when you do not need the VRF to
+originate RT-5 prefix routes (only the IRB subnet matters and it
+is carried by RT-2).
+
+**minimum** (both halves of the service + per-VRF policy)
+- L2 / RT-2 half (one of):
+    - `evo/services/evpn-elan-mac-vrf-irb.conf` (EVO)
+    - `junos/services/evpn-elan-virtual-switch-irb.conf` (Junos MX)
+- `services/evpn-type5-anchor.conf` (the slim anchor VRF — Junos and EVO)
+- `policy/l3vpn-export-import.conf`
+- `policy/communities.conf` (only the per-VRF target community)
+- `interfaces/edge-vlan-normalization.conf`
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN Type-5 above
 
 ---
 

--- a/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-snips.md
+++ b/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-snips.md
@@ -5284,10 +5284,18 @@ If the user picks `minimum` and the AI cannot tell whether the overlay activatio
 
 ---
 
-## L3VPN-VRF
+## L3VPN (PE-CE eBGP or PE-CE OSPF)
+
+Two PE-CE protocol variants — pick the snip that matches what the
+user asked for (default to eBGP if unspecified):
+
+- **L3VPN with PE-CE eBGP** (`as-override`):
+  - `services/l3vpn-bgp.conf` (Junos and EVO)
+- **L3VPN with PE-CE OSPF** (area 0, `interface-type p2p`):
+  - `services/l3vpn-ospf.conf` (Junos and EVO)
 
 **minimum** (just the service + per-VRF policy)
-- `services/l3vpn-vrf.conf`
+- `services/l3vpn-bgp.conf` **or** `services/l3vpn-ospf.conf`
 - `policy/l3vpn-export-import.conf`
 - `policy/communities.conf` (only the per-VRF target community — NOT topology tags or BGP-CT colors)
 - `interfaces/edge-vlan-normalization.conf` (PE-CE AC unit)
@@ -5432,6 +5440,102 @@ Tiers (apply to whichever of the three the user asked for):
   LDP-VPLS does not need this — it relies on LDP targeted sessions)
 - **as-deployed** = + transport underlay + full apply-group baseline
   + CoS + OAM + BGP-CT
+
+---
+
+## EVPN-FXC (Flexible Cross-Connect)
+
+EVPN-FXC bundles multiple VLAN-tagged UNIs under a single
+`evpn-vpws` routing-instance via an FXC collector group. Use this
+when the customer hands off many service-delimited VLANs on the
+same port and you want one PW per VLAN without one routing-instance
+per VLAN.
+
+**minimum** (just the service)
+- `services/evpn-fxc.conf` (Junos and EVO — `instance-type evpn-vpws` with `flexible-cross-connect`)
+- `junos/interfaces/edge-vlan-normalization.conf` (the per-VLAN AC units that join the FXC group)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-VPWS above (transport + apply-groups + CoS + OAM + FAT-PW)
+
+---
+
+## EVPN E-Tree
+
+MEF E-Tree (root / leaf isolation) on a Junos `mac-vrf` with
+`etree-ac-role` on each UNI. Junos-only in this JVD.
+
+**minimum** (just the service)
+- `junos/services/evpn-etree.conf`
+- `junos/interfaces/ethernet-bridge.conf` (E-Tree leaf/root UNI)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-ELAN above
+
+---
+
+## L2Circuit floating pseudowire
+
+Static-label L2Circuit pseudowire landing on a `ps<N>`
+pseudowire-subscriber anchor (decouples the PW from a physical AC).
+
+**minimum** (just the service)
+- `services/l2circuit-floating-pw.conf` (Junos and EVO)
+- `junos/interfaces/pseudowire-subscriber.conf` (the `ps<N>` anchor)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (L2Circuit relies on targeted LDP, not BGP — overlay is informational)
+
+**as-deployed** (= with-overlay +)
+- same baseline as L2CIRCUIT above
+
+---
+
+## L2Circuit local-switching (cross-connect on one PE)
+
+Port-to-port hairpin on a single PE via `end-interface`. EVO-only
+in this JVD.
+
+**minimum** (just the service)
+- `evo/services/l2circuit-lsw.conf`
+- `interfaces/edge-vlan-normalization.conf` (both AC units that get cross-connected)
+
+**with-overlay** — not applicable (no MP signaling required)
+
+**as-deployed** (= minimum +)
+- transport underlay + edge apply-groups + CoS + OAM + firewall policers
+
+---
+
+## Slim L3VPN IRB-anchor VRF (host /32s ride RT-2)
+
+A Type-5 anchor VRF that pairs with an EVPN-ELAN MAC-VRF for
+L2 + L3 IRB services. No explicit `ip-prefix-routes` block —
+host /32s are advertised via the MAC-VRF's RT-2. Use this instead
+of `services/evpn-type5.conf` when you do not need the VRF to
+originate RT-5 prefix routes (only the IRB subnet matters and it
+is carried by RT-2).
+
+**minimum** (both halves of the service + per-VRF policy)
+- L2 / RT-2 half (one of):
+    - `evo/services/evpn-elan-mac-vrf-irb.conf` (EVO)
+    - `junos/services/evpn-elan-virtual-switch-irb.conf` (Junos MX)
+- `services/evpn-type5-anchor.conf` (the slim anchor VRF — Junos and EVO)
+- `policy/l3vpn-export-import.conf`
+- `policy/communities.conf` (only the per-VRF target community)
+- `interfaces/edge-vlan-normalization.conf`
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN Type-5 above
 
 ---
 

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-29T23:34:44.516Z",
+  "generatedAt": "2026-05-30T00:03:06.001Z",
   "counts": {
     "total": 445,
     "junos": 217,

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/TIERS.md
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/TIERS.md
@@ -48,10 +48,18 @@ If the user picks `minimum` and the AI cannot tell whether the overlay activatio
 
 ---
 
-## L3VPN-VRF
+## L3VPN (PE-CE eBGP or PE-CE OSPF)
+
+Two PE-CE protocol variants — pick the snip that matches what the
+user asked for (default to eBGP if unspecified):
+
+- **L3VPN with PE-CE eBGP** (`as-override`):
+  - `services/l3vpn-bgp.conf` (Junos and EVO)
+- **L3VPN with PE-CE OSPF** (area 0, `interface-type p2p`):
+  - `services/l3vpn-ospf.conf` (Junos and EVO)
 
 **minimum** (just the service + per-VRF policy)
-- `services/l3vpn-vrf.conf`
+- `services/l3vpn-bgp.conf` **or** `services/l3vpn-ospf.conf`
 - `policy/l3vpn-export-import.conf`
 - `policy/communities.conf` (only the per-VRF target community — NOT topology tags or BGP-CT colors)
 - `interfaces/edge-vlan-normalization.conf` (PE-CE AC unit)
@@ -196,6 +204,102 @@ Tiers (apply to whichever of the three the user asked for):
   LDP-VPLS does not need this — it relies on LDP targeted sessions)
 - **as-deployed** = + transport underlay + full apply-group baseline
   + CoS + OAM + BGP-CT
+
+---
+
+## EVPN-FXC (Flexible Cross-Connect)
+
+EVPN-FXC bundles multiple VLAN-tagged UNIs under a single
+`evpn-vpws` routing-instance via an FXC collector group. Use this
+when the customer hands off many service-delimited VLANs on the
+same port and you want one PW per VLAN without one routing-instance
+per VLAN.
+
+**minimum** (just the service)
+- `services/evpn-fxc.conf` (Junos and EVO — `instance-type evpn-vpws` with `flexible-cross-connect`)
+- `junos/interfaces/edge-vlan-normalization.conf` (the per-VLAN AC units that join the FXC group)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-VPWS above (transport + apply-groups + CoS + OAM + FAT-PW)
+
+---
+
+## EVPN E-Tree
+
+MEF E-Tree (root / leaf isolation) on a Junos `mac-vrf` with
+`etree-ac-role` on each UNI. Junos-only in this JVD.
+
+**minimum** (just the service)
+- `junos/services/evpn-etree.conf`
+- `junos/interfaces/ethernet-bridge.conf` (E-Tree leaf/root UNI)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-ELAN above
+
+---
+
+## L2Circuit floating pseudowire
+
+Static-label L2Circuit pseudowire landing on a `ps<N>`
+pseudowire-subscriber anchor (decouples the PW from a physical AC).
+
+**minimum** (just the service)
+- `services/l2circuit-floating-pw.conf` (Junos and EVO)
+- `junos/interfaces/pseudowire-subscriber.conf` (the `ps<N>` anchor)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (L2Circuit relies on targeted LDP, not BGP — overlay is informational)
+
+**as-deployed** (= with-overlay +)
+- same baseline as L2CIRCUIT above
+
+---
+
+## L2Circuit local-switching (cross-connect on one PE)
+
+Port-to-port hairpin on a single PE via `end-interface`. EVO-only
+in this JVD.
+
+**minimum** (just the service)
+- `evo/services/l2circuit-lsw.conf`
+- `interfaces/edge-vlan-normalization.conf` (both AC units that get cross-connected)
+
+**with-overlay** — not applicable (no MP signaling required)
+
+**as-deployed** (= minimum +)
+- transport underlay + edge apply-groups + CoS + OAM + firewall policers
+
+---
+
+## Slim L3VPN IRB-anchor VRF (host /32s ride RT-2)
+
+A Type-5 anchor VRF that pairs with an EVPN-ELAN MAC-VRF for
+L2 + L3 IRB services. No explicit `ip-prefix-routes` block —
+host /32s are advertised via the MAC-VRF's RT-2. Use this instead
+of `services/evpn-type5.conf` when you do not need the VRF to
+originate RT-5 prefix routes (only the IRB subnet matters and it
+is carried by RT-2).
+
+**minimum** (both halves of the service + per-VRF policy)
+- L2 / RT-2 half (one of):
+    - `evo/services/evpn-elan-mac-vrf-irb.conf` (EVO)
+    - `junos/services/evpn-elan-virtual-switch-irb.conf` (Junos MX)
+- `services/evpn-type5-anchor.conf` (the slim anchor VRF — Junos and EVO)
+- `policy/l3vpn-export-import.conf`
+- `policy/communities.conf` (only the per-VRF target community)
+- `interfaces/edge-vlan-normalization.conf`
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN Type-5 above
 
 ---
 

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md
@@ -5284,10 +5284,18 @@ If the user picks `minimum` and the AI cannot tell whether the overlay activatio
 
 ---
 
-## L3VPN-VRF
+## L3VPN (PE-CE eBGP or PE-CE OSPF)
+
+Two PE-CE protocol variants — pick the snip that matches what the
+user asked for (default to eBGP if unspecified):
+
+- **L3VPN with PE-CE eBGP** (`as-override`):
+  - `services/l3vpn-bgp.conf` (Junos and EVO)
+- **L3VPN with PE-CE OSPF** (area 0, `interface-type p2p`):
+  - `services/l3vpn-ospf.conf` (Junos and EVO)
 
 **minimum** (just the service + per-VRF policy)
-- `services/l3vpn-vrf.conf`
+- `services/l3vpn-bgp.conf` **or** `services/l3vpn-ospf.conf`
 - `policy/l3vpn-export-import.conf`
 - `policy/communities.conf` (only the per-VRF target community — NOT topology tags or BGP-CT colors)
 - `interfaces/edge-vlan-normalization.conf` (PE-CE AC unit)
@@ -5432,6 +5440,102 @@ Tiers (apply to whichever of the three the user asked for):
   LDP-VPLS does not need this — it relies on LDP targeted sessions)
 - **as-deployed** = + transport underlay + full apply-group baseline
   + CoS + OAM + BGP-CT
+
+---
+
+## EVPN-FXC (Flexible Cross-Connect)
+
+EVPN-FXC bundles multiple VLAN-tagged UNIs under a single
+`evpn-vpws` routing-instance via an FXC collector group. Use this
+when the customer hands off many service-delimited VLANs on the
+same port and you want one PW per VLAN without one routing-instance
+per VLAN.
+
+**minimum** (just the service)
+- `services/evpn-fxc.conf` (Junos and EVO — `instance-type evpn-vpws` with `flexible-cross-connect`)
+- `junos/interfaces/edge-vlan-normalization.conf` (the per-VLAN AC units that join the FXC group)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-VPWS above (transport + apply-groups + CoS + OAM + FAT-PW)
+
+---
+
+## EVPN E-Tree
+
+MEF E-Tree (root / leaf isolation) on a Junos `mac-vrf` with
+`etree-ac-role` on each UNI. Junos-only in this JVD.
+
+**minimum** (just the service)
+- `junos/services/evpn-etree.conf`
+- `junos/interfaces/ethernet-bridge.conf` (E-Tree leaf/root UNI)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN-ELAN above
+
+---
+
+## L2Circuit floating pseudowire
+
+Static-label L2Circuit pseudowire landing on a `ps<N>`
+pseudowire-subscriber anchor (decouples the PW from a physical AC).
+
+**minimum** (just the service)
+- `services/l2circuit-floating-pw.conf` (Junos and EVO)
+- `junos/interfaces/pseudowire-subscriber.conf` (the `ps<N>` anchor)
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (L2Circuit relies on targeted LDP, not BGP — overlay is informational)
+
+**as-deployed** (= with-overlay +)
+- same baseline as L2CIRCUIT above
+
+---
+
+## L2Circuit local-switching (cross-connect on one PE)
+
+Port-to-port hairpin on a single PE via `end-interface`. EVO-only
+in this JVD.
+
+**minimum** (just the service)
+- `evo/services/l2circuit-lsw.conf`
+- `interfaces/edge-vlan-normalization.conf` (both AC units that get cross-connected)
+
+**with-overlay** — not applicable (no MP signaling required)
+
+**as-deployed** (= minimum +)
+- transport underlay + edge apply-groups + CoS + OAM + firewall policers
+
+---
+
+## Slim L3VPN IRB-anchor VRF (host /32s ride RT-2)
+
+A Type-5 anchor VRF that pairs with an EVPN-ELAN MAC-VRF for
+L2 + L3 IRB services. No explicit `ip-prefix-routes` block —
+host /32s are advertised via the MAC-VRF's RT-2. Use this instead
+of `services/evpn-type5.conf` when you do not need the VRF to
+originate RT-5 prefix routes (only the IRB subnet matters and it
+is carried by RT-2).
+
+**minimum** (both halves of the service + per-VRF policy)
+- L2 / RT-2 half (one of):
+    - `evo/services/evpn-elan-mac-vrf-irb.conf` (EVO)
+    - `junos/services/evpn-elan-virtual-switch-irb.conf` (Junos MX)
+- `services/evpn-type5-anchor.conf` (the slim anchor VRF — Junos and EVO)
+- `policy/l3vpn-export-import.conf`
+- `policy/communities.conf` (only the per-VRF target community)
+- `interfaces/edge-vlan-normalization.conf`
+
+**with-overlay** (= minimum +)
+- `transport/bgp-overlay.conf` (verify `family evpn signaling`)
+
+**as-deployed** (= with-overlay +)
+- same baseline as EVPN Type-5 above
 
 ---
 


### PR DESCRIPTION
## What's New

Aligns the BYOAI assistant's service catalog (`TIERS.md`) with the
snip-library shapes PR #108 added. Without this, the assistant
sees `MENU.md` advertising services like EVPN-FXC and E-Tree but
falls back to "service not supported" when a user actually asks
for them, because TIERS.md (the per-service include list it
treats as the source-of-truth catalog) didn't list them.

- New `TIERS.md` sections: **EVPN-FXC**, **EVPN E-Tree**,
  **L2Circuit floating pseudowire**, **L2Circuit local-switching**,
  **Slim L3VPN IRB-anchor VRF**.
- Replaced the old generic **L3VPN-VRF** section with **L3VPN
  (PE-CE eBGP or PE-CE OSPF)** that points at the
  `l3vpn-bgp.conf` / `l3vpn-ospf.conf` split.
- Each new section ships the same three tiers (`minimum`,
  `with-overlay`, `as-deployed`) and lists exactly which AC /
  anchor interface snip to pair the service with.

## Why

Reported by a BYOAI user: asking "generate 2 evpn-fxc" returned
"I cannot generate this from the snip library because EVPN-FXC
is not represented in the current Metro EBS JVD snippet set" —
even though `MENU.md` advertises it and the `evpn-fxc.conf`
snips are in the bundle. Root cause: the assistant uses
`TIERS.md` as the catalog of generatable services and the FXC
shape was missing there.

## Details

**TIERS.md**
- Added five service sections matching the new snips
- Split L3VPN-VRF into L3VPN-bgp / L3VPN-ospf, removing the
  reference to the now-deleted `services/l3vpn-vrf.conf`

**Bundle + Portal regenerated**
- `byoai/jvd-mebs-snips.md`, `byoai/jvd-mebs-byoai-prompt.txt`
- `portal/src/data/snips.json` (445 snips, 8 JVDs, 0 warnings)
- `portal/public/byoai/metro_ethernet_business_services/` mirror

## Testing

```
node portal/scripts/generate-snips.mjs --check  # OK (445 snips, 8 JVDs)
```
