### PR TITLE
docs: standardize JVD READMEs per template spec

### DIFF
--- a/data_center/adc/3stage_dc/README.md
+++ b/data_center/adc/3stage_dc/README.md
@@ -1,8 +1,18 @@
 # 3-Stage EVPN/VXLAN Data Center Design
 
+> Validated EVPN/VXLAN data center fabric with Edge-Routed Bridging overlay and lean spine underlay, managed by Juniper Apstra.
+
 Validated configurations for the Juniper Validated Design *"3-Stage Data Center Design with Juniper Apstra."* This is the most common Juniper data center fabric architecture, built on EVPN/VXLAN with an **Edge-Routed Bridging (ERB)** overlay and a **lean spine** underlay.
 
 * JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-3-stage-datacenterdesign-with-juniper-apstra/index.html>
+
+## Highlights
+
+- Most common Juniper DC fabric architecture — validated against multiple platforms per role
+- EVPN/VXLAN with Edge-Routed Bridging (ERB) overlay and lean spine underlay
+- ESI-LAG multihoming for server redundancy
+- 5 border-leaf platform variants validated (QFX5130, ACX7100, PTX10001, QFX5120, QFX5700)
+- Apstra-managed with full lifecycle automation
 
 The JVD validates the design against multiple Juniper switching platforms in each role, so customers can choose the platform that best matches their density, scale, and budget requirements.
 

--- a/data_center/adc/3stage_dc_connected_security/README.md
+++ b/data_center/adc/3stage_dc_connected_security/README.md
@@ -1,8 +1,19 @@
 # 3-Stage Data Center Connected Security
 
+> Extends the 3-stage DC fabric with SRX firewalls in Multinode HA, applying security policy without breaking VXLAN encapsulation.
+
 Validated configurations for the Juniper Validated Design *"Secure Data Center Fabric with Juniper SRX."* This JVD extends the [3-stage data center design](../3stage_dc/) by integrating Juniper **SRX firewalls in a Multinode High Availability (MNHA) cluster** into the EVPN/VXLAN fabric, so security policy can be applied without breaking VXLAN encapsulation across the fabric.
 
 * JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvde-secure-data-center-fabric-srx-series-firewall/index.html>
+
+## Highlights
+
+- SRX firewalls participate in EVPN signaling and learn Type-5 routes via spine peering
+- Inter-VRF traffic inspected by SRX without ACLs on fabric switches
+- North-south perimeter security with default route injection into EVPN/VXLAN
+- Multinode High Availability (MNHA) for firewall redundancy
+- SRX4600 and SRX4700 both validated
+- Apstra-managed fabric with exported blueprint included
 
 The SRX devices participate in EVPN signaling and learn Type-5 routes by peering with the spines, which lets network and firewall teams operate independently. Two primary use cases:
 

--- a/data_center/adc/5stage_evpn_vxlan/README.md
+++ b/data_center/adc/5stage_evpn_vxlan/README.md
@@ -1,8 +1,18 @@
 # 5-Stage EVPN-VXLAN Data Center
 
+> Web-scale data center fabric with lean super spines above multiple PODs — Compute, Storage, and Services — managed by Juniper Apstra.
+
 Validated configurations for the Juniper Validated Design *"5-Stage EVPN/VXLAN Data Center Fabric (ERB)."* This design extends the [3-stage data center](../3stage_dc/) to web-scale by introducing **lean super spines** above multiple PODs, each POD itself a 3-stage EVPN/VXLAN fabric. Super spines and POD spines forward IP only and relay routes — they do not run VXLAN encapsulation.
 
 * JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-dcfabric-5-stage/>
+
+## Highlights
+
+- Multi-POD fabric with Compute, Storage, and Services PODs interconnected by super spines
+- ERB overlay per POD; super spines are IP-only (no VXLAN encapsulation)
+- Validates RoCEv2 and multicast traversal across POD boundaries
+- 8 distinct platform/role combinations validated
+- Apstra-managed with full lifecycle automation
 
 The 5-stage fabric targets large data centers where compute and storage scale beyond a single POD, and where workloads such as RoCEv2 and multicast must traverse PODs deterministically. This JVD validates three POD types — **Compute**, **Storage**, and **Services** — interconnected by a pair of super spines, with an external gateway router providing north-south connectivity.
 

--- a/data_center/adc/collapsed_dc_fabric/README.md
+++ b/data_center/adc/collapsed_dc_fabric/README.md
@@ -1,8 +1,18 @@
 # Collapsed Data Center Fabric
 
