### PR TITLE
Initial Publish -  AI Inference Fabric configuration

### DIFF
--- a/data_center/aidc/aiml_inference_frontend/configuration/config/Frontend-Spine1.conf
+++ b/data_center/aidc/aiml_inference_frontend/configuration/config/Frontend-Spine1.conf
@@ -1,0 +1,351 @@
+version 25.2X100-D20.6-EVO;
+apply-groups POC_lab;
+groups POC_lab {
+    system {
+        host-name Storage-servers-leaf3;
+        commit synchronize;
+        domain-name svpoc.jnpr.net;
+        backup-router 10.10.10.254;
+        time-zone America/Los_Angeles;
+        management-instance;
+        name-server 10.10.10.253 routing-instance mgmt_junos;
+        ntp server x.x.x.x routing-instance mgmt_junos;
+        ntp server 10.161.216.1 routing-instance mgmt_junos;
+        authentication-order [ radius password ];
+        root-authentication {
+            encrypted-password "encrypted-password";
+        }
+        login {
+            message "Welcome to the Sunnyvale POC Lab";
+            user jnpr {
+                uid 2006;
+                class super-user;
+                authentication {
+                    encrypted-password "encrypted-password";
+                }
+            }
+        }
+        syslog {
+            user * {
+                any emergency;
+            }
+            file messages {
+                any notice;
+                authorization info;
+            }
+        }
+        services {
+            ssh;
+            netconf {
+                ssh;
+            }
+        }
+        radius-server 10.10.10.252 {
+            secret "secret";
+            retry 1;
+        }
+    }
+    interfaces {
+        re0:mgmt-0 {
+            unit 0 {
+                family inet {
+                    address 10.10.10.5/21;
+                }
+            }
+        }
+    }
+    routing-instances mgmt_junos {
+        routing-options {
+            static {
+                route 0.0.0.0/0 {
+                    next-hop 10.10.10.254;
+                }
+            }
+        }
+    }
+    protocols {
+        lldp {
+            interface all;
+        }
+    }
+}
+system {
+    host-name Frontend-Spine-1;
+    management-instance;
+    services {
+        extension-service {
+            request-response {
+                grpc {
+                    routing-instance mgmt_junos;
+                    ssl {
+                        port 32767;
+                        local-certificate aos_grpc;
+                    }
+                }
+            }
+        }
+    }
+}
+security {
+    certificates {
+        local {
+            aos_grpc {
+                "********";
+            }
+        }
+    }
+}
+interfaces {
+    et-0/0/0 {
+        description facing_frontend-leaf1:et-0/0/0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.0/31;
+            }
+        }
+    }
+    et-0/0/1 {
+        description facing_frontend-leaf1:et-0/0/1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.2/31;
+            }
+        }
+    }
+    et-0/0/2 {
+        description facing_frontend-leaf2:et-0/0/0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.4/31;
+            }
+        }
+    }
+    et-0/0/3 {
+        description facing_frontend-leaf2:et-0/0/1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.6/31;
+            }
+        }
+    }
+    et-0/0/4 {
+        description facing_frontend-leaf3:et-0/0/24:0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.32/31;
+            }
+        }
+    }
+    et-0/0/5 {
+        description facing_frontend-leaf3:et-0/0/24:1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.34/31;
+            }
+        }
+    }
+    et-0/0/6 {
+        description facing_frontend-leaf4:et-0/0/24:0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.36/31;
+            }
+        }
+    }
+    et-0/0/7 {
+        description facing_frontend-leaf4:et-0/0/24:1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.38/31;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.0.3.0/32;
+            }
+        }
+    }
+}
+policy-options {
+    community DEFAULT_DIRECT_V4 members [ 1:20007 21001:26000 ];
+    community FROM_SPINE_FABRIC_TIER members 0:15;
+    policy-statement AllPodNetworks {
+        term AllPodNetworks-10 {
+            from {
+                family inet;
+                protocol direct;
+            }
+            then {
+                community add DEFAULT_DIRECT_V4;
+                accept;
+            }
+        }
+        term AllPodNetworks-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement BGP-AOS-Policy {
+        term BGP-AOS-Policy-10 {
+            from {
+                policy AllPodNetworks;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-20 {
+            from {
+                protocol bgp;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement PFE-LB {
+        then {
+            load-balance per-packet;
+        }
+    }
+    policy-statement SPINE_TO_LEAF_FABRIC_OUT {
+        term SPINE_TO_LEAF_FABRIC_OUT-10 {
+            then {
+                community add FROM_SPINE_FABRIC_TIER;
+                accept;
+            }
+        }
+    }
+}
+routing-options {
+    router-id 10.0.3.0;
+    autonomous-system 4201032300;
+    graceful-restart;
+    forwarding-table {
+        export PFE-LB;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        log-updown;
+        multipath;
+        group l3clos-s {
+            type external;
+            multipath multiple-as;
+            vpn-apply-export;
+            bfd-liveness-detection {
+                minimum-interval 1000;
+                multiplier 3;
+            }
+            neighbor 10.0.5.1 {
+                description facing_frontend-leaf1;
+                local-address 10.0.5.0;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032400;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.3 {
+                description facing_frontend-leaf1;
+                local-address 10.0.5.2;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032400;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.5 {
+                description facing_frontend-leaf2;
+                local-address 10.0.5.4;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032401;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.7 {
+                description facing_frontend-leaf2;
+                local-address 10.0.5.6;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032401;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.33 {
+                description facing_frontend-leaf3;
+                local-address 10.0.5.32;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032406;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.35 {
+                description facing_frontend-leaf3;
+                local-address 10.0.5.34;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032406;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.37 {
+                description facing_frontend-leaf4;
+                local-address 10.0.5.36;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032407;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.39 {
+                description facing_frontend-leaf4;
+                local-address 10.0.5.38;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032407;
+                family inet {
+                    unicast;
+                }
+            }
+        }
+        graceful-restart {
+            dont-help-shared-fate-bfd-down;
+        }
+    }
+    lldp {
+        port-id-subtype interface-name;
+        port-description-type interface-description;
+        neighbour-port-info-display port-id;
+        interface all;
+    }
+    rstp {
+        disable;
+    }
+}

--- a/data_center/aidc/aiml_inference_frontend/configuration/config/Frontend-Spine2.conf
+++ b/data_center/aidc/aiml_inference_frontend/configuration/config/Frontend-Spine2.conf
@@ -1,0 +1,351 @@
+version 25.2X100-D20.6-EVO;
+apply-groups POC_lab;
+groups POC_lab {
+    system {
+        host-name Storage-servers-leaf4;
+        commit synchronize;
+        domain-name svpoc.jnpr.net;
+        backup-router 10.10.10.254;
+        time-zone America/Los_Angeles;
+        management-instance;
+        name-server 10.10.10.253 routing-instance mgmt_junos;
+        ntp server x.x.x.x routing-instance mgmt_junos;
+        ntp server 10.161.216.1 routing-instance mgmt_junos;
+        authentication-order [ radius password ];
+        root-authentication {
+            encrypted-password "encrypted-password";
+        }
+        login {
+            message "Welcome to the Sunnyvale POC Lab";
+            user jnpr {
+                uid 2007;
+                class super-user;
+                authentication {
+                    encrypted-password "encrypted-password";
+                }
+            }
+        }
+        syslog {
+            user * {
+                any emergency;
+            }
+            file messages {
+                any notice;
+                authorization info;
+            }
+        }
+        services {
+            ssh;
+            netconf {
+                ssh;
+            }
+        }
+        radius-server 10.10.10.252 {
+            secret "secret";
+            retry 1;
+        }
+    }
+    interfaces {
+        re0:mgmt-0 {
+            unit 0 {
+                family inet {
+                    address 10.10.10.6/21;
+                }
+            }
+        }
+    }
+    routing-instances mgmt_junos {
+        routing-options {
+            static {
+                route 0.0.0.0/0 {
+                    next-hop 10.10.10.254;
+                }
+            }
+        }
+    }
+    protocols {
+        lldp {
+            interface all;
+        }
+    }
+}
+system {
+    host-name Frontend-Spine-2;
+    management-instance;
+    services {
+        extension-service {
+            request-response {
+                grpc {
+                    routing-instance mgmt_junos;
+                    ssl {
+                        port 32767;
+                        local-certificate aos_grpc;
+                    }
+                }
+            }
+        }
+    }
+}
+security {
+    certificates {
+        local {
+            aos_grpc {
+                "********";
+            }
+        }
+    }
+}
+interfaces {
+    et-0/0/0 {
+        description facing_frontend-leaf1:et-0/0/2;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.8/31;
+            }
+        }
+    }
+    et-0/0/1 {
+        description facing_frontend-leaf1:et-0/0/3;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.10/31;
+            }
+        }
+    }
+    et-0/0/2 {
+        description facing_frontend-leaf2:et-0/0/2;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.12/31;
+            }
+        }
+    }
+    et-0/0/3 {
+        description facing_frontend-leaf2:et-0/0/3;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.14/31;
+            }
+        }
+    }
+    et-0/0/4 {
+        description facing_frontend-leaf3:et-0/0/25:0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.40/31;
+            }
+        }
+    }
+    et-0/0/5 {
+        description facing_frontend-leaf3:et-0/0/25:1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.42/31;
+            }
+        }
+    }
+    et-0/0/6 {
+        description facing_frontend-leaf4:et-0/0/25:0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.44/31;
+            }
+        }
+    }
+    et-0/0/7 {
+        description facing_frontend-leaf4:et-0/0/25:1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.46/31;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.0.3.1/32;
+            }
+        }
+    }
+}
+policy-options {
+    community DEFAULT_DIRECT_V4 members [ 2:20007 21001:26000 ];
+    community FROM_SPINE_FABRIC_TIER members 0:15;
+    policy-statement AllPodNetworks {
+        term AllPodNetworks-10 {
+            from {
+                family inet;
+                protocol direct;
+            }
+            then {
+                community add DEFAULT_DIRECT_V4;
+                accept;
+            }
+        }
+        term AllPodNetworks-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement BGP-AOS-Policy {
+        term BGP-AOS-Policy-10 {
+            from {
+                policy AllPodNetworks;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-20 {
+            from {
+                protocol bgp;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement PFE-LB {
+        then {
+            load-balance per-packet;
+        }
+    }
+    policy-statement SPINE_TO_LEAF_FABRIC_OUT {
+        term SPINE_TO_LEAF_FABRIC_OUT-10 {
+            then {
+                community add FROM_SPINE_FABRIC_TIER;
+                accept;
+            }
+        }
+    }
+}
+routing-options {
+    router-id 10.0.3.1;
+    autonomous-system 4201032301;
+    graceful-restart;
+    forwarding-table {
+        export PFE-LB;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        log-updown;
+        multipath;
+        group l3clos-s {
+            type external;
+            multipath multiple-as;
+            vpn-apply-export;
+            bfd-liveness-detection {
+                minimum-interval 1000;
+                multiplier 3;
+            }
+            neighbor 10.0.5.11 {
+                description facing_frontend-leaf1;
+                local-address 10.0.5.10;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032400;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.9 {
+                description facing_frontend-leaf1;
+                local-address 10.0.5.8;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032400;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.13 {
+                description facing_frontend-leaf2;
+                local-address 10.0.5.12;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032401;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.15 {
+                description facing_frontend-leaf2;
+                local-address 10.0.5.14;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032401;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.41 {
+                description facing_frontend-leaf3;
+                local-address 10.0.5.40;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032406;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.43 {
+                description facing_frontend-leaf3;
+                local-address 10.0.5.42;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032406;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.45 {
+                description facing_frontend-leaf4;
+                local-address 10.0.5.44;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032407;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.47 {
+                description facing_frontend-leaf4;
+                local-address 10.0.5.46;
+                export ( SPINE_TO_LEAF_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032407;
+                family inet {
+                    unicast;
+                }
+            }
+        }
+        graceful-restart {
+            dont-help-shared-fate-bfd-down;
+        }
+    }
+    lldp {
+        port-id-subtype interface-name;
+        port-description-type interface-description;
+        neighbour-port-info-display port-id;
+        interface all;
+    }
+    rstp {
+        disable;
+    }
+}

--- a/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf1.conf
+++ b/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf1.conf
@@ -1,0 +1,322 @@
+version 23.4R2-S5.4-EVO;
+apply-groups POC_lab;
+groups POC_lab {
+    system {
+        host-name QFX5130-32CD-23;
+        commit synchronize;
+        domain-name svpoc.jnpr.net;
+        backup-router 10.10.10.254;
+        time-zone America/Los_Angeles;
+        management-instance;
+        name-server 10.10.10.253 routing-instance mgmt_junos;
+        ntp server 10.10.10.251 routing-instance mgmt_junos;
+        authentication-order [ radius password ];
+        root-authentication {
+            encrypted-password "encrypted-password";
+        }
+        login {
+            message "Welcome to the Sunnyvale POC Lab";
+            user jnpr {
+                uid 2006;
+                class super-user;
+                authentication {
+                    encrypted-password "encrypted-password";
+                }
+            }
+        }
+        syslog {
+            user * {
+                any emergency;
+            }
+            file messages {
+                any notice;
+                authorization info;
+            }
+        }
+        services {
+            ssh;
+            netconf {
+                ssh;
+            }
+        }
+        radius-server 10.10.10.252 {
+            secret "secret";
+            retry 1;
+        }
+    }
+    interfaces {
+        re0:mgmt-0 {
+            unit 0 {
+                family inet {
+                    address 10.10.10.1/21;
+                }
+            }
+        }
+    }
+    routing-instances mgmt_junos {
+        routing-options {
+            static {
+                route 0.0.0.0/0 {
+                    next-hop 10.10.10.254;
+                }
+            }
+        }
+    }
+    protocols {
+        lldp {
+            interface all;
+        }
+    }
+}
+system {
+    host-name frontend-leaf1;
+    management-instance;
+    services {
+        extension-service {
+            request-response {
+                grpc {
+                    routing-instance mgmt_junos;
+                    ssl {
+                        port 32767;
+                        local-certificate aos_grpc;
+                    }
+                }
+            }
+        }
+    }
+}
+security {
+    certificates {
+        local {
+            aos_grpc {
+                "******";
+            }
+        }
+    }
+}
+interfaces {
+    et-0/0/0 {
+        description facing_frontend-spine-1:et-0/0/0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.1/31;
+            }
+        }
+    }
+    et-0/0/1 {
+        description facing_frontend-spine-1:et-0/0/1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.3/31;
+            }
+        }
+    }
+    et-0/0/2 {
+        description facing_frontend-spine-2:et-0/0/0;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.9/31;
+            }
+        }
+    }
+    et-0/0/3 {
+        description facing_frontend-spine-2:et-0/0/1;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.11/31;
+            }
+        }
+    }
+    et-0/0/8 {
+        description "Breakout et-0/0/8";
+        number-of-sub-ports 4;
+        speed 10g;
+    }
+    et-0/0/8:0 {
+        description to.headend-svr-01:eth0;
+        native-vlan-id 3;
+        mtu 9216;
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan members vn3;
+            }
+        }
+    }
+    et-0/0/28 {
+        description "VRF default to Lambda-X13-01";
+        speed 100g;
+        unit 0 {
+            family inet {
+                address 10.10.1.29/31;
+            }
+        }
+    }
+    irb {
+        mtu 9216;
+        unit 3 {
+            family inet {
+                mtu 9000;
+                address 10.10.3.1/24;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.0.4.0/32;
+            }
+        }
+    }
+}
+policy-options {
+    community DEFAULT_DIRECT_V4 members [ 3:20007 21001:26000 ];
+    community FROM_SPINE_FABRIC_TIER members 0:15;
+    policy-statement AllPodNetworks {
+        term AllPodNetworks-10 {
+            from {
+                family inet;
+                protocol direct;
+            }
+            then {
+                community add DEFAULT_DIRECT_V4;
+                accept;
+            }
+        }
+        term AllPodNetworks-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement BGP-AOS-Policy {
+        term BGP-AOS-Policy-10 {
+            from {
+                policy AllPodNetworks;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement LEAF_TO_SPINE_FABRIC_OUT {
+        term LEAF_TO_SPINE_FABRIC_OUT-10 {
+            from {
+                protocol bgp;
+                community FROM_SPINE_FABRIC_TIER;
+            }
+            then {
+                reject;
+            }
+        }
+        term LEAF_TO_SPINE_FABRIC_OUT-20 {
+            then {
+                accept;
+            }
+        }
+    }
+    policy-statement PFE-LB {
+        then {
+            load-balance per-packet;
+        }
+    }
+}
+routing-options {
+    router-id 10.0.4.0;
+    autonomous-system 4201032400;
+    graceful-restart;
+    forwarding-table {
+        export PFE-LB;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        log-updown;
+        multipath;
+        group l3clos-l {
+            type external;
+            multipath multiple-as;
+            vpn-apply-export;
+            bfd-liveness-detection {
+                minimum-interval 1000;
+                multiplier 3;
+            }
+            neighbor 10.0.5.0 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.1;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.2 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.3;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.10 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.11;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.8 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.9;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+        }
+        graceful-restart {
+            dont-help-shared-fate-bfd-down;
+        }
+    }
+    l2-learning {
+        telemetry enable-remote-entries;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        port-description-type interface-description;
+        neighbour-port-info-display port-id;
+        interface all;
+    }
+    rstp {
+        bridge-priority 0;
+        bpdu-block-on-edge;
+        interface et-0/0/8:0 {
+            edge;
+        }
+    }
+}
+vlans {
+    vn3 {
+        description FrontEnd-Cluster-VN3;
+        vlan-id 3;
+        l3-interface irb.3;
+    }
+}

--- a/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf2.conf
+++ b/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf2.conf
@@ -1,0 +1,294 @@
+version 23.4R2-S5.4-EVO;
+apply-groups POC_lab;
+groups POC_lab {
+    system {
+        host-name QFX5130-32CD-24;
+        commit synchronize;
+        domain-name svpoc.jnpr.net;
+        backup-router 10.10.10.254;
+        time-zone America/Los_Angeles;
+        management-instance;
+        name-server 10.10.10.253 routing-instance mgmt_junos;
+        ntp server 10.10.10.251 routing-instance mgmt_junos;
+        authentication-order [ radius password ];
+        root-authentication {
+            encrypted-password "encrypted-password";
+        }
+        login {
+            message "Welcome to the Sunnyvale POC Lab";
+            user jnpr {
+                uid 2007;
+                class super-user;
+                authentication {
+                    encrypted-password "encrypted-password";
+                }
+            }
+        }
+        syslog {
+            user * {
+                any emergency;
+            }
+            file messages {
+                any notice;
+                authorization info;
+            }
+        }
+        services {
+            ssh;
+            netconf {
+                ssh;
+            }
+        }
+        radius-server 10.10.10.252 {
+            secret "secret";
+            retry 1;
+        }
+    }
+    interfaces {
+        re0:mgmt-0 {
+            unit 0 {
+                family inet {
+                    address 10.10.10.2/21;
+                }
+            }
+        }
+    }
+    routing-instances mgmt_junos {
+        routing-options {
+            static {
+                route 0.0.0.0/0 {
+                    next-hop x.x.x.x;
+                }
+            }
+        }
+    }
+    protocols {
+        lldp {
+            interface all;
+        }
+    }
+}
+system {
+    host-name frontend-leaf2;
+    management-instance;
+    services {
+        extension-service {
+            request-response {
+                grpc {
+                    routing-instance mgmt_junos;
+                    ssl {
+                        port 32768;
+                        local-certificate aos_grpc;
+                    }
+                }
+            }
+        }
+    }
+}
+security {
+    certificates {
+        local {
+            aos_grpc {
+                "******";
+            }
+        }
+    }
+}
+interfaces {
+    et-0/0/0 {
+        description facing_frontend-spine-1:et-0/0/2;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.5/31;
+            }
+        }
+    }
+    et-0/0/1 {
+        description facing_frontend-spine-1:et-0/0/3;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.7/31;
+            }
+        }
+    }
+    et-0/0/2 {
+        description facing_frontend-spine-2:et-0/0/2;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.13/31;
+            }
+        }
+    }
+    et-0/0/3 {
+        description facing_frontend-spine-2:et-0/0/3;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.15/31;
+            }
+        }
+    }
+    et-0/0/12 {
+        description "VRF default to Lamda-Scaler-02";
+        speed 100g;
+        unit 0 {
+            family inet {
+                address 10.10.1.35/31;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.0.4.1/32;
+            }
+        }
+    }
+}
+policy-options {
+    community DEFAULT_DIRECT_V4 members [ 4:20007 21001:26000 ];
+    community FROM_SPINE_FABRIC_TIER members 0:15;
+    policy-statement AllPodNetworks {
+        term AllPodNetworks-10 {
+            from {
+                family inet;
+                protocol direct;
+            }
+            then {
+                community add DEFAULT_DIRECT_V4;
+                accept;
+            }
+        }
+        term AllPodNetworks-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement BGP-AOS-Policy {
+        term BGP-AOS-Policy-10 {
+            from {
+                policy AllPodNetworks;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement LEAF_TO_SPINE_FABRIC_OUT {
+        term LEAF_TO_SPINE_FABRIC_OUT-10 {
+            from {
+                protocol bgp;
+                community FROM_SPINE_FABRIC_TIER;
+            }
+            then {
+                reject;
+            }
+        }
+        term LEAF_TO_SPINE_FABRIC_OUT-20 {
+            then {
+                accept;
+            }
+        }
+    }
+    policy-statement PFE-LB {
+        then {
+            load-balance per-packet;
+        }
+    }
+}
+routing-options {
+    router-id 10.0.4.1;
+    autonomous-system 4201032401;
+    graceful-restart;
+    forwarding-table {
+        export PFE-LB;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        log-updown;
+        multipath;
+        group l3clos-l {
+            type external;
+            multipath multiple-as;
+            vpn-apply-export;
+            bfd-liveness-detection {
+                minimum-interval 1000;
+                multiplier 3;
+            }
+            neighbor 10.0.5.4 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.5;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.6 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.7;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.12 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.13;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.14 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.15;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+        }
+        graceful-restart {
+            dont-help-shared-fate-bfd-down;
+        }
+    }
+    l2-learning {
+        telemetry enable-remote-entries;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        port-description-type interface-description;
+        neighbour-port-info-display port-id;
+        interface all;
+    }
+    rstp {
+        bridge-priority 0;
+        bpdu-block-on-edge;
+    }
+}
+vlans {
+    vn4 {
+        description FrontEnd-Cluster-VN4;
+        vlan-id 4;
+        l3-interface irb.4;
+    }
+}

--- a/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf3.conf
+++ b/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf3.conf
@@ -1,0 +1,317 @@
+version 23.4R2-S5.4-EVO;
+apply-groups POC_lab;
+groups POC_lab {
+    system {
+        host-name QFX5130-32CD-25;
+        commit synchronize;
+        domain-name svpoc.jnpr.net;
+        backup-router 10.10.10.254;
+        time-zone America/Los_Angeles;
+        management-instance;
+        name-server 10.10.10.253 routing-instance mgmt_junos;
+        ntp server 10.10.10.251 routing-instance mgmt_junos;
+        authentication-order [ radius password ];
+        root-authentication {
+            encrypted-password "encrypted-password";
+        }
+        login {
+            message "Welcome to the Sunnyvale POC Lab";
+            user jnpr {
+                uid 2008;
+                class super-user;
+                authentication {
+                    encrypted-password "encrypted-password";
+                }
+            }
+        }
+        syslog {
+            user * {
+                any emergency;
+            }
+            file messages {
+                any notice;
+                authorization info;
+            }
+        }
+        services {
+            ssh;
+            netconf {
+                ssh;
+            }
+        }
+        radius-server 10.10.10.252 {
+            secret "secret";
+            retry 1;
+        }
+    }
+    interfaces {
+        re0:mgmt-0 {
+            unit 0 {
+                family inet {
+                    address 10.10.10.3/21;
+                }
+            }
+        }
+    }
+    routing-instances mgmt_junos {
+        routing-options {
+            static {
+                route 0.0.0.0/0 {
+                    next-hop x.x.x.x;
+                }
+            }
+        }
+    }
+    protocols {
+        lldp {
+            interface all;
+        }
+    }
+}
+system {
+    host-name frontend-leaf3;
+    services {
+        extension-service {
+            request-response {
+                grpc {
+                    routing-instance mgmt_junos;
+                    ssl {
+                        port 32769;
+                        local-certificate aos_grpc;
+                    }
+                }
+            }
+        }
+    }
+}
+security {
+    certificates {
+        local {
+            aos_grpc {
+                "******";
+            }
+        }
+    }
+}
+interfaces {
+    et-0/0/0 {
+        description to.mi300-01;
+        native-vlan-id 5;
+        mtu 9216;
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan members vn5;
+            }
+        }
+    }
+    et-0/0/24 {
+        description "Breakout et-0/0/24";
+        number-of-sub-ports 2;
+        speed 400g;
+    }
+    et-0/0/24:0 {
+        description facing_frontend-spine-1:et-0/0/4;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.33/31;
+            }
+        }
+    }
+    et-0/0/24:1 {
+        description facing_frontend-spine-1:et-0/0/5;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.35/31;
+            }
+        }
+    }
+    et-0/0/25 {
+        description "Breakout et-0/0/25";
+        number-of-sub-ports 2;
+        speed 400g;
+    }
+    et-0/0/25:0 {
+        description facing_frontend-spine-2:et-0/0/6;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.45/31;
+            }
+        }
+    }
+    et-0/0/25:1 {
+        description facing_frontend-spine-2:et-0/0/5;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.47/31;
+            }
+        }
+    }
+    irb {
+        mtu 9216;
+        unit 5 {
+            family inet {
+                mtu 9000;
+                address 10.10.5.254/24;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.0.4.4/32;
+            }
+        }
+    }
+}
+policy-options {
+    community DEFAULT_DIRECT_V4 members [ 5:20007 21001:26000 ];
+    community FROM_SPINE_FABRIC_TIER members 0:15;
+    policy-statement AllPodNetworks {
+        term AllPodNetworks-10 {
+            from {
+                family inet;
+                protocol direct;
+            }
+            then {
+                community add DEFAULT_DIRECT_V4;
+                accept;
+            }
+        }
+        term AllPodNetworks-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement BGP-AOS-Policy {
+        term BGP-AOS-Policy-10 {
+            from {
+                policy AllPodNetworks;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement LEAF_TO_SPINE_FABRIC_OUT {
+        term LEAF_TO_SPINE_FABRIC_OUT-10 {
+            from {
+                protocol bgp;
+                community FROM_SPINE_FABRIC_TIER;
+            }
+            then {
+                reject;
+            }
+        }
+        term LEAF_TO_SPINE_FABRIC_OUT-20 {
+            then {
+                accept;
+            }
+        }
+    }
+    policy-statement PFE-LB {
+        then {
+            load-balance per-packet;
+        }
+    }
+}
+routing-options {
+    router-id 10.0.4.4;
+    autonomous-system 4201032406;
+    graceful-restart;
+    forwarding-table {
+        export PFE-LB;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        log-updown;
+        multipath;
+        group l3clos-l {
+            type external;
+            multipath multiple-as;
+            vpn-apply-export;
+            bfd-liveness-detection {
+                minimum-interval 1000;
+                multiplier 3;
+            }
+            neighbor 10.0.5.32 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.33;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.34 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.35;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.40 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.41;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.42 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.43;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+        }
+        graceful-restart {
+            dont-help-shared-fate-bfd-down;
+        }
+    }
+    l2-learning {
+        telemetry enable-remote-entries;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        port-description-type interface-description;
+        neighbour-port-info-display port-id;
+        interface all;
+    }
+    rstp {
+        bridge-priority 0;
+        bpdu-block-on-edge;
+        interface et-0/0/0:0 {
+            edge;
+        }
+    }
+}
+vlans {
+    vn5 {
+        description FrontEnd-Cluster-VN5;
+        vlan-id 5;
+        l3-interface irb.5;
+    }
+}

--- a/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf4.conf
+++ b/data_center/aidc/aiml_inference_frontend/configuration/config/frontend-leaf4.conf
@@ -1,0 +1,318 @@
+version 23.4R2-S5.4-EVO;
+apply-groups POC_lab;
+groups POC_lab {
+    system {
+        host-name QFX5130-32CD-26;
+        commit synchronize;
+        domain-name svpoc.jnpr.net;
+        backup-router 10.10.10.254;
+        time-zone America/Los_Angeles;
+        management-instance;
+        name-server 10.10.10.253 routing-instance mgmt_junos;
+        ntp server 10.10.10.251 routing-instance mgmt_junos;
+        authentication-order [ radius password ];
+        root-authentication {
+            encrypted-password "encrypted-password";
+        }
+        login {
+            message "Welcome to the Sunnyvale POC Lab";
+            user jnpr {
+                uid 2009;
+                class super-user;
+                authentication {
+                    encrypted-password "encrypted-password";
+                }
+            }
+        }
+        syslog {
+            user * {
+                any emergency;
+            }
+            file messages {
+                any notice;
+                authorization info;
+            }
+        }
+        services {
+            ssh;
+            netconf {
+                ssh;
+            }
+        }
+        radius-server 10.10.10.252 {
+            secret "secret";
+            retry 1;
+        }
+    }
+    interfaces {
+        re0:mgmt-0 {
+            unit 0 {
+                family inet {
+                    address 10.10.10.4/21;
+                }
+            }
+        }
+    }
+    routing-instances mgmt_junos {
+        routing-options {
+            static {
+                route 0.0.0.0/0 {
+                    next-hop x.x.x.x;
+                }
+            }
+        }
+    }
+    protocols {
+        lldp {
+            interface all;
+        }
+    }
+}
+system {
+    host-name frontend-leaf4;
+    management-instance;
+    services {
+        extension-service {
+            request-response {
+                grpc {
+                    routing-instance mgmt_junos;
+                    ssl {
+                        port 32770;
+                        local-certificate aos_grpc;
+                    }
+                }
+            }
+        }
+    }
+}
+security {
+    certificates {
+        local {
+            aos_grpc {
+                "******";
+            }
+        }
+    }
+}
+interfaces {
+    et-0/0/0 {
+        description to.mi300-01;
+        native-vlan-id 6;
+        mtu 9216;
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan members vn6;
+            }
+        }
+    }
+    et-0/0/24 {
+        description "Breakout et-0/0/24";
+        number-of-sub-ports 2;
+        speed 400g;
+    }
+    et-0/0/24:0 {
+        description facing_frontend-spine-1:et-0/0/6;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.37/31;
+            }
+        }
+    }
+    et-0/0/24:1 {
+        description facing_frontend-spine-1:et-0/0/7;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.39/31;
+            }
+        }
+    }
+    et-0/0/25 {
+        description "Breakout et-0/0/25";
+        number-of-sub-ports 2;
+        speed 400g;
+    }
+    et-0/0/25:0 {
+        description facing_frontend-spine-2:et-0/0/6;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.45/31;
+            }
+        }
+    }
+    et-0/0/25:1 {
+        description facing_frontend-spine-2:et-0/0/7;
+        mtu 9216;
+        unit 0 {
+            family inet {
+                mtu 9170;
+                address 10.0.5.47/31;
+            }
+        }
+    }
+    irb {
+        mtu 9216;
+        unit 6 {
+            family inet {
+                mtu 9000;
+                address 10.10.6.254/24;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.0.4.5/32;
+            }
+        }
+    }
+}
+policy-options {
+    community DEFAULT_DIRECT_V4 members [ 6:20007 21001:26000 ];
+    community FROM_SPINE_FABRIC_TIER members 0:15;
+    policy-statement AllPodNetworks {
+        term AllPodNetworks-10 {
+            from {
+                family inet;
+                protocol direct;
+            }
+            then {
+                community add DEFAULT_DIRECT_V4;
+                accept;
+            }
+        }
+        term AllPodNetworks-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement BGP-AOS-Policy {
+        term BGP-AOS-Policy-10 {
+            from {
+                policy AllPodNetworks;
+            }
+            then {
+                accept;
+            }
+        }
+        term BGP-AOS-Policy-100 {
+            then {
+                reject;
+            }
+        }
+    }
+    policy-statement LEAF_TO_SPINE_FABRIC_OUT {
+        term LEAF_TO_SPINE_FABRIC_OUT-10 {
+            from {
+                protocol bgp;
+                community FROM_SPINE_FABRIC_TIER;
+            }
+            then {
+                reject;
+            }
+        }
+        term LEAF_TO_SPINE_FABRIC_OUT-20 {
+            then {
+                accept;
+            }
+        }
+    }
+    policy-statement PFE-LB {
+        then {
+            load-balance per-packet;
+        }
+    }
+}
+routing-options {
+    router-id 10.0.4.5;
+    autonomous-system 4201032407;
+    graceful-restart;
+    forwarding-table {
+        export PFE-LB;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        log-updown;
+        multipath;
+        group l3clos-l {
+            type external;
+            multipath multiple-as;
+            vpn-apply-export;
+            bfd-liveness-detection {
+                minimum-interval 1000;
+                multiplier 3;
+            }
+            neighbor 10.0.5.36 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.37;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.38 {
+                description facing_frontend-spine-1;
+                local-address 10.0.5.39;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032300;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.44 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.45;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+            neighbor 10.0.5.46 {
+                description facing_frontend-spine-2;
+                local-address 10.0.5.47;
+                export ( LEAF_TO_SPINE_FABRIC_OUT && BGP-AOS-Policy );
+                peer-as 4201032301;
+                family inet {
+                    unicast;
+                }
+            }
+        }
+        graceful-restart {
+            dont-help-shared-fate-bfd-down;
+        }
+    }
+    l2-learning {
+        telemetry enable-remote-entries;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        port-description-type interface-description;
+        neighbour-port-info-display port-id;
+        interface all;
+    }
+    rstp {
+        bridge-priority 0;
+        bpdu-block-on-edge;
+        interface et-0/0/0:0 {
+            edge;
+        }
+    }
+}
+vlans {
+    vn6 {
+        description FrontEnd-Cluster-VN6;
+        vlan-id 6;
+        l3-interface irb.6;
+    }
+}


### PR DESCRIPTION
## What's New
A brand new AI JVD for Inference Frontend Fabric.



## Why
The AI Inference Network Design with HPE Juniper QFX switches, [HPE Juniper Apstra Data Center Director] and AMD Instinct™ MI300X GPUs demonstrates how a standards-based Ethernet frontend fabric can efficiently support AI inference workloads while maintaining predictable performance characteristics. 
The validated frontend fabric follows a scalable 3-stage Clos Ethernet architecture, with QFX5140-24CD switches, QFX5220-32CD, and QFX5130-32OD leaf nodes and QFX5220-32CD spine nodes.

The solution provides a benchmark-focused reference architecture for high-performance AI inference environments and demonstrates how modern Ethernet-based frontend networks can support production inference deployments. 
The solution validates a range of commonly deployed Large Language Models (LLMs) with varying model sizes and inference characteristics, including:
• Llama 3.1 8B — representing smaller models optimized for lower latency and higher request concurrency.
• Llama 3.3 70B — representing larger-scale models with increased compute and memory requirements.
• Qwen 2.5 72B — representing alternative large-model architectures used for advanced conversational and reasoning workloads.