### PR TITLE
chore(portal): BYOAI beta pill, generator coming-soon, prompt marker fix

### DIFF
--- a/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
@@ -187,9 +187,9 @@ the actual .conf snip BODIES to render config. Check for them:
 ---
 MODE SELECTION — once corpus state is determined, present the mode
 menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output VERBATIM:
+a fetch). Output exactly the text below (the "Hi — …" block), then
+STOP. Do NOT print these instruction lines or any surrounding markers:
 
-    <<<MODE_MENU_BEGIN>>>
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
 
@@ -206,7 +206,6 @@ a fetch). Output VERBATIM:
        documentation as my primary reference and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
-    <<<MODE_MENU_END>>>
 
 After the user responds:
   - If they pick Configuration mode OR state a concrete generation
@@ -255,9 +254,10 @@ SNIP RENDERING (Configuration mode):
   read those snips from the loaded jvd-maas-snips.md bundle. If the
   bundle is not loaded, ask the user to attach it before generating.
 
-STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
+STEP 1 — SERVICE PROFILE (what kind of Ethernet service). Output
+exactly the text below (do not print this instruction line or any
+markers), then STOP:
 
-    <<<PROFILE_MENU_BEGIN>>>
     Hi — I generate Junos and Junos Evolved configuration from the
     Metro-as-a-Service JVD's validated MEF Ethernet-service snippets.
 
@@ -279,7 +279,6 @@ STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
 
     For the full catalog of everything this JVD can build, see:
     https://github.com/Juniper/jvd/blob/main/service_provider/metro_as_a_service/configuration/snips/byoai/MENU.md
-    <<<PROFILE_MENU_END>>>
 
 STEP 2 — SERVICE MULTIPLEXING (port vs VLAN) — ask only when the chosen
 profile has both a port-based and VLAN-based flavor (E-Line, E-LAN):

--- a/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
+++ b/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
@@ -165,9 +165,9 @@ the actual .conf snip BODIES to render config. Check for them:
 ---
 MODE SELECTION — once corpus state is determined, present the mode
 menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output VERBATIM:
+a fetch). Output exactly the text below (the "Hi — …" block), then
+STOP. Do NOT print these instruction lines or any surrounding markers:
 
-    <<<MODE_MENU_BEGIN>>>
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
 
@@ -184,7 +184,6 @@ a fetch). Output VERBATIM:
        documentation as my primary reference and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
-    <<<MODE_MENU_END>>>
 
 After the user responds:
   - If they pick Configuration mode OR state a concrete generation
@@ -233,9 +232,10 @@ SNIP RENDERING (Configuration mode):
   read those snips from the loaded jvd-maas-snips.md bundle. If the
   bundle is not loaded, ask the user to attach it before generating.
 
-STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
+STEP 1 — SERVICE PROFILE (what kind of Ethernet service). Output
+exactly the text below (do not print this instruction line or any
+markers), then STOP:
 
-    <<<PROFILE_MENU_BEGIN>>>
     Hi — I generate Junos and Junos Evolved configuration from the
     Metro-as-a-Service JVD's validated MEF Ethernet-service snippets.
 
@@ -257,7 +257,6 @@ STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
 
     For the full catalog of everything this JVD can build, see:
     https://github.com/Juniper/jvd/blob/main/service_provider/metro_as_a_service/configuration/snips/byoai/MENU.md