-Validated configurations for the Juniper Validated Design *"Collapsed Data Center Fabric with Juniper Apstra."* The collapsed-fabric (a.k.a. collapsed-spine) architecture is Juniper's recommended pattern for **small data centers** where a separate spine tier isn't justified — the leaf switches *are* the fabric, peering directly with each other over EVPN/VXLAN.
+> Simplified DC fabric for small data centers where leaf switches peer directly over EVPN/VXLAN — no separate spine tier needed.
+
+Validated configurations for the Juniper Validated Design *"Collapsed Data Center Fabric with Juniper Apstra."* The collapsed-fabric (a.k.a. collapsed-spine) architecture is Juniper’s recommended pattern for **small data centers** where a separate spine tier isn’t justified — the leaf switches *are* the fabric, peering directly with each other over EVPN/VXLAN.
 
 * JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-collapsed-dc-fabric-with-apstra/index.html>
+
+## Highlights
+
+- Simplest EVPN/VXLAN fabric — 2 switches, no spines
+- ERB overlay with direct leaf-to-leaf peering
+- ESI-LAG multihoming for server redundancy
+- Apstra-managed with full lifecycle automation
+- Ideal for branch offices, edge sites, and small colos
 
 <img width="678" alt="Collapsed Data Center Fabric architecture" src="https://github.com/user-attachments/assets/52e20a5a-127e-4947-97ea-0f7ded3f5431" />
 

--- a/data_center/adc/collapsed_dc_fabric_with_access/README.md
+++ b/data_center/adc/collapsed_dc_fabric_with_access/README.md
@@ -1,8 +1,17 @@
 # Collapsed Data Center Fabric with Access Switches
 
+> Extends the collapsed fabric with EX-series access switches for high-density mGig server connectivity.
+
 Validated configurations for the Juniper Validated Design *"Collapsed Data Center Fabric with Juniper Apstra and Access Switches."* This JVD extends the [base collapsed fabric](../collapsed_dc_fabric/) with a pair of EX-series access switches, adding ~48 mGig high-availability access ports per access pair (and supporting as many access pairs as the collapsed-leaf high-availability ports allow).
 
 * JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-collapsed-dc-fabric-juniper-apstra-access-switches/index.html>
+
+## Highlights
+
+- Extends collapsed fabric with EX4400 access tier
+- ~48 mGig high-availability ports per access pair
+- Scalable — supports multiple access pairs per collapsed-leaf HA port
+- Apstra-managed end-to-end (fabric + access)
 
 <img width="900" alt="Collapsed Data Center Fabric with Access Switches" src="https://github.com/user-attachments/assets/47a0a73e-5510-42ad-b40d-0b8082dbeaac" />
 

--- a/data_center/adc/evpn_vxlan_dci/README.md
+++ b/data_center/adc/evpn_vxlan_dci/README.md
@@ -1,8 +1,18 @@
 # EVPN-VXLAN Data Center Interconnect (DCI)
 
+> Three validated techniques for stretching EVPN/VXLAN fabrics across multiple data centers with MACSEC encryption.
+
 Validated configurations for the Juniper Validated Design *"EVPN-VXLAN Data Center Interconnect."* This JVD demonstrates three distinct techniques for stretching an EVPN/VXLAN fabric across multiple data centers, all built on the [3-stage data center](../3stage_dc/) and [5-stage EVPN-VXLAN](../5stage_evpn_vxlan/) baseline designs.
 
 * JVD landing page: <https://www.juniper.net/documentation/validated-designs/us/en/data-center/>
+
+## Highlights
+
+- Three DCI techniques validated: Over-the-Top (OTT), Type 2 Seamless Stitching, Type 2 + Type 5 Seamless Stitching
+- MACSEC encryption between border-leaf gateways in all scenarios
+- Interconnects between 3-stage and 5-stage EVPN/VXLAN fabrics
+- 10 platform variants across spine, leaf, border-leaf, and super-spine roles
+- Selective L2/L3 VXLAN stretching for scale-appropriate DCI
 
 The DCI design covers three interconnect techniques, each captured as a separate, fully-rendered fabric configuration set in this folder:
 

--- a/data_center/adc/evpn_vxlan_sflow_apstra/README.md
+++ b/data_center/adc/evpn_vxlan_sflow_apstra/README.md
@@ -1,8 +1,18 @@
 # EVPN-VXLAN Data Center sFlow with Juniper Apstra
 
