### PR TITLE
feat(ewan_finance): enrich snip headers + add Apache-2.0 LICENSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ Release notes for the Juniper Validated Design (JVD) configuration repository.
 
 ---
 
+## 2026-06-01
+
+Two Enterprise WAN snip libraries audited and enriched — EWAN Advanced
+Core & Edge and EWAN Finance — bringing cross-reference metadata,
+service-mapping headers, and topology-derived use-case context to both.
+The repository now also carries an explicit Apache-2.0 license.
+
+### New content
+
+- **EWAN Advanced Core & Edge snip library audit** — headers enriched
+  across all 48 snips in
+  [`enterprise_wan/ewan_adv_core_edge/configuration/snips/`](enterprise_wan/ewan_adv_core_edge/configuration/snips/).
+  Pair-with cross-references corrected, Seen-on device lists validated
+  against source configs (MX304, MX204, ACX7100-48L running Junos),
+  and service-mapping metadata injected for EVPN-VPWS, L3VPN, and
+  SR-MPLS transport services.
+
+- **EWAN Finance snip library audit** — headers enriched across all
+  38 snips in
+  [`enterprise_wan/ewan_finance/configuration/snips/`](enterprise_wan/ewan_finance/configuration/snips/).
+  Topology-derived use-case map added covering MPLS RSVP-TE transport,
+  multicast (P2MP LSPs), L3VPN, EVPN Virtual Switch, and Virtual
+  Router services across MX304 and ACX7100-48L devices running
+  Junos EVO.
+
+- **Apache-2.0 license** — the repository now includes an explicit
+  [`LICENSE`](LICENSE) file (Apache License, Version 2.0), clarifying
+  reuse terms for all configurations and snippets.
+
+- **Portal snip data** regenerated — the
+  [Snip Library browser](https://juniper.github.io/jvd/portal/#snips)
+  reflects updated header metadata for both EWAN libraries
+  (442 snips across 8 JVDs).
+
+### What this means for you
+
+- Pull the latest `main` to get corrected cross-references in both
+  EWAN snip libraries — `Pair with:` and `Seen on:` sections now
+  accurately reflect validated device pairings.
+- If you're building an MPLS/RSVP-TE or multicast design, start from
+  the EWAN Finance snips — they cover P2MP LSPs and MVPN patterns
+  not found in other JVDs.
+- Reuse of any content is now governed by the Apache-2.0 license at
+  the repo root.
+
+---
+
+### By the numbers
+
+<details>
+<summary>Per-JVD / per-area changes</summary>
+
+| JVD / Area | Added | Modified | Lines added | Lines removed |
+| --- | ---: | ---: | ---: | ---: |
+| `enterprise_wan/ewan_adv_core_edge` | 0 | 34 | 107 | 9 |
+| `enterprise_wan/ewan_finance` | 0 | 20 | 80 | 15 |
+| `portal/` | 0 | 2 | 790 | 195 |
+| `LICENSE` | 1 | 0 | 190 | 0 |
+| **TOTAL** | **1** | **56** | **1,167** | **219** |
+
+</details>
+
+<details>
+<summary>Net lines added/removed by area</summary>
+
+| Area | Lines added | Lines removed | Net |
+| --- | ---: | ---: | ---: |
+| Enterprise WAN | 187 | 24 | +163 |
+| Portal | 790 | 195 | +595 |
+| License | 190 | 0 | +190 |
+| **Total** | **1,167** | **219** | **+948** |
+
+</details>
+
+---
+
 ## 2026-05-30
 
 Quality sweep across three snip libraries — SRv6, Broadband Edge

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Juniper Networks, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/flexible-vlan-subinterface.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/flexible-vlan-subinterface.conf
@@ -14,6 +14,7 @@
  * Pair with:
  *  - evo/services/virtual-router-instance.conf  (VR instances bind these subinterfaces)
  *  - evo/oam/twamp-client.conf                  (TWAMP probes use these as source)
+ *  - evo/interfaces/vlan-bridge-domain.conf     (VLAN bridge-domains on same interface)
  *
  * Variables (example values from cr1_acx7100-48l):
  *   $INTERFACE_NAME   e.g. et-0/0/47

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/physical-p2p-mpls.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/physical-p2p-mpls.conf
@@ -10,6 +10,7 @@
  *  - /24 point-to-point addressing convention for inter-router links
  *
  * Pair with:
+ *  - evo/cos/exp-classifiers-schedulers.conf
  *  - evo/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)
  *  - evo/transport/mpls-interfaces.conf     (MPLS enabled on these interfaces)
  *  - evo/transport/rsvp-signaling.conf      (RSVP signaling on these interfaces)

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/vlan-bridge-domain.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/interfaces/vlan-bridge-domain.conf
@@ -12,7 +12,7 @@
  *
  * Pair with:
  *  - evo/interfaces/lag-lacp.conf                   (ae0 LAG carrying these VLANs)
- *  - evo/interfaces/flexible-vlan-bridge.conf       (interface vlan-bridge units)
+ *  - evo/interfaces/flexible-vlan-subinterface.conf  (interface vlan-bridge units)
  *
  * Variables (example values from l2-l3_edge_acx7100):
  *   $VLAN_NAME         e.g. vlan1

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/policy/protocol-redistribution.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/policy/protocol-redistribution.conf
@@ -11,6 +11,7 @@
  *  - Simple accept-all policies — no route-filtering or manipulation
  *
  * Pair with:
+ *  - evo/policy/route-filter-med.conf
  *  - evo/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)
  *
  * Variables (example values from p1_ptx10003-80c):

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/services/virtual-router-instance.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/services/virtual-router-instance.conf
@@ -17,19 +17,26 @@
  *  - evo/oam/twamp-client.conf                     (TWAMP probes originate per-VR)
  *  - evo/policy/route-filter-med.conf              (MED export policies referenced)
  *