-    <<<PROFILE_MENU_END>>>
 
 STEP 2 — SERVICE MULTIPLEXING (port vs VLAN) — ask only when the chosen
 profile has both a port-based and VLAN-based flavor (E-Line, E-LAN):

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -78,6 +78,9 @@ export default function ByoaiSection() {
               <span className="ml-1 inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
                 Available now
               </span>
+              <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400">
+                Beta
+              </span>
             </div>
             <p className="mt-3 max-w-2xl text-sm text-muted-foreground">
               Generate Junos and Junos EVO configuration with the AI you already use. Pick a JVD,
@@ -164,7 +167,7 @@ export default function ByoaiSection() {
               <AiTile
                 name="ChatGPT"
                 description="OpenAI's web app. Wide reach and good for quick, single-shot config snippets."
-                tip="Tip: use Instant mode for the fastest experience."
+                tip="Tip: use Instant mode + a Temporary Chat (avoids memory carryover between sessions)."
                 href={chatGptUrl}
                 disabled={!selected}
                 logo={<ChatGptLogo />}

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -329,9 +329,16 @@ export default function JvdPortal() {
       {/* Generator */}
       <section id="generator" className="border-b border-border">
         <div className="mx-auto max-w-7xl px-6 py-24">
-          <h2 className="text-3xl font-semibold tracking-tight">JVD Config Generator</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-3xl font-semibold tracking-tight">JVD Config Generator</h2>
+            <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400">
+              Coming soon
+            </span>
+          </div>
           <p className="mt-3 max-w-2xl text-muted-foreground">
-            Pick a JVD, choose your device role, get a templated configuration.
+            A deterministic, no-AI config builder: pick a service, choose your
+            options, fill in the parameters, and download validated Junos /
+            Junos EVO configuration rendered straight from the JVD snip library.
           </p>
 
           <div className="mt-10 grid gap-4 md:grid-cols-3">
@@ -357,7 +364,7 @@ export default function JvdPortal() {
             >
               Launch Generator
             </button>
-            <span className="text-xs text-muted-foreground">In development</span>
+            <span className="text-xs text-muted-foreground">Coming soon</span>
           </div>
         </div>
       </section>

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-06T19:07:48.950Z",
+  "generatedAt": "2026-07-06T21:59:27.402Z",
   "counts": {
     "total": 515,
     "junos": 248,

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -187,9 +187,9 @@ the actual .conf snip BODIES to render config. Check for them:
 ---
 MODE SELECTION — once corpus state is determined, present the mode
 menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output VERBATIM:
+a fetch). Output exactly the text below (the "Hi — …" block), then
+STOP. Do NOT print these instruction lines or any surrounding markers:
 
-    <<<MODE_MENU_BEGIN>>>
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
 
@@ -206,7 +206,6 @@ a fetch). Output VERBATIM:
        documentation as my primary reference and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
-    <<<MODE_MENU_END>>>
 
 After the user responds:
   - If they pick Configuration mode OR state a concrete generation
@@ -255,9 +254,10 @@ SNIP RENDERING (Configuration mode):
   read those snips from the loaded jvd-maas-snips.md bundle. If the
   bundle is not loaded, ask the user to attach it before generating.
 
-STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
+STEP 1 — SERVICE PROFILE (what kind of Ethernet service). Output
+exactly the text below (do not print this instruction line or any
+markers), then STOP:
 
-    <<<PROFILE_MENU_BEGIN>>>
     Hi — I generate Junos and Junos Evolved configuration from the
     Metro-as-a-Service JVD's validated MEF Ethernet-service snippets.
 
@@ -279,7 +279,6 @@ STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
 
     For the full catalog of everything this JVD can build, see:
     https://github.com/Juniper/jvd/blob/main/service_provider/metro_as_a_service/configuration/snips/byoai/MENU.md
-    <<<PROFILE_MENU_END>>>
 
 STEP 2 — SERVICE MULTIPLEXING (port vs VLAN) — ask only when the chosen
 profile has both a port-based and VLAN-based flavor (E-Line, E-LAN):

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
@@ -165,9 +165,9 @@ the actual .conf snip BODIES to render config. Check for them:
 ---
 MODE SELECTION — once corpus state is determined, present the mode
 menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output VERBATIM:
+a fetch). Output exactly the text below (the "Hi — …" block), then
+STOP. Do NOT print these instruction lines or any surrounding markers:
 
-    <<<MODE_MENU_BEGIN>>>
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
 
@@ -184,7 +184,6 @@ a fetch). Output VERBATIM:
        documentation as my primary reference and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
-    <<<MODE_MENU_END>>>
 
 After the user responds:
   - If they pick Configuration mode OR state a concrete generation
@@ -233,9 +232,10 @@ SNIP RENDERING (Configuration mode):
   read those snips from the loaded jvd-maas-snips.md bundle. If the
   bundle is not loaded, ask the user to attach it before generating.
 
-STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
+STEP 1 — SERVICE PROFILE (what kind of Ethernet service). Output
+exactly the text below (do not print this instruction line or any
+markers), then STOP:
 
-    <<<PROFILE_MENU_BEGIN>>>
     Hi — I generate Junos and Junos Evolved configuration from the
     Metro-as-a-Service JVD's validated MEF Ethernet-service snippets.
 
@@ -257,7 +257,6 @@ STEP 1 — SERVICE PROFILE (what kind of Ethernet service):
 
     For the full catalog of everything this JVD can build, see:
     https://github.com/Juniper/jvd/blob/main/service_provider/metro_as_a_service/configuration/snips/byoai/MENU.md
-    <<<PROFILE_MENU_END>>>
 
 STEP 2 — SERVICE MULTIPLEXING (port vs VLAN) — ask only when the chosen
 profile has both a port-based and VLAN-based flavor (E-Line, E-LAN):


### PR DESCRIPTION
## What's New

Portal polish to set expectations while BYOAI matures and to preview the upcoming config generator:

- **"Beta" pill** on the Bring Your Own AI section (amber, next to the existing "Available Now") — signals it's still stabilizing.
- **"Coming Soon"** treatment on the JVD Config Generator, with copy describing it as a deterministic, no-AI config builder (the direction we're taking that feature).
- **Temp-chat tip** on the ChatGPT launch tile — recommends Instant mode + a Temporary Chat to avoid ChatGPT memory carrying context between sessions.
- **Prompt marker fix** — removed the `<<<MODE_MENU_BEGIN>>>` / `<<<PROFILE_MENU_BEGIN>>>` delimiters from the MaaS prompt that some models (e.g. Claude Haiku) were printing literally in their output.

## Why

- BYOAI is live but still being refined; a Beta pill sets honest expectations.
- The rigid guided funnel is moving to a deterministic portal generator (code, not prompt), so the generator section now previews that.
- ChatGPT's cross-session memory was injecting unrelated context (e.g. a prior Cisco-translation chat) into BYOAI sessions — the temp-chat tip mitigates that.
- The instruction markers were never meant to be user-visible.

## Details

- `ByoaiSection.tsx` — added amber Beta pill; updated ChatGPT tile tip.
- `JvdPortal.tsx` — Generator section: Coming Soon pill + revised description + "Coming soon" button note.
- `SYSTEM_PROMPT.md` — replaced `<<<…>>>` marker framing with plain "Output exactly the text below, then STOP" instructions; regenerated `jvd-maas-byoai-prompt.txt` + portal mirror.

## Testing

- `bun run build`: clean (exit 0)
- `generate-snips.mjs --check`: OK (515 snips, 9 JVDs)
- No `<<<` markers remain in the prompt or bundle
- No type errors in edited components

## Notes

- BYOAI's larger reliability work (moving the rigid funnel to a deterministic portal generator) is the next, separate effort. This PR only adds the Beta label + the marker fix; the funnel logic itself is unchanged.