+> Real-time packet-sampled traffic visibility via sFlow telemetry export to Juniper Apstra Flow across an EVPN/VXLAN fabric.
+
 Validated configurations for the Juniper Validated Design *"EVPN-VXLAN Data Center sFlow with Juniper Apstra."* This JVD extends the [3-stage data center design](../3stage_dc/) by adding sFlow telemetry export to **Juniper Apstra Flow**, providing real-time, packet-sampled visibility into traffic flowing through the EVPN-VXLAN fabric.
 
 * JVD landing page: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-sflow/jvd-evpn-vxlan-datacenter-sflow.pdf>
+
+## Highlights
+
+- sFlow telemetry on every fabric switch via Apstra configlets
+- Swap-matrix approach — multiple platform variants validated per role
+- Apstra Flow collector with OpenSearch dashboards for visualization
+- Validated across Junos 23.4R2-S5, 24.2R2, and 24.4R2
+- Configurations in display-set format (`configuration/set/`)
 
 sFlow is enabled on every fabric switch via Apstra configlets. Each switch exports sampled packet headers and interface statistics over UDP to the Apstra Flow collector, which decodes the data and visualizes it through OpenSearch dashboards. The collector is reached over a dedicated revenue/WAN port (not the management interface), with the route advertised into the fabric by the default Apstra underlay policy.
 

--- a/data_center/aidc/aiml_multitenancy_backend/README.md
+++ b/data_center/aidc/aiml_multitenancy_backend/README.md
@@ -1,5 +1,7 @@
 # EVPN/VXLAN GPU Backend Fabric for Multitenancy (GPUaaS)
 
+> Validated GPU backend fabric enabling multi-tenant isolation over EVPN/VXLAN with rail-optimized stripe topology for AI/ML inference workloads.
+
 Validated configurations for the **GPU backend fabric** described in the Juniper Validated Design
 *"AI Data Center Multitenancy with EVPN/VXLAN."*
 

--- a/enterprise_wan/ewan_adv_core_edge/README.md
+++ b/enterprise_wan/ewan_adv_core_edge/README.md
@@ -1,5 +1,7 @@
 # Enterprise WAN Advanced Core and Edge Services
 
+> MPLS-based enterprise WAN backbone delivering EVPN-VPWS, EVPN Type-5, and EVPN ELAN at scale with MACsec encryption and Ethernet OAM.
+
 Validated configurations for the **Enterprise WAN Advanced Core and Edge
 Services** Juniper Validated Design. This JVD demonstrates an MPLS-based
 enterprise WAN backbone that delivers EVPN-VPWS, EVPN Type-5 (IP-VRF),
@@ -10,6 +12,14 @@ encryption between WAN segments.
 * JVD document: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-ewan-adv-core-edge-svc-01/index.html>
 * Solution overview: <https://www.juniper.net/documentation/us/en/software/jvd/sol-overview-ewan-adv-core-edge-svc-01.pdf>
 * Test report: <https://www.juniper.net/documentation/us/en/software/jvd/test-report-brief-ewan-adv-core-edge-svc-01.pdf>
+
+## Highlights
+
+- ~1,500 EVPN-VPWS + 1,200 EVPN/MAC-VRF + 350 IP-VRF instances per edge router
+- Segment Routing and LDP coexistence via SR Mapping Server (SRMS)
+- MACsec encryption between WAN segments
+- Ethernet OAM (802.1ag CFM) for per-service SLA monitoring
+- Regressively validated across multiple Junos / Junos EVO releases
 
 The design validates advanced service scale on the WAN edge — each edge
 router carries approximately 1,500 EVPN-VPWS instances, 1,200+ EVPN /

--- a/enterprise_wan/ewan_core_edge/README.md
+++ b/enterprise_wan/ewan_core_edge/README.md
@@ -1,3 +1,29 @@
-# <h3> Configurations provided for the Juniper Networks Validated Design for Enterprise WAN Advanced Core and Edge.
+# Enterprise WAN Core and Edge
+
+> Reliable MPLS/SR-based enterprise WAN connecting branch, campus, and data center locations with Juniper MX and SRX platforms.
 
 Discover how to create a reliable network design for an enterprise WAN edge and core network with Juniper's validated design. Seamlessly connect your branch and campus locations with enterprise data centers and public cloud provider data centers.