+ * JVD service mapping:
+ *   13 instances total (high 10 / med 0 / low 3)
+ *   On devices: cr1_acx7100-48l (13), cr2_mx480 (13)
+ *   Example: VIRTUAL-ROUTER-V1 (RD —, RT —)
+ *     cr1_acx7100-48l  et-0/0/42.1
+ *     cr2_mx480  xe-3/0/6.1
+ *
  * Variables (example values from cr1_acx7100-48l):
  *   $VR_NAME             e.g. VIRTUAL-ROUTER-V1
  *   $AP_PEER_AS          e.g. 64512
  *   $AP_NEIGHBOR_1       e.g. 10.101.48.1
  *   $AP_NEIGHBOR_2       e.g. 10.101.78.1
  *   $EXPORT_POLICIES     e.g. [ med-10 med-30 ]
- *   $IXIA_PEER_AS        e.g. 64521
+ *   $IXIA_PEER_AS        e.g. 64520
  *   $IXIA_NEIGHBOR       e.g. 10.101.81.2
  *   $RP_ADDRESS          e.g. 10.10.47.101
  *   $MCAST_GROUP_RANGE   e.g. 225.0.0.0/22
- *   $IFACE_AP1           e.g. et-0/0/47.1
+ *   $IFACE_AP1           e.g. et-0/0/42.1
  *   $IFACE_AP2           e.g. et-0/0/48.1
