### PR TITLE
feat(portal): deterministic Config Generator (MaaS E-Line)

### DIFF
--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -81,6 +81,7 @@ type Selection = {
   homing?: string;
   color?: string;
   cos: boolean;
+  firewall: boolean;
 };
 
 function Chip({
@@ -126,7 +127,7 @@ export default function ConfigGenerator() {
     return m;
   }, []);
 
-  const [sel, setSel] = useState<Selection>({ cos: true });
+  const [sel, setSel] = useState<Selection>({ cos: true, firewall: true });
   const [vars, setVars] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState(false);
   const [step, setStep] = useState(0);
@@ -146,7 +147,7 @@ export default function ConfigGenerator() {
       : null;
   const attrs = osBlock ? attributeOptions(osBlock) : { homing: [], color: [] };
 
-  const attrsComplete = Boolean(sel.homing && (!sel.cos || sel.color));
+  const attrsComplete = Boolean(sel.homing && (!sel.firewall || sel.color));
   const currentStep = STEPS[Math.min(step, STEPS.length - 1)];
 
   const complete = Boolean(
@@ -155,7 +156,7 @@ export default function ConfigGenerator() {
       sel.deploymentId &&
       sel.os &&
       sel.homing &&
-      (!sel.cos || sel.color),
+      (!sel.firewall || sel.color),
   );
 
   const resolvedIds = useMemo(() => {
@@ -168,6 +169,7 @@ export default function ConfigGenerator() {
       homing: sel.homing!,
       color: sel.color ?? "",
       cos: sel.cos,
+      firewall: sel.firewall,
     });
   }, [complete, sel]);
 
@@ -184,6 +186,7 @@ export default function ConfigGenerator() {
     sel.homing,
     sel.color,
     sel.cos,
+    sel.firewall,
   ]);
   useEffect(() => {
     const seed: Record<string, string> = {};
@@ -223,9 +226,10 @@ export default function ConfigGenerator() {
         return attrsComplete
           ? [
               HOMING_LABELS[sel.homing!] ?? sel.homing,
-              sel.cos
-                ? `With CoS · ${COLOR_LABELS[sel.color!] ?? sel.color}`
-                : "Service only",
+              sel.cos ? "CoS" : "no CoS",
+              sel.firewall
+                ? `filter (${COLOR_LABELS[sel.color!] ?? sel.color})`
+                : "no filter",
             ].join(" · ")
           : null;
       default:
@@ -236,7 +240,7 @@ export default function ConfigGenerator() {
   const crumbs = STEPS.slice(0, step).filter((id) => crumbValue(id) !== null);
 
   const reset = () => {
-    setSel({ cos: true });
+    setSel({ cos: true, firewall: true });
     setVars({});
     setStep(0);
   };
@@ -417,20 +421,40 @@ export default function ConfigGenerator() {
                 <div className="space-y-2">
                   <Chip
                     label="With CoS"
-                    sub="Classifiers, scheduler binding + UNI firewall filter"
+                    sub="Classifiers, IEEE 802.1p binding + rewrite rules"
                     active={sel.cos}
                     onClick={() => setSel((p) => ({ ...p, cos: true }))}
                   />
                   <Chip
-                    label="Service only"
-                    sub="Routing-instance + interface (minimum)"
+                    label="Without CoS"
+                    sub="Skip class-of-service"
                     active={!sel.cos}
-                    onClick={() => setSel((p) => ({ ...p, cos: false, color: undefined }))}
+                    onClick={() => setSel((p) => ({ ...p, cos: false }))}
                   />
                 </div>
               </div>
 
-              {sel.cos && (
+              <div>
+                <div className="mb-2 text-xs font-medium text-foreground">
+                  UNI firewall filter
+                </div>
+                <div className="space-y-2">
+                  <Chip
+                    label="With filter"
+                    sub="Bandwidth-profile policer at the customer UNI"
+                    active={sel.firewall}
+                    onClick={() => setSel((p) => ({ ...p, firewall: true }))}
+                  />
+                  <Chip
+                    label="Without filter"
+                    sub="No UNI policer"
+                    active={!sel.firewall}
+                    onClick={() => setSel((p) => ({ ...p, firewall: false, color: undefined }))}
+                  />
+                </div>
+              </div>
+
+              {sel.firewall && (
                 <div>
                   <div className="mb-2 text-xs font-medium text-foreground">Color mode</div>
                   <div className="space-y-2">
@@ -540,8 +564,10 @@ export default function ConfigGenerator() {
               </pre>
               <div className="mt-2 text-[11px] text-muted-foreground">
                 {resolvedIds.length} snip{resolvedIds.length === 1 ? "" : "s"} ·{" "}
-                {sel.cos ? "with-cos" : "minimum"} tier · rendered client-side from the
-                JVD snip library
+                {[sel.cos && "CoS", sel.firewall && "firewall filter"]
+                  .filter(Boolean)
+                  .join(" + ") || "service only"}{" "}
+                · rendered client-side from the JVD snip library
               </div>
             </>
           )}

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { Cpu, Download, Copy, Check, AlertTriangle } from "lucide-react";
+import {
+  Cpu,
+  Download,
+  Copy,
+  Check,
+  AlertTriangle,
+  ChevronLeft,
+  ChevronRight,
+  RotateCcw,
+} from "lucide-react";
 import { snipBundle, type SnipRecord } from "@/lib/snips";
 import maasCatalog from "@/data/generator/metro_as_a_service.json";
 import {
@@ -14,6 +23,16 @@ import {
 
 const CATALOG = maasCatalog as unknown as GenCatalog;
 
+/** JVDs available in the generator. Only MaaS has a catalog today. */
+const JVDS = [
+  {
+    id: "metro_as_a_service",
+    label: CATALOG.jvdLabel,
+    available: true,
+    tagline: "MEF Carrier Ethernet services",
+  },
+];
+
 const HOMING_LABELS: Record<string, string> = {
   "single-homed": "Single-homed",
   multihomed: "Multihomed (all-active ESI)",
@@ -24,7 +43,37 @@ const COLOR_LABELS: Record<string, string> = {
 };
 const OS_LABELS: Record<GenOsKey, string> = { evo: "Junos EVO", junos: "Junos" };
 
+type StepId =
+  | "jvd"
+  | "family"
+  | "mux"
+  | "deployment"
+  | "os"
+  | "attributes"
+  | "params";
+
+const STEP_TITLES: Record<StepId, string> = {
+  jvd: "Choose a JVD",
+  family: "Service type",
+  mux: "Service profile",
+  deployment: "Deployment",
+  os: "Device OS",
+  attributes: "Service attributes",
+  params: "Parameters",
+};
+
+const STEPS: StepId[] = [
+  "jvd",
+  "family",
+  "mux",
+  "deployment",
+  "os",
+  "attributes",
+  "params",
+];
+
 type Selection = {
+  jvd?: string;
   familyId?: string;
   muxId?: string;
   deploymentId?: string;
@@ -53,7 +102,7 @@ function Chip({
       disabled={disabled}
       onClick={onClick}
       className={[
-        "rounded-lg border px-4 py-3 text-left transition-colors",
+        "flex w-full items-center justify-between gap-3 rounded-lg border px-4 py-3 text-left transition-colors",
         disabled
           ? "cursor-not-allowed border-dashed border-border opacity-50"
           : active
@@ -61,22 +110,12 @@ function Chip({
             : "border-border bg-background hover:border-primary/50",
       ].join(" ")}
     >
-      <div className="text-sm font-medium text-foreground">{label}</div>
-      {sub && <div className="mt-0.5 text-xs text-muted-foreground">{sub}</div>}
+      <span>
+        <span className="block text-sm font-medium text-foreground">{label}</span>
+        {sub && <span className="mt-0.5 block text-xs text-muted-foreground">{sub}</span>}
+      </span>
+      {!disabled && <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
     </button>
-  );
-}
-
-function StepLabel({ n, title }: { n: number; title: string }) {
-  return (
-    <div className="flex items-center gap-2">
-      <span className="flex h-6 w-6 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-xs font-semibold text-primary">
-        {n}
-      </span>
-      <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-        {title}
-      </span>
-    </div>
   );
 }
 
@@ -90,6 +129,7 @@ export default function ConfigGenerator() {
   const [sel, setSel] = useState<Selection>({ cos: true });
   const [vars, setVars] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState(false);
+  const [step, setStep] = useState(0);
 
   const family = CATALOG.families.find((f) => f.id === sel.familyId);
   const mux = family?.multiplexing.find((m) => m.id === sel.muxId);
@@ -105,6 +145,9 @@ export default function ConfigGenerator() {
         })
       : null;
   const attrs = osBlock ? attributeOptions(osBlock) : { homing: [], color: [] };
+
+  const attrsComplete = Boolean(sel.homing && (!sel.cos || sel.color));
+  const currentStep = STEPS[Math.min(step, STEPS.length - 1)];
 
   const complete = Boolean(
     sel.familyId &&
@@ -133,8 +176,6 @@ export default function ConfigGenerator() {
     [resolvedIds, byId],
   );
 
-  // Seed the parameter form with lab-safe example values whenever the
-  // resolved path changes.
   const pathKey = JSON.stringify([
     sel.familyId,
     sel.muxId,
@@ -156,13 +197,49 @@ export default function ConfigGenerator() {
     return renderConfig(resolvedIds, vars, byId);
   }, [complete, resolvedIds, vars, byId]);
 
-  // Setters that clear downstream state.
-  const pick = (patch: Partial<Selection>, clears: (keyof Selection)[]) =>
+  // Update selection, clearing downstream fields, then advance one step.
+  const advance = (patch: Partial<Selection>, clears: (keyof Selection)[]) => {
     setSel((prev) => {
       const next = { ...prev, ...patch };
       for (const k of clears) if (!(k in patch)) delete next[k];
       return next;
     });
+    setStep((s) => s + 1);
+  };
+
+  const crumbValue = (id: StepId): string | null => {
+    switch (id) {
+      case "jvd":
+        return sel.jvd ? JVDS.find((j) => j.id === sel.jvd)?.label ?? null : null;
+      case "family":
+        return family?.label ?? null;
+      case "mux":
+        return mux?.label ?? null;
+      case "deployment":
+        return deployment?.label ?? null;
+      case "os":
+        return sel.os ? OS_LABELS[sel.os] : null;
+      case "attributes":
+        return attrsComplete
+          ? [
+              HOMING_LABELS[sel.homing!] ?? sel.homing,
+              sel.cos
+                ? `With CoS · ${COLOR_LABELS[sel.color!] ?? sel.color}`
+                : "Service only",
+            ].join(" · ")
+          : null;
+      default:
+        return null;
+    }
+  };
+
+  const crumbs = STEPS.slice(0, step).filter((id) => crumbValue(id) !== null);
+
+  const reset = () => {
+    setSel({ cos: true });
+    setVars({});
+    setStep(0);
+  };
 
   const download = () => {
     if (!render) return;
@@ -185,21 +262,66 @@ export default function ConfigGenerator() {
 
   return (
     <div className="mt-10 grid gap-6 lg:grid-cols-[1fr_minmax(22rem,32rem)]">
-      {/* Left: the funnel */}
-      <div className="space-y-6">
-        {/* Step 1 — Service family */}
-        <div className="rounded-lg border border-border bg-surface p-6">
-          <StepLabel n={1} title="Service type" />
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            {CATALOG.families.map((f) => (
+      {/* Left: the wizard (one step at a time) */}
+      <div className="rounded-lg border border-border bg-surface p-6">
+        {/* Breadcrumb of prior choices */}
+        {crumbs.length > 0 && (
+          <div className="mb-4 flex flex-wrap items-center gap-1.5 text-xs">
+            {crumbs.map((id, i) => (
+              <span key={id} className="flex items-center gap-1.5">
+                <button
+                  onClick={() => setStep(STEPS.indexOf(id))}
+                  className="rounded-full border border-border bg-background px-2.5 py-0.5 text-muted-foreground hover:border-primary/50 hover:text-primary"
+                  title={`Back to ${STEP_TITLES[id]}`}
+                >
+                  {crumbValue(id)}
+                </button>
+                {i < crumbs.length - 1 && (
+                  <ChevronRight className="h-3 w-3 text-muted-foreground/50" />
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Header: back + step counter + start over */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {step > 0 && (
+              <button
+                onClick={() => setStep((s) => Math.max(0, s - 1))}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:text-primary"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" /> Back
+              </button>
+            )}
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Step {step + 1} of {STEPS.length} · {STEP_TITLES[currentStep]}
+            </span>
+          </div>
+          {step > 0 && (
+            <button
+              onClick={reset}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary"
+            >
+              <RotateCcw className="h-3 w-3" /> Start over
+            </button>
+          )}
+        </div>
+
+        {/* Current step body */}
+        <div className="mt-4 space-y-3">
+          {currentStep === "jvd" &&
+            JVDS.map((j) => (
               <Chip
-                key={f.id}
-                label={f.available ? f.label : `${f.label} — coming soon`}
-                sub={f.tagline + " · " + f.description}
-                active={sel.familyId === f.id}
-                disabled={!f.available}
+                key={j.id}
+                label={j.available ? j.label : `${j.label} — coming soon`}
+                sub={j.tagline}
+                active={sel.jvd === j.id}
+                disabled={!j.available}
                 onClick={() =>
-                  pick({ familyId: f.id }, [
+                  advance({ jvd: j.id }, [
+                    "familyId",
                     "muxId",
                     "deploymentId",
                     "os",
@@ -209,88 +331,80 @@ export default function ConfigGenerator() {
                 }
               />
             ))}
-          </div>
-        </div>
 
-        {/* Step 2 — Multiplexing */}
-        {family?.available && (
-          <div className="rounded-lg border border-border bg-surface p-6">
-            <StepLabel n={2} title="Service profile" />
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              {family.multiplexing.map((m) => (
-                <Chip
-                  key={m.id}
-                  label={m.label}
-                  sub={m.description}
-                  active={sel.muxId === m.id}
-                  onClick={() =>
-                    pick({ muxId: m.id }, ["deploymentId", "os", "homing", "color"])
-                  }
-                />
-              ))}
-            </div>
-          </div>
-        )}
+          {currentStep === "family" &&
+            CATALOG.families.map((f) => (
+              <Chip
+                key={f.id}
+                label={f.available ? f.label : `${f.label} — coming soon`}
+                sub={`${f.tagline} · ${f.description}`}
+                active={sel.familyId === f.id}
+                disabled={!f.available}
+                onClick={() =>
+                  advance({ familyId: f.id }, [
+                    "muxId",
+                    "deploymentId",
+                    "os",
+                    "homing",
+                    "color",
+                  ])
+                }
+              />
+            ))}
 
-        {/* Step 3 — Deployment */}
-        {mux && (
-          <div className="rounded-lg border border-border bg-surface p-6">
-            <StepLabel n={3} title="Deployment" />
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              {mux.deployments.map((d) => (
-                <Chip
-                  key={d.id}
-                  label={d.label}
-                  sub={d.description}
-                  active={sel.deploymentId === d.id}
-                  onClick={() =>
-                    pick({ deploymentId: d.id }, ["os", "homing", "color"])
-                  }
-                />
-              ))}
-            </div>
-          </div>
-        )}
+          {currentStep === "mux" &&
+            family?.multiplexing.map((m) => (
+              <Chip
+                key={m.id}
+                label={m.label}
+                sub={m.description}
+                active={sel.muxId === m.id}
+                onClick={() =>
+                  advance({ muxId: m.id }, ["deploymentId", "os", "homing", "color"])
+                }
+              />
+            ))}
 
-        {/* Step 4 — OS / device family */}
-        {deployment && (
-          <div className="rounded-lg border border-border bg-surface p-6">
-            <StepLabel n={4} title="Device OS" />
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              {(["junos", "evo"] as GenOsKey[]).map((os) => (
-                <Chip
-                  key={os}
-                  label={OS_LABELS[os]}
-                  sub={
-                    osOptions.includes(os)
-                      ? os === "evo"
-                        ? "ACX 7xxx"
-                        : "MX, ACX 5xxx / 710"
-                      : "not validated for this service"
-                  }
-                  active={sel.os === os}
-                  disabled={!osOptions.includes(os)}
-                  onClick={() => pick({ os }, ["homing", "color"])}
-                />
-              ))}
-            </div>
-          </div>
-        )}
+          {currentStep === "deployment" &&
+            mux?.deployments.map((d) => (
+              <Chip
+                key={d.id}
+                label={d.label}
+                sub={d.description}
+                active={sel.deploymentId === d.id}
+                onClick={() => advance({ deploymentId: d.id }, ["os", "homing", "color"])}
+              />
+            ))}
 
-        {/* Step 5 — Attributes */}
-        {osBlock && (
-          <div className="rounded-lg border border-border bg-surface p-6">
-            <StepLabel n={5} title="Service attributes" />
-            <div className="mt-4 space-y-4">
+          {currentStep === "os" &&
+            (["junos", "evo"] as GenOsKey[]).map((os) => (
+              <Chip
+                key={os}
+                label={OS_LABELS[os]}
+                sub={
+                  osOptions.includes(os)
+                    ? os === "evo"
+                      ? "ACX 7xxx"
+                      : "MX, ACX 5xxx / 710"
+                    : "not validated for this service"
+                }
+                active={sel.os === os}
+                disabled={!osOptions.includes(os)}
+                onClick={() => advance({ os }, ["homing", "color"])}
+              />
+            ))}
+
+          {currentStep === "attributes" && osBlock && (
+            <div className="space-y-4">
               <div>
                 <div className="mb-2 text-xs font-medium text-foreground">Homing</div>
-                <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
                   {attrs.homing.map((h) => (
                     <Chip
                       key={h}
                       label={HOMING_LABELS[h] ?? h}
                       active={sel.homing === h}
-                      onClick={() => pick({ homing: h }, [])}
+                      onClick={() => setSel((p) => ({ ...p, homing: h }))}
                     />
                   ))}
                 </div>
@@ -300,69 +414,86 @@ export default function ConfigGenerator() {
                 <div className="mb-2 text-xs font-medium text-foreground">
                   Class of Service
                 </div>
-                <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
                   <Chip
                     label="With CoS"
                     sub="Classifiers, scheduler binding + UNI firewall filter"
                     active={sel.cos}
-                    onClick={() => pick({ cos: true }, [])}
+                    onClick={() => setSel((p) => ({ ...p, cos: true }))}
                   />
                   <Chip
                     label="Service only"
                     sub="Routing-instance + interface (minimum)"
                     active={!sel.cos}
-                    onClick={() => pick({ cos: false, color: undefined }, [])}
+                    onClick={() => setSel((p) => ({ ...p, cos: false, color: undefined }))}
                   />
                 </div>
               </div>
 
               {sel.cos && (
                 <div>
-                  <div className="mb-2 text-xs font-medium text-foreground">
-                    Color mode
-                  </div>
-                  <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="mb-2 text-xs font-medium text-foreground">Color mode</div>
+                  <div className="space-y-2">
                     {attrs.color.map((c) => (
                       <Chip
                         key={c}
                         label={COLOR_LABELS[c] ?? c}
                         active={sel.color === c}
-                        onClick={() => pick({ color: c }, [])}
+                        onClick={() => setSel((p) => ({ ...p, color: c }))}
                       />
                     ))}
                   </div>
                 </div>
               )}
-            </div>
-          </div>
-        )}
 
-        {/* Step 6 — Parameters */}
-        {complete && variables.length > 0 && (
-          <div className="rounded-lg border border-border bg-surface p-6">
-            <StepLabel n={6} title="Parameters" />
-            <p className="mt-2 text-xs text-muted-foreground">
-              Prefilled with lab-safe example values — edit any field for your
-              deployment.
-            </p>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              {variables.map((v) => (
-                <label key={v.name} className="block">
-                  <span className="text-[11px] font-mono text-muted-foreground">
-                    {v.name}
-                  </span>
-                  <input
-                    value={vars[v.name] ?? ""}
-                    onChange={(e) =>
-                      setVars((p) => ({ ...p, [v.name]: e.target.value }))
-                    }
-                    className="mt-1 h-9 w-full rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
-                  />
-                </label>
-              ))}
+              <button
+                disabled={!attrsComplete}
+                onClick={() => setStep((s) => s + 1)}
+                className={[
+                  "mt-2 inline-flex items-center gap-1.5 rounded-md px-4 py-2 text-sm font-medium",
+                  attrsComplete
+                    ? "border border-primary/40 bg-primary/10 text-primary hover:bg-primary/20"
+                    : "cursor-not-allowed border border-border text-muted-foreground opacity-60",
+                ].join(" ")}
+              >
+                Continue to parameters <ChevronRight className="h-4 w-4" />
+              </button>
             </div>
-          </div>
-        )}
+          )}
+
+          {currentStep === "params" && (
+            <div>
+              {variables.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No variables for this selection — the config on the right is ready.
+                </p>
+              ) : (
+                <>
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    Prefilled with lab-safe example values — edit any field for your
+                    deployment. The config updates live on the right.
+                  </p>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {variables.map((v) => (
+                      <label key={v.name} className="block">
+                        <span className="text-[11px] font-mono text-muted-foreground">
+                          {v.name}
+                        </span>
+                        <input
+                          value={vars[v.name] ?? ""}
+                          onChange={(e) =>
+                            setVars((p) => ({ ...p, [v.name]: e.target.value }))
+                          }
+                          className="mt-1 h-9 w-full rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Right: output */}
@@ -394,17 +525,14 @@ export default function ConfigGenerator() {
           {!complete ? (
             <div className="mt-4 flex flex-col items-center justify-center rounded-md border border-dashed border-border py-16 text-center text-sm text-muted-foreground">
               <Cpu className="mb-2 h-6 w-6 text-muted-foreground/60" />
-              Make your selections and the validated config appears here.
+              Work through the steps and the validated config appears here.
             </div>
           ) : (
             <>
               {render && render.missing.length > 0 && (
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
                   <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>
-                    Unfilled variables: {render.missing.join(", ")}. Fill them
-                    in Step 6.
-                  </span>
+                  <span>Unfilled variables: {render.missing.join(", ")}.</span>
                 </div>
               )}
               <pre className="mt-3 max-h-[32rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
@@ -412,8 +540,8 @@ export default function ConfigGenerator() {
               </pre>
               <div className="mt-2 text-[11px] text-muted-foreground">
                 {resolvedIds.length} snip{resolvedIds.length === 1 ? "" : "s"} ·{" "}
-                {sel.cos ? "with-cos" : "minimum"} tier · rendered client-side
-                from the JVD snip library
+                {sel.cos ? "with-cos" : "minimum"} tier · rendered client-side from the
+                JVD snip library
               </div>
             </>
           )}

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useMemo, useState } from "react";
+import { Cpu, Download, Copy, Check, AlertTriangle } from "lucide-react";
+import { snipBundle, type SnipRecord } from "@/lib/snips";
+import maasCatalog from "@/data/generator/metro_as_a_service.json";
+import {
+  type GenCatalog,
+  type GenOsKey,
+  resolveOsBlock,
+  resolveSnipIds,
+  attributeOptions,
+  collectVariables,
+  renderConfig,
+} from "@/lib/generator";
+
+const CATALOG = maasCatalog as unknown as GenCatalog;
+
+const HOMING_LABELS: Record<string, string> = {
+  "single-homed": "Single-homed",
+  multihomed: "Multihomed (all-active ESI)",
+};
+const COLOR_LABELS: Record<string, string> = {
+  "color-blind": "Color-blind",
+  "color-aware": "Color-aware",
+};
+const OS_LABELS: Record<GenOsKey, string> = { evo: "Junos EVO", junos: "Junos" };
+
+type Selection = {
+  familyId?: string;
+  muxId?: string;
+  deploymentId?: string;
+  os?: GenOsKey;
+  homing?: string;
+  color?: string;
+  cos: boolean;
+};
+
+function Chip({
+  label,
+  sub,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  sub?: string;
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={[
+        "rounded-lg border px-4 py-3 text-left transition-colors",
+        disabled
+          ? "cursor-not-allowed border-dashed border-border opacity-50"
+          : active
+            ? "border-primary bg-primary/10"
+            : "border-border bg-background hover:border-primary/50",
+      ].join(" ")}
+    >
+      <div className="text-sm font-medium text-foreground">{label}</div>
+      {sub && <div className="mt-0.5 text-xs text-muted-foreground">{sub}</div>}
+    </button>
+  );
+}
+
+function StepLabel({ n, title }: { n: number; title: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-xs font-semibold text-primary">
+        {n}
+      </span>
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </span>
+    </div>
+  );
+}
+
+export default function ConfigGenerator() {
+  const byId = useMemo(() => {
+    const m = new Map<string, SnipRecord>();
+    for (const s of snipBundle.snips) m.set(s.id, s);
+    return m;
+  }, []);
+
+  const [sel, setSel] = useState<Selection>({ cos: true });
+  const [vars, setVars] = useState<Record<string, string>>({});
+  const [copied, setCopied] = useState(false);
+
+  const family = CATALOG.families.find((f) => f.id === sel.familyId);
+  const mux = family?.multiplexing.find((m) => m.id === sel.muxId);
+  const deployment = mux?.deployments.find((d) => d.id === sel.deploymentId);
+  const osOptions = deployment ? (Object.keys(deployment.os) as GenOsKey[]) : [];
+  const osBlock =
+    sel.familyId && sel.muxId && sel.deploymentId && sel.os
+      ? resolveOsBlock(CATALOG, {
+          familyId: sel.familyId,
+          muxId: sel.muxId,
+          deploymentId: sel.deploymentId,
+          os: sel.os,
+        })
+      : null;
+  const attrs = osBlock ? attributeOptions(osBlock) : { homing: [], color: [] };
+
+  const complete = Boolean(
+    sel.familyId &&
+      sel.muxId &&
+      sel.deploymentId &&
+      sel.os &&
+      sel.homing &&
+      (!sel.cos || sel.color),
+  );
+
+  const resolvedIds = useMemo(() => {
+    if (!complete) return [];
+    return resolveSnipIds(CATALOG, {
+      familyId: sel.familyId!,
+      muxId: sel.muxId!,
+      deploymentId: sel.deploymentId!,
+      os: sel.os!,
+      homing: sel.homing!,
+      color: sel.color ?? "",
+      cos: sel.cos,
+    });
+  }, [complete, sel]);
+
+  const variables = useMemo(
+    () => collectVariables(resolvedIds, byId),
+    [resolvedIds, byId],
+  );
+
+  // Seed the parameter form with lab-safe example values whenever the
+  // resolved path changes.
+  const pathKey = JSON.stringify([
+    sel.familyId,
+    sel.muxId,
+    sel.deploymentId,
+    sel.os,
+    sel.homing,
+    sel.color,
+    sel.cos,
+  ]);
+  useEffect(() => {
+    const seed: Record<string, string> = {};
+    for (const v of variables) seed[v.name] = v.example;
+    setVars(seed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathKey]);
+
+  const render = useMemo(() => {
+    if (!complete || resolvedIds.length === 0) return null;
+    return renderConfig(resolvedIds, vars, byId);
+  }, [complete, resolvedIds, vars, byId]);
+
+  // Setters that clear downstream state.
+  const pick = (patch: Partial<Selection>, clears: (keyof Selection)[]) =>
+    setSel((prev) => {
+      const next = { ...prev, ...patch };
+      for (const k of clears) if (!(k in patch)) delete next[k];
+      return next;
+    });
+
+  const download = () => {
+    if (!render) return;
+    const fname = `maas-${sel.familyId}-${sel.deploymentId}-${sel.os}.conf`;
+    const blob = new Blob([render.text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fname;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const copy = async () => {
+    if (!render) return;
+    await navigator.clipboard.writeText(render.text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="mt-10 grid gap-6 lg:grid-cols-[1fr_minmax(22rem,32rem)]">
+      {/* Left: the funnel */}
+      <div className="space-y-6">
+        {/* Step 1 — Service family */}
+        <div className="rounded-lg border border-border bg-surface p-6">
+          <StepLabel n={1} title="Service type" />
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {CATALOG.families.map((f) => (
+              <Chip
+                key={f.id}
+                label={f.available ? f.label : `${f.label} — coming soon`}
+                sub={f.tagline + " · " + f.description}
+                active={sel.familyId === f.id}
+                disabled={!f.available}
+                onClick={() =>
+                  pick({ familyId: f.id }, [
+                    "muxId",
+                    "deploymentId",
+                    "os",
+                    "homing",
+                    "color",
+                  ])
+                }
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Step 2 — Multiplexing */}
+        {family?.available && (
+          <div className="rounded-lg border border-border bg-surface p-6">
+            <StepLabel n={2} title="Service profile" />
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              {family.multiplexing.map((m) => (
+                <Chip
+                  key={m.id}
+                  label={m.label}
+                  sub={m.description}
+                  active={sel.muxId === m.id}
+                  onClick={() =>
+                    pick({ muxId: m.id }, ["deploymentId", "os", "homing", "color"])
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Step 3 — Deployment */}
+        {mux && (
+          <div className="rounded-lg border border-border bg-surface p-6">
+            <StepLabel n={3} title="Deployment" />
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              {mux.deployments.map((d) => (
+                <Chip
+                  key={d.id}
+                  label={d.label}
+                  sub={d.description}
+                  active={sel.deploymentId === d.id}
+                  onClick={() =>
+                    pick({ deploymentId: d.id }, ["os", "homing", "color"])
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Step 4 — OS / device family */}
+        {deployment && (
+          <div className="rounded-lg border border-border bg-surface p-6">
+            <StepLabel n={4} title="Device OS" />
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              {(["junos", "evo"] as GenOsKey[]).map((os) => (
+                <Chip
+                  key={os}
+                  label={OS_LABELS[os]}
+                  sub={
+                    osOptions.includes(os)
+                      ? os === "evo"
+                        ? "ACX 7xxx"
+                        : "MX, ACX 5xxx / 710"
+                      : "not validated for this service"
+                  }
+                  active={sel.os === os}
+                  disabled={!osOptions.includes(os)}
+                  onClick={() => pick({ os }, ["homing", "color"])}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Step 5 — Attributes */}
+        {osBlock && (
+          <div className="rounded-lg border border-border bg-surface p-6">
+            <StepLabel n={5} title="Service attributes" />
+            <div className="mt-4 space-y-4">
+              <div>
+                <div className="mb-2 text-xs font-medium text-foreground">Homing</div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {attrs.homing.map((h) => (
+                    <Chip
+                      key={h}
+                      label={HOMING_LABELS[h] ?? h}
+                      active={sel.homing === h}
+                      onClick={() => pick({ homing: h }, [])}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <div className="mb-2 text-xs font-medium text-foreground">
+                  Class of Service
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Chip
+                    label="With CoS"
+                    sub="Classifiers, scheduler binding + UNI firewall filter"
+                    active={sel.cos}
+                    onClick={() => pick({ cos: true }, [])}
+                  />
+                  <Chip
+                    label="Service only"
+                    sub="Routing-instance + interface (minimum)"
+                    active={!sel.cos}
+                    onClick={() => pick({ cos: false, color: undefined }, [])}
+                  />
+                </div>
+              </div>
+
+              {sel.cos && (
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    Color mode
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {attrs.color.map((c) => (
+                      <Chip
+                        key={c}
+                        label={COLOR_LABELS[c] ?? c}
+                        active={sel.color === c}
+                        onClick={() => pick({ color: c }, [])}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Step 6 — Parameters */}
+        {complete && variables.length > 0 && (
+          <div className="rounded-lg border border-border bg-surface p-6">
+            <StepLabel n={6} title="Parameters" />
+            <p className="mt-2 text-xs text-muted-foreground">
+              Prefilled with lab-safe example values — edit any field for your
+              deployment.
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {variables.map((v) => (
+                <label key={v.name} className="block">
+                  <span className="text-[11px] font-mono text-muted-foreground">
+                    {v.name}
+                  </span>
+                  <input
+                    value={vars[v.name] ?? ""}
+                    onChange={(e) =>
+                      setVars((p) => ({ ...p, [v.name]: e.target.value }))
+                    }
+                    className="mt-1 h-9 w-full rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Right: output */}
+      <div className="lg:sticky lg:top-6 lg:self-start">
+        <div className="rounded-lg border border-border bg-surface p-6">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Generated config
+            </span>
+            {render && (
+              <div className="flex gap-2">
+                <button
+                  onClick={copy}
+                  className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-primary"
+                >
+                  {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+                <button
+                  onClick={download}
+                  className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/20"
+                >
+                  <Download className="h-3 w-3" /> .conf
+                </button>
+              </div>
+            )}
+          </div>
+
+          {!complete ? (
+            <div className="mt-4 flex flex-col items-center justify-center rounded-md border border-dashed border-border py-16 text-center text-sm text-muted-foreground">
+              <Cpu className="mb-2 h-6 w-6 text-muted-foreground/60" />
+              Make your selections and the validated config appears here.
+            </div>
+          ) : (
+            <>
+              {render && render.missing.length > 0 && (
+                <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>
+                    Unfilled variables: {render.missing.join(", ")}. Fill them
+                    in Step 6.
+                  </span>
+                </div>
+              )}
+              <pre className="mt-3 max-h-[32rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
+                {render?.text}
+              </pre>
+              <div className="mt-2 text-[11px] text-muted-foreground">
+                {resolvedIds.length} snip{resolvedIds.length === 1 ? "" : "s"} ·{" "}
+                {sel.cos ? "with-cos" : "minimum"} tier · rendered client-side
+                from the JVD snip library
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Github, ExternalLink, Network, Layers } from "lucide-react"
 import brandLogo from "@/assets/hpe-juniper-networking.avif";
 import SnipLibrary from "@/components/SnipLibrary";
 import ByoaiSection from "@/components/ByoaiSection";
+import ConfigGenerator from "@/components/ConfigGenerator";
 import { snipBundle } from "@/lib/snips";
 
 type Jvd = {
@@ -332,40 +333,18 @@ export default function JvdPortal() {
           <div className="flex items-center gap-2">
             <h2 className="text-3xl font-semibold tracking-tight">JVD Config Generator</h2>
             <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400">
-              Coming soon
+              Beta
             </span>
           </div>
           <p className="mt-3 max-w-2xl text-muted-foreground">
-            A deterministic, no-AI config builder: pick a service, choose your
+            A deterministic config builder: pick a service, choose your
             options, fill in the parameters, and download validated Junos /
             Junos EVO configuration rendered straight from the JVD snip library.
+            Metro-as-a-Service E-Line is available first — more services and
+            JVDs coming.
           </p>
 
-          <div className="mt-10 grid gap-4 md:grid-cols-3">
-            {[
-              { n: 1, t: "Choose JVD", d: "Select from the catalog of validated designs." },
-              { n: 2, t: "Pick Device Role", d: "Spine, leaf, edge, core — whatever your topology calls for." },
-              { n: 3, t: "Generate Config", d: "Get a deployable Junos snippet ready for staging." },
-            ].map((s) => (
-              <div key={s.n} className="rounded-lg border border-border bg-surface p-6">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-sm font-semibold text-primary">
-                  {s.n}
-                </div>
-                <h3 className="mt-4 text-base font-semibold">{s.t}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{s.d}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="mt-10 flex flex-col items-start gap-2">
-            <button
-              disabled
-              className="inline-flex cursor-not-allowed items-center gap-2 rounded-md border border-border bg-surface px-5 py-2.5 text-sm font-medium text-muted-foreground opacity-60"
-            >
-              Launch Generator
-            </button>
-            <span className="text-xs text-muted-foreground">Coming soon</span>
-          </div>
+          <ConfigGenerator />
         </div>
       </section>
 

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -1,0 +1,145 @@
+{
+  "jvd": "metro_as_a_service",
+  "jvdLabel": "Metro as a Service",
+  "version": 1,
+  "note": "Machine-readable decision tree for the JVD Config Generator. Transcribed from configuration/snips/byoai/CATALOG.md. snip IDs are relative to the jvd (prefix with 'metro_as_a_service/' to match snips.json ids). v1 covers the E-Line CCC-family deployments; other families are placeholders (available:false).",
+  "tiers": {
+    "minimum": { "label": "Minimum", "description": "Service routing-instance + attachment-circuit interface only." },
+    "with-cos": { "label": "With CoS", "description": "Adds CoS binding + the UNI firewall filter for the chosen color mode." }
+  },
+  "cosSnips": {
+    "evo": ["evo/cos/classifiers", "evo/cos/cos-binding-ieee8021p", "evo/cos/rewrite-rules"],
+    "junos": ["junos/cos/classifiers", "junos/cos/cos-binding-ieee8021p", "junos/cos/rewrite-rules"]
+  },
+  "families": [
+    {
+      "id": "e-line",
+      "label": "E-Line",
+      "tagline": "Point-to-point",
+      "description": "Connects exactly two sites, like a private virtual wire (MEF EPL / EVPL).",
+      "available": true,
+      "multiplexing": [
+        {
+          "id": "evpl",
+          "label": "EVPL (VLAN-based)",
+          "description": "Specific customer VLAN(s) on the port map to the service; other VLANs can be other services.",
+          "deployments": [
+            {
+              "id": "evpn-vpws",
+              "label": "EVPN-VPWS",
+              "description": "EVPN-signalled point-to-point (modern default).",
+              "os": {
+                "evo": {
+                  "service": ["evo/services/evpn-vpws-vlan-based"],
+                  "interface": {
+                    "single-homed": "evo/interfaces/vlan-ccc",
+                    "multihomed": "evo/interfaces/vlan-ccc-esi"
+                  },
+                  "interfaceExtras": ["evo/interfaces/physical-mtu"],
+                  "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }
+                },
+                "junos": {
+                  "service": ["junos/services/evpn-vpws-vlan-based"],
+                  "interface": {
+                    "single-homed": "junos/interfaces/vlan-ccc-vlan-map",
+                    "multihomed": "junos/interfaces/vlan-ccc-vlan-map-esi"
+                  },
+                  "interfaceExtras": [],
+                  "filter": {
+                    "color-blind": "junos/firewall/filter-ccc-color-blind",
+                    "color-aware": "junos/firewall/filter-ccc-color-aware"
+                  }
+                }
+              }
+            },
+            {
+              "id": "l2vpn-kompella",
+              "label": "L2VPN (Kompella)",
+              "description": "BGP-signalled L2VPN pseudowire (RFC 4761).",
+              "os": {
+                "evo": {
+                  "service": ["evo/services/l2vpn-kompella-vlan-based"],
+                  "interface": { "single-homed": "evo/interfaces/vlan-ccc" },
+                  "interfaceExtras": ["evo/interfaces/physical-mtu"],
+                  "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }
+                },
+                "junos": {
+                  "service": ["junos/services/l2vpn-kompella-vlan-based"],
+                  "interface": { "single-homed": "junos/interfaces/vlan-ccc" },
+                  "interfaceExtras": [],
+                  "filter": {
+                    "color-aware": "junos/firewall/filter-ccc-color-aware",
+                    "color-blind": "junos/firewall/filter-ccc-color-blind"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "epl",
+          "label": "EPL (port-based)",
+          "description": "The whole physical port is the service (all traffic, all VLANs).",
+          "deployments": [
+            {
+              "id": "evpn-vpws",
+              "label": "EVPN-VPWS",
+              "description": "EVPN-signalled point-to-point over a full-port UNI.",
+              "os": {
+                "evo": {
+                  "service": ["evo/services/evpn-vpws-port-based"],
+                  "interface": { "single-homed": "evo/interfaces/ethernet-ccc" },
+                  "interfaceExtras": ["evo/interfaces/physical-mtu"],
+                  "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind-l2cp" }
+                }
+              }
+            },
+            {
+              "id": "l2vpn-kompella",
+              "label": "L2VPN (Kompella)",
+              "description": "BGP-signalled L2VPN pseudowire over a full-port UNI.",
+              "os": {
+                "evo": {
+                  "service": ["evo/services/l2vpn-kompella-port-based"],
+                  "interface": { "single-homed": "evo/interfaces/ethernet-ccc" },
+                  "interfaceExtras": ["evo/interfaces/physical-mtu"],
+                  "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind-l2cp" }
+                },
+                "junos": {
+                  "service": ["junos/services/l2vpn-kompella-port-based"],
+                  "interface": { "single-homed": "junos/interfaces/ethernet-ccc" },
+                  "interfaceExtras": [],
+                  "filter": { "color-aware": "junos/firewall/filter-ccc-color-aware-l2cp" }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "e-lan",
+      "label": "E-LAN",
+      "tagline": "Multipoint",
+      "description": "Connects three or more sites into one shared broadcast domain (MEF EP-LAN / EVP-LAN).",
+      "available": false,
+      "multiplexing": []
+    },
+    {
+      "id": "e-tree",
+      "label": "E-Tree",
+      "tagline": "Rooted-multipoint",
+      "description": "Leaf sites talk only to root sites, never to each other (MEF EP-Tree / EVP-Tree).",
+      "available": false,
+      "multiplexing": []
+    },
+    {
+      "id": "e-access",
+      "label": "Access E-Line",
+      "tagline": "Operator hand-off",
+      "description": "Access / ENNI segment carrying a customer's VLANs (often QinQ) into the metro (MEF E-Access).",
+      "available": false,
+      "multiplexing": []
+    }
+  ]
+}

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -59,8 +59,9 @@ export type GenSelection = {
   deploymentId: string;
   os: GenOsKey;
   homing: string; // key into osBlock.interface
-  color: string; // key into osBlock.filter
-  cos: boolean; // true = with-cos tier, false = minimum
+  cos: boolean; // include CoS binding snips (classifiers, scheduler binding)
+  firewall: boolean; // include the UNI firewall filter
+  color: string; // key into osBlock.filter (required when firewall = true)
 };
 
 /** Walk the catalog to the OS block for a (family, mux, deployment, os). */
@@ -77,7 +78,7 @@ export function resolveOsBlock(
 /**
  * Resolve the ordered list of jvd-qualified snip IDs for a full selection.
  * Order: service(s) → attachment-circuit interface → interface extras →
- * (if CoS) UNI firewall filter → CoS binding snips.
+ * (if firewall) UNI firewall filter → (if CoS) CoS binding snips.
  */
 export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[] {
   const osb = resolveOsBlock(catalog, sel);
@@ -87,9 +88,11 @@ export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[]
   const iface = osb.interface[sel.homing];
   if (iface) rel.push(iface);
   rel.push(...osb.interfaceExtras);
-  if (sel.cos) {
+  if (sel.firewall) {
     const filter = osb.filter[sel.color];
     if (filter) rel.push(filter);
+  }
+  if (sel.cos) {
     rel.push(...(catalog.cosSnips[sel.os] ?? []));
   }
   // De-dupe while preserving order, then qualify with the jvd prefix.

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -1,0 +1,201 @@
+/**
+ * JVD Config Generator — deterministic render engine.
+ *
+ * Pure, testable functions that turn a wizard selection (family →
+ * multiplexing → deployment → OS → attributes → tier) into an ordered
+ * list of snip IDs, and render those snips (with variable substitution)
+ * into a downloadable Junos / Junos EVO configuration.
+ *
+ * No AI. The decision tree lives in src/data/generator/<jvd>.json; the
+ * snip bodies + variables come from src/data/snips.json (via lib/snips).
+ */
+
+import type { SnipRecord, SnipVariable } from "@/lib/snips";
+
+export type GenOsKey = "evo" | "junos";
+
+export type GenOsBlock = {
+  service: string[];
+  interface: Record<string, string>; // homing key -> snip id (relative to jvd)
+  interfaceExtras: string[];
+  filter: Record<string, string>; // color key -> snip id (relative to jvd)
+};
+
+export type GenDeployment = {
+  id: string;
+  label: string;
+  description: string;
+  os: Partial<Record<GenOsKey, GenOsBlock>>;
+};
+
+export type GenMux = {
+  id: string;
+  label: string;
+  description: string;
+  deployments: GenDeployment[];
+};
+
+export type GenFamily = {
+  id: string;
+  label: string;
+  tagline: string;
+  description: string;
+  available: boolean;
+  multiplexing: GenMux[];
+};
+
+export type GenCatalog = {
+  jvd: string;
+  jvdLabel: string;
+  version: number;
+  tiers: Record<string, { label: string; description: string }>;
+  cosSnips: Record<GenOsKey, string[]>;
+  families: GenFamily[];
+};
+
+export type GenSelection = {
+  familyId: string;
+  muxId: string;
+  deploymentId: string;
+  os: GenOsKey;
+  homing: string; // key into osBlock.interface
+  color: string; // key into osBlock.filter
+  cos: boolean; // true = with-cos tier, false = minimum
+};
+
+/** Walk the catalog to the OS block for a (family, mux, deployment, os). */
+export function resolveOsBlock(
+  catalog: GenCatalog,
+  sel: Pick<GenSelection, "familyId" | "muxId" | "deploymentId" | "os">,
+): GenOsBlock | null {
+  const fam = catalog.families.find((f) => f.id === sel.familyId);
+  const mux = fam?.multiplexing.find((m) => m.id === sel.muxId);
+  const dep = mux?.deployments.find((d) => d.id === sel.deploymentId);
+  return dep?.os[sel.os] ?? null;
+}
+
+/**
+ * Resolve the ordered list of jvd-qualified snip IDs for a full selection.
+ * Order: service(s) → attachment-circuit interface → interface extras →
+ * (if CoS) UNI firewall filter → CoS binding snips.
+ */
+export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[] {
+  const osb = resolveOsBlock(catalog, sel);
+  if (!osb) return [];
+  const rel: string[] = [];
+  rel.push(...osb.service);
+  const iface = osb.interface[sel.homing];
+  if (iface) rel.push(iface);
+  rel.push(...osb.interfaceExtras);
+  if (sel.cos) {
+    const filter = osb.filter[sel.color];
+    if (filter) rel.push(filter);
+    rel.push(...(catalog.cosSnips[sel.os] ?? []));
+  }
+  // De-dupe while preserving order, then qualify with the jvd prefix.
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rel) {
+    const qualified = `${catalog.jvd}/${r}`;
+    if (!seen.has(qualified)) {
+      seen.add(qualified);
+      out.push(qualified);
+    }
+  }
+  return out;
+}
+
+/** The homing / color attribute options that are valid for a given OS block. */
+export function attributeOptions(osb: GenOsBlock): {
+  homing: string[];
+  color: string[];
+} {
+  return {
+    homing: Object.keys(osb.interface),
+    color: Object.keys(osb.filter),
+  };
+}
+
+/** Unique variables (name + example) across a set of snips, first example wins. */
+export function collectVariables(
+  snipIds: string[],
+  byId: Map<string, SnipRecord>,
+): SnipVariable[] {
+  const out: SnipVariable[] = [];
+  const seen = new Set<string>();
+  for (const id of snipIds) {
+    const snip = byId.get(id);
+    if (!snip) continue;
+    for (const v of snip.variables) {
+      if (!seen.has(v.name)) {
+        seen.add(v.name);
+        out.push(v);
+      }
+    }
+  }
+  return out;
+}
+
+/** Strip a leading C-style /* … *\/ doc header if one is present. */
+function stripHeader(body: string): string {
+  const t = body.replace(/^\uFEFF?\s*/, "");
+  if (t.startsWith("/*")) {
+    const end = t.indexOf("*/");
+    if (end !== -1) return t.slice(end + 2).replace(/^\s*\n/, "");
+  }
+  return body;
+}
+
+/** Substitute ${VAR} then $VAR for every provided value (longest key first). */
+function substitute(body: string, values: Record<string, string>): string {
+  let out = body;
+  const names = Object.keys(values).sort((a, b) => b.length - a.length);
+  for (const name of names) {
+    const val = values[name];
+    if (val === undefined || val === "") continue;
+    const bare = name.startsWith("$") ? name.slice(1) : name;
+    out = out.split(`\${${bare}}`).join(val).split(`$${bare}`).join(val);
+  }
+  return out;
+}
+
+export type RenderResult = {
+  text: string;
+  /** Variable names still present as $VAR after substitution. */
+  missing: string[];
+  /** The snip IDs that were rendered, in order. */
+  usedSnipIds: string[];
+};
+
+/**
+ * Render the resolved snips into one config blob. Each snip is prefixed
+ * with a `/* snips/<path> *\/` provenance comment; its own doc header is
+ * stripped. `values` maps variable names (with or without leading $) to
+ * concrete values.
+ */
+export function renderConfig(
+  snipIds: string[],
+  values: Record<string, string>,
+  byId: Map<string, SnipRecord>,
+): RenderResult {
+  // Normalise value keys to bare names (no leading $).
+  const norm: Record<string, string> = {};
+  for (const [k, v] of Object.entries(values)) {
+    norm[k.startsWith("$") ? k.slice(1) : k] = v;
+  }
+
+  const blocks: string[] = [];
+  const used: string[] = [];
+  for (const id of snipIds) {
+    const snip = byId.get(id);
+    if (!snip) continue;
+    used.push(id);
+    const shortPath = `${snip.osKey}/${snip.category}/${snip.name}.conf`;
+    const rendered = substitute(stripHeader(snip.body), norm).replace(/\s+$/, "");
+    blocks.push(`/* snips/${shortPath} */\n${rendered}`);
+  }
+
+  const text = blocks.join("\n\n") + "\n";
+  const missing = Array.from(new Set(text.match(/\$\{?[A-Z_][A-Z0-9_]*\}?/g) ?? []));
+  return { text, missing, usedSnipIds: used };
+}


### PR DESCRIPTION
## What's New

The first **deterministic Config Generator** — the guided funnel-as-code. Pick a service, choose your options, fill parameters, download validated Junos / Junos EVO config. No AI, no fetch, no drift.

- Live wizard on the portal `#generator` route (replaces the placeholder)
- **Metro-as-a-Service E-Line** vertical slice: EVPL + EPL × EVPN-VPWS + L2VPN-Kompella × Junos + EVO
- Progressive funnel: Service type → Service profile → Deployment → Device OS → Attributes (homing / CoS / color) → Parameters → download `.conf`
- Only valid options are offered at each step (e.g. Multihomed auto-selects the `-esi` interface variant; color-aware is Junos-only; unsupported OS is greyed out)
- Client-side variable substitution straight from the JVD snip library — every field prefilled with lab-safe examples, editable per deployment

## Why

Easier than BYOAI when user needs straight forward deterministic and validated configurations. The funnel is fundamentally a decision tree — so it belongs in code. This moves it to an engine that can't drift, hallucinate, or depend on a flaky fetch. BYOAI stays for what AI is actually good at (explain / freeform).

## Details

- `src/data/generator/metro_as_a_service.json` — machine-readable decision tree transcribed from `CATALOG.md`; every snip ID validated against `snips.json` (26 refs, 0 unresolved).
- `src/lib/generator.ts` — pure render engine: `resolveSnipIds`, `attributeOptions`, `collectVariables`, `renderConfig` (variable substitution, header strip, provenance comments, missing-var detection).
- `src/components/ConfigGenerator.tsx` — the wizard UI (progressive steps, live preview, copy + download).
- `JvdPortal.tsx` — wired the component into `#generator`; section now labeled Beta; description updated per request.

## Testing

- Render logic: 5 representative E-Line paths render with **0 dangling `$VAR`s**, balanced output.
- Catalog integrity: all 26 snip references resolve against `snips.json`.
- `bun run build`: clean. `generate-snips.mjs --check`: OK (515 snips, 9 JVDs). No type errors.
- **Browser-verified**: drove the full funnel (EVPL → EVPN-VPWS → Junos → Multihomed → With CoS → Color-blind) → 6 snips rendered correctly, multihomed picked the `-esi` interface, values substituted.

## Notes

- Vertical slice by design — E-Line only. E-LAN / E-Tree / Access are stubbed (`available:false`, greyed). Next: widen to the other families + the bridge-based E-Line deployments (BGP-VPLS, FXC, floating-PW, hot-standby), then generalize the catalog to other JVDs.
- The `catalog.json` decision tree can later become the single source shared with BYOAI's `CATALOG.md`.