+
+## Highlights
+
+- MPLS/Segment Routing transport with RSVP-TE and SR-MPLS options
+- L3VPN and EVPN overlay services for multi-site connectivity
+- Redundant WAN edge with SRX-based security integration
+- BGP-based SD-WAN traffic steering
+- Sub-50ms convergence with TI-LFA and BFD
+
+---
+
+## Documentation
+
+- **JVD Document:**  
+  [Enterprise WAN Core and Edge JVD](https://www.juniper.net/documentation/us/en/software/jvd/jvd-ewan-core-edge-01/index.html)
+
+- **Solution Overview:**  
+  [PDF Overview](https://www.juniper.net/documentation/us/en/software/jvd/sol-overview-ewan-core-edge-01.pdf)
+
+- **Test Report Brief:**  
+  [PDF Test Brief](https://www.juniper.net/documentation/us/en/software/jvd/testreportbrief-ewan-core-edge-01.pdf)
+
+- **🎧 Audio Overview:**  
+  [Listen](https://www.juniper.net/documentation/webstatic/audios/Ent-WAN-Core-and-Edge_audio-overview.mp3)

--- a/enterprise_wan/ewan_finance/README.md
+++ b/enterprise_wan/ewan_finance/README.md
@@ -72,13 +72,15 @@ The JVD includes **59+ tests** across **4 high-level scenarios**, validating:
 
 ## Validated Platforms
 
-Validated on platforms including:
-
-- **ACX7100-48L**
-- **MX480**
-- **MX304**
-- **MX10004**
-- **MX10008**
+| Juniper Product | Role | Config |
+|---|---|---|
+| **ACX7100-48L** | Core Router / Multicast | [`cr1_acx7100-48l.conf`](configuration/conf/cr1_acx7100-48l.conf) |
+| **MX480** | Core Router | [`cr2_mx480.conf`](configuration/conf/cr2_mx480.conf) |
+| **MX304** | WAN Edge / Access Provider | [`wanedge1_mx304.conf`](configuration/conf/wanedge1_mx304.conf), [`ap1_mx304.conf`](configuration/conf/ap1_mx304.conf) |
+| **MX10004** | WAN Edge / Access Provider | [`wanedge2_mx10004.conf`](configuration/conf/wanedge2_mx10004.conf), [`ap2_mx10004.conf`](configuration/conf/ap2_mx10004.conf) |
+| **PTX10003-80C** | P Router | [`p1_ptx10003-80c.conf`](configuration/conf/p1_ptx10003-80c.conf) |
+| **PTX10001-36MR** | P Router | [`p2_ptx10001-36mr.conf`](configuration/conf/p2_ptx10001-36mr.conf) |
+| **ACX7100-48L** | L2/L3 Edge | [`l2-l3_edge_acx7100.conf`](configuration/conf/l2-l3_edge_acx7100.conf) |
 
 ---
 

--- a/optical/dci_over_ipodwdm/README.md
+++ b/optical/dci_over_ipodwdm/README.md
@@ -1,0 +1,36 @@
+# DCI over IP-over-DWDM
+
+> Data Center Interconnect leveraging IP-over-DWDM with coherent optics for cost-effective, high-capacity inter-site connectivity.
+
+Data Center Interconnect (DCI) using IP-over-DWDM eliminates the traditional optical transport layer by running coherent DWDM optics directly in routers, reducing cost and complexity while delivering high-capacity, low-latency inter-site connectivity.
+
+## Highlights
+
+- IP-over-DWDM eliminates standalone optical transport equipment
+- Coherent pluggable optics (ZR/ZR+) in router line cards
+- Validated across PTX, MX, and ACX platforms
+- Simplified operations — single management domain for IP + optical
+- Scalable DCI for metro and long-haul distances
+
+---
+
+## Validated Hardware
+
+| Juniper Product | Role | Config |
+|---|---|---|
+| **PTX10001-36MR** | DCI Router | [`dci1_ptx10001-36mr.conf`](configuration/conf/dci1_ptx10001-36mr.conf) |
+| **MX304** | DCI Router | [`dci2_mx304.conf`](configuration/conf/dci2_mx304.conf) |
+| **ACX7100-48L** | DCI Router | [`dci3_acx7100-48l.conf`](configuration/conf/dci3_acx7100-48l.conf) |
+
+---
+
+## Documentation
+
+- **JVD Document:**  
+  [DCI over IP-over-DWDM JVD](https://www.juniper.net/documentation/us/en/software/jvd/jvd-optics-base-01-01/index.html)
+
+- **Solution Overview:**  
+  [PDF Overview](https://www.juniper.net/documentation/us/en/software/jvd/solution-overview-optics-base-01-01.pdf)
+
+- **Test Report Brief:**  
+  [PDF Test Brief](https://www.juniper.net/documentation/us/en/software/jvd/test-report-brief-optics-base-01-01.pdf)

--- a/security/scale_out_firewall_nat/README.md
+++ b/security/scale_out_firewall_nat/README.md
@@ -1,5 +1,15 @@
 # Connected Security Distributed Services (CSDS)
 
+> Scale-out stateful firewall and CGNAT with MX load balancers distributing traffic across SRX clusters.
+
+## Highlights
+
+- MX Series as stateless load balancer for SRX-based stateful security services
+- Four deployment architectures: single/dual MX × standalone/MNHA SRX
+- ECMP Consistent Hashing and TLB/Traffic Orchestrator load balancing methods
+- Validated for both Service Provider (CGNAT) and Enterprise (Source NAT) scenarios
+- IPv4 and IPv6 support
+
 ## SCALEOUT – the technical architecture used by CSDS
 
 ---
@@ -101,4 +111,13 @@ Other config examples for **ECMP CHASH** and **TLB** variants are included in th
 | **IPSEC** | IP Security with IKE (v1/v2) and ESP encryption |
 
 ---
+
+## Validated Hardware
+
+| Juniper Product | Role | Config |
+|---|---|---|
+| **MX304** | Load Balancer / Traffic Orchestrator | [`mx1_mx304.conf`](configuration/conf/mx1_mx304.conf) |
+| **SRX4600** | Stateful Firewall + CGNAT (pair 1) | [`srx1a_srx4600.conf`](configuration/conf/srx1a_srx4600.conf), [`srx1b_srx4600.conf`](configuration/conf/srx1b_srx4600.conf) |
+| **SRX4600** | Stateful Firewall + CGNAT (pair 2) | [`srx2a_srx4600.conf`](configuration/conf/srx2a_srx4600.conf), [`srx2b_srx4600.conf`](configuration/conf/srx2b_srx4600.conf) |
+| — | Gateway emulator | [`gateway_emulator.conf`](configuration/conf/gateway_emulator.conf) |
 

--- a/security/scale_out_ipsec/README.md
+++ b/security/scale_out_ipsec/README.md
@@ -1,5 +1,15 @@
 # Connected Security Distributed Services (CSDS)
 
+> Scale-out IPsec with MX load balancers distributing encrypted tunnel traffic across SRX clusters.
+
+## Highlights
+
+- MX Series as stateless load balancer for SRX-based IPsec services
+- Four deployment architectures: single/dual MX × standalone/MNHA SRX
+- ECMP Consistent Hashing and TLB/Traffic Orchestrator load balancing methods
+- Validated for both Service Provider (mobile) and Enterprise IPsec scenarios
+- IKEv1/v2 with ESP encryption
+
 ## SCALEOUT – the technical architecture used by CSDS
 
 ---
@@ -101,3 +111,12 @@ Other config examples for **ECMP CHASH** and **TLB** variants are included in th
 | **IPSEC** | IP Security with IKE (v1/v2) and ESP encryption |
 
 ---
+
+## Validated Hardware
+
+| Juniper Product | Role | Config |
+|---|---|---|
+| **MX304** | Load Balancer / Traffic Orchestrator | [`mx304.conf`](configuration/conf/mx304.conf) |
+| **MX304** | IPsec Initiator Gateway | [`ipsec_initiator_gateway_mx304.conf`](configuration/conf/ipsec_initiator_gateway_mx304.conf) |
+| **SRX4600** | IPsec Endpoint (pair 1) | [`srx1a_srx4600.conf`](configuration/conf/srx1a_srx4600.conf), [`srx1b_srx4600.conf`](configuration/conf/srx1b_srx4600.conf) |
+| **SRX4600** | IPsec Endpoint (pair 2) | [`srx2a_srx4600.conf`](configuration/conf/srx2a_srx4600.conf), [`srx2b_srx4600.conf`](configuration/conf/srx2b_srx4600.conf) |

--- a/service_provider/broadband_edge/README.md
+++ b/service_provider/broadband_edge/README.md
@@ -1,6 +1,16 @@
 # Metro Fabric and Broadband Edge JVD
 
+> Cloud Metro fabric architecture for subscriber broadband access, integrating access, aggregation, and BNG functions with scale-out CGNAT.
+
 Use Cloud Metro fabric principles to stitch together access, aggregation, and BNG functions, simplifying deployment and reducing costs. This solution seamlessly integrates with Juniper's Scale-out Carrier Grade NAT (CGNAT) solution, enhancing network scalability and resilience while supporting dynamic expansion based on subscriber demand.
+
+## Highlights
+
+- Cloud Metro fabric spanning access, aggregation, and BNG domains
+- BNG validated across MX304, MX204, MX480, and MX10004 platforms
+- Stateless rapid-reconnect model for sub-second subscriber recovery
+- Integrated scale-out CGNAT for elastic subscriber capacity
+- TI-LFA fast reroute for sub-50ms transport convergence
 
 ---
 
@@ -14,6 +24,23 @@ Use Cloud Metro fabric principles to stitch together access, aggregation, and BN
 
 - **Test Report Brief:**  
   [PDF Test Brief](https://www.juniper.net/documentation/us/en/software/jvd/test-report-brief-metro-fabric-and-broadband-edge.pdf.pdf)
+
+---
+
+## Validated Hardware
+
+| Juniper Product | Role | Config |
+|---|---|---|
+| **PTX10004** | Core Router | [`cr1_ptx10004.conf`](configuration/conf/cr1_ptx10004.conf) |
+| **MX304** | BNG | [`bng1_mx304.conf`](configuration/conf/bng1_mx304.conf) |
+| **MX204** | BNG | [`bng2_mx204.conf`](configuration/conf/bng2_mx204.conf) |
+| **MX10004** | BNG | [`bng3_mx10004.conf`](configuration/conf/bng3_mx10004.conf) |
+| **MX480** | BNG | [`bng4_mx480.conf`](configuration/conf/bng4_mx480.conf) |
+| **ACX7100-32C** | Aggregation Node | [`agn1_acx7100-32c.conf`](configuration/conf/agn1_acx7100-32c.conf), [`agn2_acx7100-32c.conf`](configuration/conf/agn2_acx7100-32c.conf) |
+| **ACX7024** | Access Node | [`an1_acx7024.conf`](configuration/conf/an1_acx7024.conf) |
+| **ACX7100-48L** | Access Node | [`an2_acx7100-48l.conf`](configuration/conf/an2_acx7100-48l.conf), [`an3_acx7100-48l.conf`](configuration/conf/an3_acx7100-48l.conf), [`an4_acx7100-48l.conf`](configuration/conf/an4_acx7100-48l.conf), [`an5_acx7100-48l.conf`](configuration/conf/an5_acx7100-48l.conf) |
+| **QFX5120-32C** | Switch | [`sw1_qfx5120-32c.conf`](configuration/conf/sw1_qfx5120-32c.conf) |
+| **QFX5210-64C** | Switch | [`sw2_qfx5210-64c.conf`](configuration/conf/sw2_qfx5210-64c.conf) |
 
 ---
 

--- a/service_provider/low_latency_queueing/README.md
+++ b/service_provider/low_latency_queueing/README.md
@@ -31,9 +31,18 @@ Unlock the full potential of 5G with our Low-Latency QoS solutions, ensuring unp
   - **Fronthaul:** EVPN-VPWS (primary), EVPN-FXC, EVPN-ELAN, L3VPN
   - **Midhaul / Mobile Backhaul (MBH):** L3VPN, BGP-VPLS, L2Circuit
 
-- **Validated platforms (DUTs and extended roles)**
-  - **ACX7024** (CSR role), **ACX7100-32C** and **ACX7509** (HSR roles)
-  - Extended validation includes **MX304** as Services Aggregation Gateway (SAG) and **PTX10001-36MR** in the Core
+## Validated Platforms
+
+| Juniper Product | Role | OS | Config |
+|---|---|---|---|
+| **ACX7509** | HSR Aggregation | Junos EVO | [`ag1_1_acx7509.conf`](configuration/conf/ag1_1_acx7509.conf) |
+| **ACX7100-32C** | HSR Aggregation | Junos EVO | [`ag1_2_acx7100-32c.conf`](configuration/conf/ag1_2_acx7100-32c.conf) |
+| **MX204** | Aggregation | Junos | [`ag2_1_mx204.conf`](configuration/conf/ag2_1_mx204.conf), [`ag2_2_mx204.conf`](configuration/conf/ag2_2_mx204.conf) |
+| **MX480** | Aggregation | Junos | [`ag3_1_mx480.conf`](configuration/conf/ag3_1_mx480.conf), [`ag3_2_mx480.conf`](configuration/conf/ag3_2_mx480.conf) |
+| **ACX7100-48L** | Access Node | Junos EVO | [`an1_acx7100-48l.conf`](configuration/conf/an1_acx7100-48l.conf), [`an3_acx7100-48l.conf`](configuration/conf/an3_acx7100-48l.conf) |
+| **ACX7024** | CSR Access Node | Junos EVO | [`an4_acx7024.conf`](configuration/conf/an4_acx7024.conf) |
+| **PTX10001-36MR** | Core Router | Junos EVO | [`cr1_ptx10001-36mr.conf`](configuration/conf/cr1_ptx10001-36mr.conf), [`cr2_ptx10001-36mr.conf`](configuration/conf/cr2_ptx10001-36mr.conf) |
+| **MX304** | Services Aggregation Gateway | Junos | [`sag_mx304.conf`](configuration/conf/sag_mx304.conf) |
 
 ---
 

--- a/service_provider/metro_as_a_service/README.md
+++ b/service_provider/metro_as_a_service/README.md
@@ -1,5 +1,15 @@
 # Metro as a Service (MaaS) — Juniper Validated Design (JVD)
 
+> Full end-to-end MEF 3.0 conformance over a Cloud Metro architecture with EVPN-FXC, EVPN-ETREE, BGP-VPLS, and floating pseudowires.
+
+## Highlights
+
+- First JVD to achieve full MEF 3.0 conformance end-to-end
+- Extends Metro EBS with EVPN-FXC, EVPN-ETREE, EVPN-ELAN Type-5, BGP-VPLS E2E, and Floating Pseudowires
+- Cloud Metro architecture with SR-MPLS transport and multi-ring core
+- Mixed ACX (access/aggregation) and MX (edge/core) hardware
+- E-Line, E-LAN, E-Tree, and E-Access MEF service layers validated
+
 Metro as a Service (MaaS) is the first Juniper Validated Design to achieve
 full end-to-end **MEF 3.0 conformance** over a **Cloud Metro architecture**.
 It extends the

--- a/service_provider/metro_ethernet_business_services/README.md
+++ b/service_provider/metro_ethernet_business_services/README.md
@@ -1,5 +1,7 @@
 # Metro Ethernet Business Services – Juniper Validated Design (JVD)
 
+> Production-ready Cloud Metro architecture with MEF 3.0 EVPN, VPLS, L2VPN, and L3VPN services across a scalable Metro Fabric and multi-ring core.
+
 The Metro Ethernet Business Services (Metro EBS) JVD defines a production-ready Cloud Metro architecture composed of a scalable Metro Fabric for access and aggregation, seamlessly integrated with a resilient multi-ring core. This validated design enables x-to-anything connectivity across MEF 3.0-compliant EVPN, VPLS, L2VPN, and L3VPN services. Leveraging Juniper ACX, MX, and PTX Series platforms, the solution supports interdomain color-aware transport, TI-LFA-based resiliency, and intent-based traffic steering for high-performance, future-ready metro deployments.
 
 ---
@@ -58,6 +60,24 @@ This solution is extended by the [Metro as a Service (MaaS) JVD](https://www.jun
 
 - **GitHub Configurations:**  
   [Metro as a Service](../metro_as_a_service/)
+
+---
+
+## Validated Hardware
+
+| Juniper Product | Role | Config |
+|---|---|---|
+| **PTX10001-36MR** | Core Router | [`cr1_ptx10001-36mr.conf`](configuration/conf/cr1_ptx10001-36mr.conf), [`cr2_ptx10001-36mr.conf`](configuration/conf/cr2_ptx10001-36mr.conf) |
+| **ACX7509** | Metro Domain Router | [`mdr1_acx7509.conf`](configuration/conf/mdr1_acx7509.conf) |
+| **MX10003** | Metro Domain Router | [`mdr2_mx10003.conf`](configuration/conf/mdr2_mx10003.conf) |
+| **ACX7100-32C** | Metro Edge Gateway | [`meg1_acx7100-32c.conf`](configuration/conf/meg1_acx7100-32c.conf), [`meg2_acx7509.conf`](configuration/conf/meg2_acx7509.conf) |
+| **MX304** | Metro SE | [`mse1_mx304.conf`](configuration/conf/mse1_mx304.conf), [`mse2_mx304.conf`](configuration/conf/mse2_mx304.conf) |
+| **MX204** | Metro Aggregation / Access Node | [`ma2_mx204.conf`](configuration/conf/ma2_mx204.conf), [`ma4_mx204.conf`](configuration/conf/ma4_mx204.conf), [`ma5_mx204.conf`](configuration/conf/ma5_mx204.conf), [`an1_mx204.conf`](configuration/conf/an1_mx204.conf) |
+| **ACX7024** | Metro Aggregation | [`ma1-1_acx7024.conf`](configuration/conf/ma1-1_acx7024.conf), [`ma1-2_acx7024.conf`](configuration/conf/ma1-2_acx7024.conf) |
+| **ACX7100-48L** | Metro Aggregation / Access Node | [`ma3_acx7100-48l.conf`](configuration/conf/ma3_acx7100-48l.conf), [`an3_acx7100-48l.conf`](configuration/conf/an3_acx7100-48l.conf) |
+| **ACX5448** | Access Node | [`an2_acx5448.conf`](configuration/conf/an2_acx5448.conf) |
+| **ACX710** | Access Node | [`an4_acx710.conf`](configuration/conf/an4_acx710.conf) |
+| **ACX7100-32C** | Aggregation Gateway | [`ag1-1_acx7100-32c.conf`](configuration/conf/ag1-1_acx7100-32c.conf), [`ag1-2_acx7100-32c.conf`](configuration/conf/ag1-2_acx7100-32c.conf) |
 
 ---
 

--- a/service_provider/port_fan_out/README.md
+++ b/service_provider/port_fan_out/README.md
@@ -1,9 +1,22 @@
-# <h3> Configurations provided for the Juniper Networks Validated Design for Port Fan-Out.
+# Port Fan-Out
+
+> Cost-effective port density expansion using channelized optics on Metro and DC platforms.
 
 Implement Juniper's port fan-out solution to achieve cost savings, port flexibility, and a higher density of ports in your network. Benefit from reduced complexity and operational costs.
 
-Solution Design
-https://www.juniper.net/documentation/us/en/software/jvd/jvd-metro-port-fanout-04-01/index.html
+## Highlights
 
-Solution Overview
-https://www.juniper.net/documentation/us/en/software/jvd/sol-brief-metro-port-fanout-04-01.pdf
+- Channelized optics for 4×10G or 4×25G breakout from single high-speed ports
+- Cost reduction through higher effective port density
+- Reduced cabling and operational complexity
+- Validated on Cloud Metro access and aggregation platforms
+
+---
+
+## Documentation
+
+- **Solution Design:**  
+  [Port Fan-Out JVD](https://www.juniper.net/documentation/us/en/software/jvd/jvd-metro-port-fanout-04-01/index.html)
+
+- **Solution Overview:**  
+  [PDF Overview](https://www.juniper.net/documentation/us/en/software/jvd/sol-brief-metro-port-fanout-04-01.pdf)


### PR DESCRIPTION
## What's New

Standardizes all 20 JVD READMEs against a consistent template with tiered (MUST/SHOULD/MAY) fields.

- Added one-line summary blockquotes to 17 JVDs
- Added Highlights sections (4–6 bullets each) to 16 JVDs
- Added Validated Hardware tables with config file links to 7 JVDs
- Corrected/added JVD documentation links for 3 JVDs (DCI, EWAN Core Edge, Port Fan-Out)
- Reformatted ewan_finance HW section from bullet list to proper table with config links
- Created new README for dci_over_ipodwdm (previously had none)

## Why

README quality varied widely — some had full docs + images + HW tables, others were one-liners with raw URLs. This makes the repo harder to navigate for customers and internal teams browsing GitHub.

## Details

19 files changed, +281/−18. All existing content preserved — no deletions of substance. Changes are additive: summary blockquotes, highlights, hardware tables, and doc link sections.

Three JVDs still have gaps that require team-provided assets:
- `ewan_core_edge` and `port_fan_out`: need config files + topology images added to the repo
- `dci_over_ipodwdm`: needs a topology image

Three audit "false negatives" require no action: collapsed_dc_fabric and collapsed_dc_fabric_with_access use HTML `<img>` tags (valid), evpn_vxlan_sflow_apstra uses `.set` files (valid).

## Testing

Ran automated README audit script against all 20 JVDs before and after. 14/20 now score 7/7 on MUST fields (up from 5/20). Remaining 6 are blocked on missing source assets, not README content.