- *   $IFACE_TG            e.g. et-0/0/46.1
+ *   $IFACE_TG            e.g. et-0/0/49.1
  */
 
 routing-instances {

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ibgp-core-mesh.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ibgp-core-mesh.conf
@@ -1,7 +1,7 @@
 /*
  * Topic:   iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   Junos: (none)
  *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
  *
  * Highlights:
@@ -13,6 +13,7 @@
  *  - All peers in a single iBGP group (full mesh, no route-reflectors)
  *
  * Pair with:
+ *  - evo/interfaces/loopback-multi-af.conf
  *  - evo/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)
  *  - evo/transport/mpls-interfaces.conf      (label transport for VPN families)
  *  - evo/policy/protocol-redistribution.conf (export policies referenced in group)

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/mpls-interfaces.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/mpls-interfaces.conf
@@ -1,7 +1,7 @@
 /*
  * Topic:   MPLS protocol enablement on core and loopback interfaces
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   Junos: (none)
  *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
  *
  * Highlights:
@@ -10,6 +10,8 @@
  *  - Combined with RSVP-TE for traffic-engineered label-switched paths
  *
  * Pair with:
+ *  - evo/cos/exp-classifiers-schedulers.conf
+ *  - evo/transport/ospf-te-protection.conf
  *  - evo/transport/rsvp-signaling.conf       (RSVP signals LSPs over these interfaces)
  *  - evo/transport/ibgp-core-mesh.conf       (BGP VPN families ride over MPLS)
  *  - evo/interfaces/physical-p2p-mpls.conf   (family mpls configured on interfaces)

--- a/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ospf-te-protection.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/evo/transport/ospf-te-protection.conf
@@ -1,7 +1,7 @@
 /*
  * Topic:   OSPF with traffic engineering, node-link-protection, and BFD
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   Junos: (none)
  *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
  *
  * Highlights:
@@ -12,6 +12,8 @@
  *  - All interfaces in area 0.0.0.0 (single-area backbone)
  *
  * Pair with:
+ *  - evo/interfaces/loopback-multi-af.conf
+ *  - evo/transport/ibgp-core-mesh.conf
  *  - evo/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)
  *  - evo/transport/mpls-interfaces.conf      (MPLS co-exists on same interfaces)
  *  - evo/interfaces/physical-p2p-mpls.conf   (the physical interfaces referenced)

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/cos/exp-classifiers-schedulers.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/cos/exp-classifiers-schedulers.conf
@@ -1,8 +1,8 @@
 /*
  * Topic:   MPLS EXP-based QoS — classifiers, forwarding classes, schedulers, and rewrite rules
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
- *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *   Junos: ap1_mx304 wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
  *
  * Highlights:
  *  - 4 forwarding classes: FC-LLQ (strict-high, queue 2) for low-latency finance traffic,
@@ -13,6 +13,7 @@
  *  - FC-LLQ uses strict-high priority for deterministic low-latency forwarding
  *
  * Pair with:
+ *  - junos/firewall/multicast-fwd-cache-filter.conf
  *  - junos/interfaces/physical-p2p-mpls.conf  (interfaces where CoS is applied)
  *  - junos/transport/mpls-lsp-p2mp.conf       (MPLS transport carrying marked traffic)
  *

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/firewall/multicast-fwd-cache-filter.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/firewall/multicast-fwd-cache-filter.conf
@@ -12,6 +12,9 @@
  *  - Ensures multicast stock-exchange data gets low-latency queue treatment end-to-end
  *
  * Pair with:
+ *  - junos/multicast/forwarding-multicast-tuning.conf
+ *  - junos/services/mvpn-instance.conf
+ *  - junos/services/vrf-l3vpn.conf
  *  - junos/interfaces/irb-l3-gateway.conf      (filter applied on IRB input)
  *  - junos/cos/exp-classifiers-schedulers.conf  (forwarding classes referenced here)
  *

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/irb-l3-gateway.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/irb-l3-gateway.conf
@@ -11,6 +11,8 @@
  *  - One IRB unit per MVPN instance / EVPN bridge-domain
  *
  * Pair with:
+ *  - junos/interfaces/lag-esi-lacp.conf
+ *  - junos/services/vrf-l3vpn.conf
  *  - junos/services/evpn-virtual-switch-esi.conf  (bridge-domain routing-interface irb.N)
  *  - junos/services/mvpn-instance.conf            (MVPN instance binds interface irb.N)
  *  - junos/firewall/multicast-fwd-cache-filter.conf (mfc-filter applied here)

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/physical-p2p-mpls.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/interfaces/physical-p2p-mpls.conf
@@ -10,6 +10,7 @@
  *  - /24 point-to-point addressing convention for inter-router links
  *
  * Pair with:
+ *  - junos/cos/exp-classifiers-schedulers.conf
  *  - junos/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)
  *  - junos/transport/mpls-lsp-p2mp.conf       (MPLS LSPs traverse these interfaces)
  *  - junos/transport/rsvp-signaling.conf      (RSVP signaling on these interfaces)

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/policy/protocol-redistribution.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/policy/protocol-redistribution.conf
@@ -11,6 +11,7 @@
  *  - Simple accept-all policies — no route-filtering or manipulation
  *
  * Pair with:
+ *  - junos/policy/route-filter-med.conf
  *  - junos/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)
  *
  * Variables (example values from wanedge1_mx304):

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/evpn-virtual-switch-esi.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/evpn-virtual-switch-esi.conf
@@ -17,6 +17,13 @@
  *  - junos/interfaces/irb-l3-gateway.conf   (IRB routing-interface for L3 gateway)
  *  - junos/services/mvpn-instance.conf      (MVPN uses same IRB for multicast ingress)
  *
+ * JVD service mapping:
+ *   13 instances total (high 13 / med 0 / low 0)
+ *   On devices: wanedge1_mx304 (13), wanedge2_mx10004 (13)
+ *   Example: EVPN_ESI_LAG1 (RD 10.200.50.12:1, RT target:61535:1)
+ *     wanedge1_mx304  ae0.1 00:11:11:11:11:11:12:12:12:12 S-A
+ *     wanedge2_mx10004  ae0.1 00:11:11:11:11:11:12:12:12:12 S-A
+ *
  * Variables (example values from wanedge1_mx304):
  *   $INSTANCE_NAME         e.g. EVPN_ESI_LAG1
  *   $BD_NAME               e.g. BD_EVPN_GROUP1

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/mvpn-instance.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/mvpn-instance.conf
@@ -1,7 +1,7 @@
 /*
  * Topic:   NG-MVPN VRF instance with PIM, OSPF, BGP, and RSVP-TE provider-tunnel
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   Junos: wanedge1_mx304 wanedge2_mx10004
  *   EVO:   (none)
  *
  * Highlights:
@@ -15,10 +15,22 @@
  *  - Per-VRF OSPF for CE route distribution + BGP eBGP for traffic-generator peering
  *
  * Pair with:
+ *  - junos/bootstrap/chassis-config.conf
+ *  - junos/oam/twamp-server.conf
+ *  - junos/services/evpn-virtual-switch-esi.conf
  *  - junos/transport/mpls-lsp-p2mp.conf               (P2MP template referenced)
  *  - junos/interfaces/irb-l3-gateway.conf             (IRB interface bound to this VRF)
  *  - junos/multicast/forwarding-multicast-tuning.conf (multicast PFE rate-limiting)
  *  - junos/firewall/multicast-fwd-cache-filter.conf   (CoS marking on multicast ingress)
+ *
+ * JVD service mapping:
+ *   10 instances total (high 10 / med 0 / low 0)
+ *   On devices: ap1_mx304 (10), ap2_mx10004 (10), wanedge1_mx304 (10), wanedge2_mx10004 (10)
+ *   Example: MVPN_INSTANCE1 (RD 10.200.50.14:61, RT target:64512:11)
+ *     ap1_mx304  et-0/0/6.1
+ *     ap2_mx10004  et-0/0/2.1
+ *     wanedge1_mx304
+ *     wanedge2_mx10004
  *
  * Variables (example values from wanedge1_mx304):
  *   $INSTANCE_NAME       e.g. MVPN_INSTANCE1

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/virtual-router-instance.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/virtual-router-instance.conf
@@ -17,6 +17,13 @@
  *  - junos/oam/twamp-client.conf                     (TWAMP probes originate per-VR)
  *  - junos/policy/route-filter-med.conf              (MED export policies referenced)
  *
+ * JVD service mapping:
+ *   13 instances total (high 10 / med 0 / low 3)
+ *   On devices: cr1_acx7100-48l (13), cr2_mx480 (13)
+ *   Example: VIRTUAL-ROUTER-V1 (RD —, RT —)
+ *     cr1_acx7100-48l  et-0/0/42.1
+ *     cr2_mx480  xe-3/0/6.1
+ *
  * Variables (example values from cr2_mx480):
  *   $VR_NAME             e.g. VIRTUAL-ROUTER-V1
  *   $AP_PEER_AS          e.g. 64512

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/services/vrf-l3vpn.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/services/vrf-l3vpn.conf
@@ -17,6 +17,15 @@
  *  - junos/firewall/multicast-fwd-cache-filter.conf   (filter on IRB for these VRFs)
  *  - junos/transport/ibgp-core-mesh.conf              (inet-vpn family carries VRF routes)
  *
+ * JVD service mapping:
+ *   13 instances total (high 13 / med 0 / low 0)
+ *   On devices: ap1_mx304 (13), ap2_mx10004 (13), wanedge1_mx304 (13), wanedge2_mx10004 (13)
+ *   Example: MVPN_INSTANCE1 (RD 10.200.50.14:61, RT target:64512:11)
+ *     ap1_mx304  et-0/0/6.1
+ *     ap2_mx10004  et-0/0/2.1
+ *     wanedge1_mx304
+ *     wanedge2_mx10004
+ *
  * Variables (example values from wanedge1_mx304):
  *   $VRF_NAME             e.g. VRF21
  *   $LOCAL_ADDRESS        e.g. 172.16.21.1

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ibgp-core-mesh.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ibgp-core-mesh.conf
@@ -1,8 +1,8 @@
 /*
  * Topic:   iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
- *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *   Junos: ap1_mx304 ap2_mx10004 wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
  *
  * Highlights:
  *  - family inet-vpn unicast + any for L3VPN route exchange
@@ -13,6 +13,8 @@
  *  - All peers in a single iBGP group (full mesh, no route-reflectors)
  *
  * Pair with:
+ *  - junos/interfaces/loopback-multi-af.conf
+ *  - junos/services/vrf-l3vpn.conf
  *  - junos/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)
  *  - junos/transport/mpls-lsp-p2mp.conf        (label transport for VPN families)
  *  - junos/policy/protocol-redistribution.conf (export policies referenced in group)

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/mpls-lsp-p2mp.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/mpls-lsp-p2mp.conf
@@ -1,7 +1,7 @@
 /*
  * Topic:   MPLS LSPs with P2MP template and named point-to-point paths
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
+ *   Junos: ap1_mx304 ap2_mx10004 wanedge1_mx304 wanedge2_mx10004
  *   EVO:   (none)
  *
  * Highlights:
@@ -12,6 +12,9 @@
  *  - retry-timer 5 for fast LSP re-establishment after failure
  *
  * Pair with:
+ *  - junos/cos/exp-classifiers-schedulers.conf
+ *  - junos/interfaces/physical-p2p-mpls.conf
+ *  - junos/transport/ibgp-core-mesh.conf
  *  - junos/transport/rsvp-signaling.conf     (RSVP signals these LSPs)
  *  - junos/transport/ospf-te-protection.conf (CSPF uses OSPF-TE TED)
  *  - junos/services/mvpn-instance.conf       (MVPN uses P2MP provider-tunnel)

--- a/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ospf-te-protection.conf
+++ b/enterprise_wan/ewan_finance/configuration/snips/junos/transport/ospf-te-protection.conf
@@ -1,8 +1,8 @@
 /*
  * Topic:   OSPF with traffic engineering, node-link-protection, and BFD
  * Seen on:
- *   Junos: wanedge1_mx304 wanedge2_mx10004 ap1_mx304 ap2_mx10004
- *   EVO:   p1_ptx10003-80c p2_ptx10001-36mr
+ *   Junos: ap1_mx304 ap2_mx10004 wanedge1_mx304 wanedge2_mx10004
+ *   EVO:   (none)
  *
  * Highlights:
  *  - traffic-engineering enables OSPF-TE extensions (RFC 3630) for RSVP-TE CSPF
@@ -12,6 +12,8 @@
  *  - All interfaces in area 0.0.0.0 (single-area backbone)
  *
  * Pair with:
+ *  - junos/interfaces/loopback-multi-af.conf
+ *  - junos/transport/ibgp-core-mesh.conf
  *  - junos/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)
  *  - junos/transport/mpls-lsp-p2mp.conf        (MPLS LSPs use CSPF paths)
  *  - junos/interfaces/physical-p2p-mpls.conf   (the physical interfaces referenced)

--- a/portal/scripts/jvd-usecase-map.json
+++ b/portal/scripts/jvd-usecase-map.json
@@ -5,5 +5,6 @@
   "metro_as_a_service": ["Service Provider", "Metro", "Business Services", "MEF"],
   "metro_ethernet_business_services": ["Service Provider", "Metro", "Business Services", "MEF"],
   "srv6_core_edge": ["Service Provider", "SRv6", "Core/Edge"],
-  "ewan_adv_core_edge": ["Enterprise WAN", "EVPN-VPWS", "EVPN-ELAN", "MPLS"]
+  "ewan_adv_core_edge": ["Enterprise WAN", "EVPN-VPWS", "EVPN-ELAN", "MPLS"],
+  "ewan_finance": ["Enterprise WAN", "L3VPN", "Multicast", "MPLS"]
 }

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T18:41:02.338Z",
+  "generatedAt": "2026-06-01T19:26:34.548Z",
   "counts": {
     "total": 442,
     "junos": 216,
@@ -41,9 +41,11 @@
     "EVPN-ELAN",
     "EVPN-VPWS",
     "Enterprise WAN",
+    "L3VPN",
     "MEF",
     "MPLS",
     "Metro",
+    "Multicast",
     "SRv6",
     "Service Provider",
     "Subscriber Mgmt"
@@ -8983,7 +8985,10 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9055,7 +9060,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9095,6 +9103,11 @@
           "raw": "evo/oam/twamp-client.conf                  (TWAMP probes use these as source)",
           "id": "ewan_finance/evo/oam/twamp-client",
           "note": "TWAMP probes use these as source"
+        },
+        {
+          "raw": "evo/interfaces/vlan-bridge-domain.conf     (VLAN bridge-domains on same interface)",
+          "id": "ewan_finance/evo/interfaces/vlan-bridge-domain",
+          "note": "VLAN bridge-domains on same interface"
         }
       ],
       "variables": [
@@ -9127,7 +9140,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9192,7 +9208,10 @@
       "techFamily": "Interfaces",
       "subfamily": "LAG / LACP",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9266,7 +9285,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9299,6 +9321,11 @@
         "/24 point-to-point addressing convention for inter-router links"
       ],
       "pairWith": [
+        {
+          "raw": "evo/cos/exp-classifiers-schedulers.conf",
+          "id": "ewan_finance/evo/cos/exp-classifiers-schedulers",
+          "note": null
+        },
         {
           "raw": "evo/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)",
           "id": "ewan_finance/evo/transport/ospf-te-protection",
@@ -9342,7 +9369,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9376,8 +9406,8 @@
           "note": "ae0 LAG carrying these VLANs"
         },
         {
-          "raw": "evo/interfaces/flexible-vlan-bridge.conf       (interface vlan-bridge units)",
-          "id": null,
+          "raw": "evo/interfaces/flexible-vlan-subinterface.conf  (interface vlan-bridge units)",
+          "id": "ewan_finance/evo/interfaces/flexible-vlan-subinterface",
           "note": "interface vlan-bridge units"
         }
       ],
@@ -9407,7 +9437,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9452,7 +9485,10 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9533,7 +9569,10 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9568,6 +9607,11 @@
       ],
       "pairWith": [
         {
+          "raw": "evo/policy/route-filter-med.conf",
+          "id": "ewan_finance/evo/policy/route-filter-med",
+          "note": null
+        },
+        {
           "raw": "evo/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)",
           "id": "ewan_finance/evo/transport/ibgp-core-mesh",
           "note": "export policies referenced in BGP group"
@@ -9595,7 +9639,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9666,7 +9713,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9737,7 +9787,7 @@
         },
         {
           "name": "$IXIA_PEER_AS",
-          "example": "64521"
+          "example": "64520"
         },
         {
           "name": "$IXIA_NEIGHBOR",
@@ -9753,7 +9803,7 @@
         },
         {
           "name": "$IFACE_AP1",
-          "example": "et-0/0/47.1"
+          "example": "et-0/0/42.1"
         },
         {
           "name": "$IFACE_AP2",
@@ -9761,10 +9811,16 @@
         },
         {
           "name": "$IFACE_TG",
-          "example": "et-0/0/46.1"
+          "example": "et-0/0/49.1"
         }
       ],
-      "jvdServiceMapping": [],
+      "jvdServiceMapping": [
+        "  13 instances total (high 10 / med 0 / low 3)",
+        "  On devices: cr1_acx7100-48l (13), cr2_mx480 (13)",
+        "  Example: VIRTUAL-ROUTER-V1 (RD —, RT —)",
+        "    cr1_acx7100-48l  et-0/0/42.1",
+        "    cr2_mx480  xe-3/0/6.1"
+      ],
       "body": "routing-instances {\n    $VR_NAME {\n        instance-type virtual-router;\n        protocols {\n            bgp {\n                group AP {\n                    type external;\n                    export $EXPORT_POLICIES;\n                    peer-as $AP_PEER_AS;\n                    neighbor $AP_NEIGHBOR_1;\n                    neighbor $AP_NEIGHBOR_2;\n                }\n                group IXIA {\n                    type internal;\n                    peer-as $IXIA_PEER_AS;\n                    neighbor $IXIA_NEIGHBOR;\n                }\n            }\n            pim {\n                rp {\n                    static {\n                        address $RP_ADDRESS {\n                            group-ranges {\n                                $MCAST_GROUP_RANGE;\n                            }\n                        }\n                    }\n                }\n                interface $IFACE_AP1 {\n                    mode sparse;\n                }\n                interface $IFACE_AP2 {\n                    mode sparse;\n                }\n                interface $IFACE_TG {\n                    mode sparse;\n                }\n            }\n        }\n        interface $IFACE_TG;\n        interface $IFACE_AP1;\n        interface $IFACE_AP2;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VR_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-router;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group AP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICIES;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $AP_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group IXIA {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $IXIA_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $IXIA_NEIGHBOR;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            pim {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        address $RP_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            group-ranges {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                                $MCAST_GROUP_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_TG {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_TG;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
       "bytes": 1245,
@@ -9772,7 +9828,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9788,12 +9847,7 @@
       "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/ibgp-core-mesh.conf",
       "topic": "iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families",
       "seenOn": {
-        "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
-          "ap1_mx304",
-          "ap2_mx10004"
-        ],
+        "junos": [],
         "evo": [
           "p1_ptx10003-80c",
           "p2_ptx10001-36mr"
@@ -9808,6 +9862,11 @@
         "All peers in a single iBGP group (full mesh, no route-reflectors)"
       ],
       "pairWith": [
+        {
+          "raw": "evo/interfaces/loopback-multi-af.conf",
+          "id": "ewan_finance/evo/interfaces/loopback-multi-af",
+          "note": null
+        },
         {
           "raw": "evo/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)",
           "id": "ewan_finance/evo/transport/ospf-te-protection",
@@ -9866,7 +9925,10 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9882,12 +9944,7 @@
       "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/mpls-interfaces.conf",
       "topic": "MPLS protocol enablement on core and loopback interfaces",
       "seenOn": {
-        "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
-          "ap1_mx304",
-          "ap2_mx10004"
-        ],
+        "junos": [],
         "evo": [
           "p1_ptx10003-80c",
           "p2_ptx10001-36mr"
@@ -9899,6 +9956,16 @@
         "Combined with RSVP-TE for traffic-engineered label-switched paths"
       ],
       "pairWith": [
+        {
+          "raw": "evo/cos/exp-classifiers-schedulers.conf",
+          "id": "ewan_finance/evo/cos/exp-classifiers-schedulers",
+          "note": null
+        },
+        {
+          "raw": "evo/transport/ospf-te-protection.conf",
+          "id": "ewan_finance/evo/transport/ospf-te-protection",
+          "note": null
+        },
         {
           "raw": "evo/transport/rsvp-signaling.conf       (RSVP signals LSPs over these interfaces)",
           "id": "ewan_finance/evo/transport/rsvp-signaling",
@@ -9941,7 +10008,10 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -9957,12 +10027,7 @@
       "path": "enterprise_wan/ewan_finance/configuration/snips/evo/transport/ospf-te-protection.conf",
       "topic": "OSPF with traffic engineering, node-link-protection, and BFD",
       "seenOn": {
-        "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
-          "ap1_mx304",
-          "ap2_mx10004"
-        ],
+        "junos": [],
         "evo": [
           "p1_ptx10003-80c",
           "p2_ptx10001-36mr"
@@ -9976,6 +10041,16 @@
         "All interfaces in area 0.0.0.0 (single-area backbone)"
       ],
       "pairWith": [
+        {
+          "raw": "evo/interfaces/loopback-multi-af.conf",
+          "id": "ewan_finance/evo/interfaces/loopback-multi-af",
+          "note": null
+        },
+        {
+          "raw": "evo/transport/ibgp-core-mesh.conf",
+          "id": "ewan_finance/evo/transport/ibgp-core-mesh",
+          "note": null
+        },
         {
           "raw": "evo/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)",
           "id": "ewan_finance/evo/transport/rsvp-signaling",
@@ -10026,7 +10101,10 @@
       "techFamily": "Transport",
       "subfamily": "OSPF",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10102,7 +10180,10 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10199,7 +10280,10 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10216,15 +10300,11 @@
       "topic": "MPLS EXP-based QoS — classifiers, forwarding classes, schedulers, and rewrite rules",
       "seenOn": {
         "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
           "ap1_mx304",
-          "ap2_mx10004"
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
         ],
-        "evo": [
-          "p1_ptx10003-80c",
-          "p2_ptx10001-36mr"
-        ]
+        "evo": []
       },
       "highlights": [
         "4 forwarding classes: FC-LLQ (strict-high, queue 2) for low-latency finance traffic, FC-HIGH (queue 1), CONTROL (queue 3), BEST-EFFORT (queue 0)",
@@ -10234,6 +10314,11 @@
         "FC-LLQ uses strict-high priority for deterministic low-latency forwarding"
       ],
       "pairWith": [
+        {
+          "raw": "junos/firewall/multicast-fwd-cache-filter.conf",
+          "id": "ewan_finance/junos/firewall/multicast-fwd-cache-filter",
+          "note": null
+        },
         {
           "raw": "junos/interfaces/physical-p2p-mpls.conf  (interfaces where CoS is applied)",
           "id": "ewan_finance/junos/interfaces/physical-p2p-mpls",
@@ -10263,7 +10348,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10293,6 +10381,21 @@
         "Ensures multicast stock-exchange data gets low-latency queue treatment end-to-end"
       ],
       "pairWith": [
+        {
+          "raw": "junos/multicast/forwarding-multicast-tuning.conf",
+          "id": "ewan_finance/junos/multicast/forwarding-multicast-tuning",
+          "note": null
+        },
+        {
+          "raw": "junos/services/mvpn-instance.conf",
+          "id": "ewan_finance/junos/services/mvpn-instance",
+          "note": null
+        },
+        {
+          "raw": "junos/services/vrf-l3vpn.conf",
+          "id": "ewan_finance/junos/services/vrf-l3vpn",
+          "note": null
+        },
         {
           "raw": "junos/interfaces/irb-l3-gateway.conf      (filter applied on IRB input)",
           "id": "ewan_finance/junos/interfaces/irb-l3-gateway",
@@ -10338,7 +10441,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10409,7 +10515,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10438,6 +10547,16 @@
         "One IRB unit per MVPN instance / EVPN bridge-domain"
       ],
       "pairWith": [
+        {
+          "raw": "junos/interfaces/lag-esi-lacp.conf",
+          "id": "ewan_finance/junos/interfaces/lag-esi-lacp",
+          "note": null
+        },
+        {
+          "raw": "junos/services/vrf-l3vpn.conf",
+          "id": "ewan_finance/junos/services/vrf-l3vpn",
+          "note": null
+        },
         {
           "raw": "junos/services/evpn-virtual-switch-esi.conf  (bridge-domain routing-interface irb.N)",
           "id": "ewan_finance/junos/services/evpn-virtual-switch-esi",
@@ -10480,7 +10599,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10576,7 +10698,10 @@
       "techFamily": "Interfaces",
       "subfamily": "LAG / LACP",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10650,7 +10775,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10683,6 +10811,11 @@
         "/24 point-to-point addressing convention for inter-router links"
       ],
       "pairWith": [
+        {
+          "raw": "junos/cos/exp-classifiers-schedulers.conf",
+          "id": "ewan_finance/junos/cos/exp-classifiers-schedulers",
+          "note": null
+        },
         {
           "raw": "junos/transport/ospf-te-protection.conf  (OSPF runs over these interfaces)",
           "id": "ewan_finance/junos/transport/ospf-te-protection",
@@ -10726,7 +10859,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10786,7 +10922,10 @@
       "techFamily": "Other",
       "subfamily": "Multicast",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10831,7 +10970,10 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10917,7 +11059,10 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -10997,7 +11142,10 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11032,6 +11180,11 @@
       ],
       "pairWith": [
         {
+          "raw": "junos/policy/route-filter-med.conf",
+          "id": "ewan_finance/junos/policy/route-filter-med",
+          "note": null
+        },
+        {
           "raw": "junos/transport/ibgp-core-mesh.conf  (export policies referenced in BGP group)",
           "id": "ewan_finance/junos/transport/ibgp-core-mesh",
           "note": "export policies referenced in BGP group"
@@ -11059,7 +11212,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11130,7 +11286,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11207,7 +11366,13 @@
           "example": "target:61535:1"
         }
       ],
-      "jvdServiceMapping": [],
+      "jvdServiceMapping": [
+        "  13 instances total (high 13 / med 0 / low 0)",
+        "  On devices: wanedge1_mx304 (13), wanedge2_mx10004 (13)",
+        "  Example: EVPN_ESI_LAG1 (RD 10.200.50.12:1, RT target:61535:1)",
+        "    wanedge1_mx304  ae0.1 00:11:11:11:11:11:12:12:12:12 S-A",
+        "    wanedge2_mx10004  ae0.1 00:11:11:11:11:11:12:12:12:12 S-A"
+      ],
       "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type virtual-switch;\n        protocols {\n            evpn {\n                encapsulation mpls;\n                default-gateway do-not-advertise;\n                no-control-word;\n            }\n        }\n        bridge-domains {\n            $BD_NAME {\n                vlan-id $VLAN_ID;\n                interface $AE_UNIT;\n                routing-interface $IRB_UNIT;\n            }\n        }\n        route-distinguisher $ROUTE_DISTINGUISHER;\n        vrf-target $VRF_TARGET;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-switch;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation mpls;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                default-gateway do-not-advertise;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                no-control-word;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        bridge-domains {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $BD_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                vlan-id $VLAN_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $AE_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                routing-interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $ROUTE_DISTINGUISHER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
       "bytes": 537,
@@ -11215,7 +11380,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11233,9 +11401,7 @@
       "seenOn": {
         "junos": [
           "wanedge1_mx304",
-          "wanedge2_mx10004",
-          "ap1_mx304",
-          "ap2_mx10004"
+          "wanedge2_mx10004"
         ],
         "evo": []
       },
@@ -11250,6 +11416,21 @@
         "Per-VRF OSPF for CE route distribution + BGP eBGP for traffic-generator peering"
       ],
       "pairWith": [
+        {
+          "raw": "junos/bootstrap/chassis-config.conf",
+          "id": "ewan_finance/junos/bootstrap/chassis-config",
+          "note": null
+        },
+        {
+          "raw": "junos/oam/twamp-server.conf",
+          "id": "ewan_finance/junos/oam/twamp-server",
+          "note": null
+        },
+        {
+          "raw": "junos/services/evpn-virtual-switch-esi.conf",
+          "id": "ewan_finance/junos/services/evpn-virtual-switch-esi",
+          "note": null
+        },
         {
           "raw": "junos/transport/mpls-lsp-p2mp.conf               (P2MP template referenced)",
           "id": "ewan_finance/junos/transport/mpls-lsp-p2mp",
@@ -11321,7 +11502,15 @@
           "example": "target:64512:11"
         }
       ],
-      "jvdServiceMapping": [],
+      "jvdServiceMapping": [
+        "  10 instances total (high 10 / med 0 / low 0)",
+        "  On devices: ap1_mx304 (10), ap2_mx10004 (10), wanedge1_mx304 (10), wanedge2_mx10004 (10)",
+        "  Example: MVPN_INSTANCE1 (RD 10.200.50.14:61, RT target:64512:11)",
+        "    ap1_mx304  et-0/0/6.1",
+        "    ap2_mx10004  et-0/0/2.1",
+        "    wanedge1_mx304",
+        "    wanedge2_mx10004"
+      ],
       "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type vrf;\n        protocols {\n            bgp {\n                group custA_TGN {\n                    type external;\n                    local-address $CE_LOCAL_ADDRESS;\n                    export PS-ADV_DIRECT;\n                    neighbor $CE_NEIGHBOR {\n                        peer-as $CE_PEER_AS;\n                    }\n                }\n            }\n            mvpn {\n                sender-site;\n                mvpn-mode {\n                    spt-only;\n                }\n                route-target {\n                    import-target {\n                        target $MVPN_RT_IMPORT;\n                    }\n                    export-target {\n                        target $MVPN_RT_EXPORT;\n                    }\n                }\n                sender-based-rpf;\n                hot-root-standby {\n                    source-tree;\n                    min-rate {\n                        rate 3m;\n                        revert-delay 5;\n                    }\n                }\n            }\n            ospf {\n                area 0.0.0.0 {\n                    interface $LO_UNIT;\n                }\n                export PS-send-ospf;\n            }\n            pim {\n                join-prune-timeout 420;\n                rp {\n                    local {\n                        address $RP_ADDRESS;\n                        group-ranges {\n                            $MCAST_GROUP_RANGE;\n                        }\n                    }\n                }\n                interface $IRB_UNIT;\n                interface $LO_UNIT;\n            }\n        }\n        interface $IRB_UNIT;\n        interface $LO_UNIT;\n        route-distinguisher $ROUTE_DISTINGUISHER;\n        vrf-target $VRF_TARGET;\n        vrf-table-label;\n        provider-tunnel {\n            rsvp-te {\n                label-switched-path-template {\n                    default-template;\n                }\n            }\n        }\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group custA_TGN {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    local-address $CE_LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> PS-ADV_DIRECT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $CE_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        peer-as $CE_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            mvpn {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                sender-site;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                mvpn-mode {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    spt-only;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                route-target {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    import-target {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        target $MVPN_RT_IMPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\">-target {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        target $MVPN_RT_EXPORT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                sender-based-rpf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                hot-root-standby {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    source-tree;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    min-rate {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        rate 3m;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        revert-delay </span><span style=\"color:#79C0FF\">5</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            ospf {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                area </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    interface $LO_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                export</span><span style=\"color:#E6EDF3\"> PS-send-ospf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            pim {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                join-prune-timeout </span><span style=\"color:#79C0FF\">420</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    local {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        address $RP_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        group-ranges {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            $MCAST_GROUP_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $LO_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $LO_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $ROUTE_DISTINGUISHER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        provider-tunnel {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            rsvp-te {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                label-switched-path-template {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    default-template;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
       "bytes": 1965,
@@ -11329,7 +11518,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11427,7 +11619,13 @@
           "example": "xe-3/0/6.1"
         }
       ],
-      "jvdServiceMapping": [],
+      "jvdServiceMapping": [
+        "  13 instances total (high 10 / med 0 / low 3)",
+        "  On devices: cr1_acx7100-48l (13), cr2_mx480 (13)",
+        "  Example: VIRTUAL-ROUTER-V1 (RD —, RT —)",
+        "    cr1_acx7100-48l  et-0/0/42.1",
+        "    cr2_mx480  xe-3/0/6.1"
+      ],
       "body": "routing-instances {\n    $VR_NAME {\n        instance-type virtual-router;\n        protocols {\n            bgp {\n                group AP {\n                    type external;\n                    export $EXPORT_POLICIES;\n                    peer-as $AP_PEER_AS;\n                    neighbor $AP_NEIGHBOR_1;\n                    neighbor $AP_NEIGHBOR_2;\n                }\n                group IXIA {\n                    type internal;\n                    peer-as $IXIA_PEER_AS;\n                    neighbor $IXIA_NEIGHBOR;\n                }\n            }\n            pim {\n                rp {\n                    static {\n                        address $RP_ADDRESS {\n                            group-ranges {\n                                $MCAST_GROUP_RANGE;\n                            }\n                        }\n                    }\n                }\n                interface $IFACE_AP1 {\n                    mode sparse;\n                }\n                interface $IFACE_AP2 {\n                    mode sparse;\n                }\n                interface $IFACE_TG {\n                    mode sparse;\n                }\n            }\n        }\n        interface $IFACE_TG;\n        interface $IFACE_AP1;\n        interface $IFACE_AP2;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VR_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type virtual-router;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group AP {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICIES;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $AP_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $AP_NEIGHBOR_2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group IXIA {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type internal;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    peer-as $IXIA_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $IXIA_NEIGHBOR;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            pim {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                rp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        address $RP_ADDRESS {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            group-ranges {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                                $MCAST_GROUP_RANGE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_AP2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                interface $IFACE_TG {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    mode sparse;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_TG;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP1;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IFACE_AP2;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
       "bytes": 1245,
@@ -11435,7 +11633,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11516,7 +11717,15 @@
           "example": "target:64512:21"
         }
       ],
-      "jvdServiceMapping": [],
+      "jvdServiceMapping": [
+        "  13 instances total (high 13 / med 0 / low 0)",
+        "  On devices: ap1_mx304 (13), ap2_mx10004 (13), wanedge1_mx304 (13), wanedge2_mx10004 (13)",
+        "  Example: MVPN_INSTANCE1 (RD 10.200.50.14:61, RT target:64512:11)",
+        "    ap1_mx304  et-0/0/6.1",
+        "    ap2_mx10004  et-0/0/2.1",
+        "    wanedge1_mx304",
+        "    wanedge2_mx10004"
+      ],
       "body": "routing-instances {\n    $VRF_NAME {\n        instance-type vrf;\n        protocols {\n            bgp {\n                group TGN_AF {\n                    type external;\n                    local-address $LOCAL_ADDRESS;\n                    export $EXPORT_POLICY;\n                    neighbor $CE_NEIGHBOR {\n                        peer-as $CE_PEER_AS;\n                    }\n                }\n            }\n        }\n        interface $IRB_UNIT;\n        route-distinguisher $ROUTE_DISTINGUISHER;\n        vrf-target $VRF_TARGET;\n        vrf-table-label;\n    }\n}",
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VRF_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type vrf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            bgp {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                group TGN_AF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    type external;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    local-address $LOCAL_ADDRESS;</span></span>\n<span class=\"line\"><span style=\"color:#79C0FF\">                    export</span><span style=\"color:#E6EDF3\"> $EXPORT_POLICY;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    neighbor $CE_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                        peer-as $CE_PEER_AS;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $IRB_UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $ROUTE_DISTINGUISHER;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target $VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-table-label;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
       "bytes": 556,
@@ -11524,7 +11733,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11541,15 +11753,12 @@
       "topic": "iBGP full-mesh with inet-vpn, EVPN, and inet-mvpn address families",
       "seenOn": {
         "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
           "ap1_mx304",
-          "ap2_mx10004"
+          "ap2_mx10004",
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
         ],
-        "evo": [
-          "p1_ptx10003-80c",
-          "p2_ptx10001-36mr"
-        ]
+        "evo": []
       },
       "highlights": [
         "family inet-vpn unicast + any for L3VPN route exchange",
@@ -11560,6 +11769,16 @@
         "All peers in a single iBGP group (full mesh, no route-reflectors)"
       ],
       "pairWith": [
+        {
+          "raw": "junos/interfaces/loopback-multi-af.conf",
+          "id": "ewan_finance/junos/interfaces/loopback-multi-af",
+          "note": null
+        },
+        {
+          "raw": "junos/services/vrf-l3vpn.conf",
+          "id": "ewan_finance/junos/services/vrf-l3vpn",
+          "note": null
+        },
         {
           "raw": "junos/transport/ospf-te-protection.conf   (IGP underlay for iBGP next-hops)",
           "id": "ewan_finance/junos/transport/ospf-te-protection",
@@ -11618,7 +11837,10 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11635,10 +11857,10 @@
       "topic": "MPLS LSPs with P2MP template and named point-to-point paths",
       "seenOn": {
         "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
           "ap1_mx304",
-          "ap2_mx10004"
+          "ap2_mx10004",
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
         ],
         "evo": []
       },
@@ -11650,6 +11872,21 @@
         "retry-timer 5 for fast LSP re-establishment after failure"
       ],
       "pairWith": [
+        {
+          "raw": "junos/cos/exp-classifiers-schedulers.conf",
+          "id": "ewan_finance/junos/cos/exp-classifiers-schedulers",
+          "note": null
+        },
+        {
+          "raw": "junos/interfaces/physical-p2p-mpls.conf",
+          "id": "ewan_finance/junos/interfaces/physical-p2p-mpls",
+          "note": null
+        },
+        {
+          "raw": "junos/transport/ibgp-core-mesh.conf",
+          "id": "ewan_finance/junos/transport/ibgp-core-mesh",
+          "note": null
+        },
         {
           "raw": "junos/transport/rsvp-signaling.conf     (RSVP signals these LSPs)",
           "id": "ewan_finance/junos/transport/rsvp-signaling",
@@ -11712,7 +11949,10 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11729,15 +11969,12 @@
       "topic": "OSPF with traffic engineering, node-link-protection, and BFD",
       "seenOn": {
         "junos": [
-          "wanedge1_mx304",
-          "wanedge2_mx10004",
           "ap1_mx304",
-          "ap2_mx10004"
+          "ap2_mx10004",
+          "wanedge1_mx304",
+          "wanedge2_mx10004"
         ],
-        "evo": [
-          "p1_ptx10003-80c",
-          "p2_ptx10001-36mr"
-        ]
+        "evo": []
       },
       "highlights": [
         "traffic-engineering enables OSPF-TE extensions (RFC 3630) for RSVP-TE CSPF",
@@ -11747,6 +11984,16 @@
         "All interfaces in area 0.0.0.0 (single-area backbone)"
       ],
       "pairWith": [
+        {
+          "raw": "junos/interfaces/loopback-multi-af.conf",
+          "id": "ewan_finance/junos/interfaces/loopback-multi-af",
+          "note": null
+        },
+        {
+          "raw": "junos/transport/ibgp-core-mesh.conf",
+          "id": "ewan_finance/junos/transport/ibgp-core-mesh",
+          "note": null
+        },
         {
           "raw": "junos/transport/rsvp-signaling.conf       (RSVP uses OSPF-TE database for CSPF)",
           "id": "ewan_finance/junos/transport/rsvp-signaling",
@@ -11789,7 +12036,10 @@
       "techFamily": "Transport",
       "subfamily": "OSPF",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },
@@ -11857,7 +12107,10 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "L3VPN",
+        "Multicast",
+        "MPLS"
       ],
       "parseWarnings": []
     },


### PR DESCRIPTION
## What's New

- Apache-2.0 LICENSE file added at repo root (matching Juniper org convention)
- EWAN Finance snip library headers enriched: Pair-with reciprocity, Seen-on corrections, service-mapping injection, Variables block fix
- Portal use-case map updated with EWAN Finance tags

## Why

The repo lacked a LICENSE file — every other Juniper public repo ships Apache-2.0. Adding it gives GitHub the license badge and clarifies reuse terms.

EWAN Finance snip headers had stale cross-references and missing reciprocal Pair-with links identified by the audit pipeline.

## Details

- `LICENSE`: standard Apache-2.0 text (Copyright 2024 Juniper Networks, Inc.)
- 20 snip header edits across `evo/` and `junos/` (Pair-with reciprocity, Seen-on, service-mapping counts)
- `evo/services/virtual-router-instance.conf`: Variables block corrected to match actual V1 instance on cr1_acx7100-48l
- `portal/scripts/jvd-usecase-map.json`: added ewan_finance tags
- `portal/src/data/snips.json`: regenerated (442 snips, 8 JVDs)

## Testing

- Full audit pipeline (D1–D6): 0 errors, 0 warnings, 169 info-only findings
- Phase 4 roundtrip render: 5/5 service snips PASS
- Portal `generate-snips.mjs --check`: OK