### PR TITLE
feat(portal): validated E-Line config generator

### DIFF
--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -22,6 +22,7 @@ import {
   renderConfig,
   classifyVar,
   endpointValues,
+  instanceValues,
 } from "@/lib/generator";
 
 const CATALOG = maasCatalog as unknown as GenCatalog;
@@ -208,6 +209,7 @@ export default function ConfigGenerator() {
   const [perB, setPerB] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState(false);
   const [step, setStep] = useState(0);
+  const [count, setCount] = useState(1);
 
   const family = CATALOG.families.find((f) => f.id === sel.familyId);
   const mux = family?.multiplexing.find((m) => m.id === sel.muxId);
@@ -413,13 +415,35 @@ export default function ConfigGenerator() {
     setShared({});
     setPerA({});
     setPerB({});
+    setCount(1);
     setStep(0);
   };
 
   const download = () => {
     if (!fullText) return;
-    const fname = `maas-${sel.familyId}-${sel.deploymentId}.conf`;
-    const blob = new Blob([fullText + "\n"], { type: "text/plain" });
+    // Emit all N service instances: instance i increments every non-constant
+    // variable's trailing integer by i (instance 0 = the values entered).
+    const n = Math.max(1, Math.min(count, 500));
+    const chunks: string[] = [];
+    for (let i = 0; i < n; i++) {
+      const sh = instanceValues(shared, ROLES, i);
+      const a = instanceValues(perA, ROLES, i);
+      const b = instanceValues(perB, ROLES, i);
+      const ra = idsA.length
+        ? renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId)
+        : null;
+      const rb =
+        twoPe && idsB.length
+          ? renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId)
+          : null;
+      const body = [ra?.text, rb?.text].filter(Boolean).join("\n\n");
+      chunks.push(
+        n > 1 ? `/* ===== service ${i + 1} of ${n} ===== */\n${body}` : body,
+      );
+    }
+    const text = chunks.join("\n\n") + "\n";
+    const fname = `maas-${sel.familyId}-${sel.deploymentId}${n > 1 ? `-x${n}` : ""}.conf`;
+    const blob = new Blob([text], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -707,6 +731,27 @@ export default function ConfigGenerator() {
 
           {currentStep === "params" && (
             <div className="space-y-5">
+              <div className="flex flex-wrap items-center gap-3 rounded-md border border-border bg-background p-3">
+                <label className="text-xs font-medium text-foreground">
+                  Number of services
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={500}
+                  value={count}
+                  onChange={(e) =>
+                    setCount(Math.max(1, Math.min(500, Number(e.target.value) || 1)))
+                  }
+                  className="h-8 w-20 rounded-md border border-border bg-surface px-2 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                />
+                <span className="text-[11px] text-muted-foreground">
+                  {count > 1
+                    ? `The values below are service #1. Services #2–${count} increment automatically; the download includes all ${count}.`
+                    : "The values below are your service. Increase the count to generate a numbered batch."}
+                </span>
+              </div>
+
               {sharedFields.length > 0 && (
                 <div>
                   <div className="mb-2 text-xs font-medium text-foreground">
@@ -843,12 +888,18 @@ export default function ConfigGenerator() {
                 </div>
               )}
               <div className="mt-2 text-[11px] text-muted-foreground">
+                {count > 1 ? `Previewing service 1 of ${count} · ` : ""}
                 {twoPe ? "2 endpoints · matched identifiers" : "single device"} ·{" "}
                 {[sel.cos && "CoS", sel.firewall && "firewall filter"]
                   .filter(Boolean)
                   .join(" + ") || "service only"}{" "}
                 · rendered client-side from the JVD snip library
               </div>
+              {count > 1 && (
+                <div className="mt-1 text-[11px] font-medium text-primary">
+                  Download includes all {count} services (#2–{count} auto-incremented).
+                </div>
+              )}
             </>
           )}
         </div>

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -344,6 +344,15 @@ export default function ConfigGenerator() {
         );
       }
     }
+    // Mirrored pairs: if both PEs use the same local value, each PE ends up
+    // with local == remote, which is invalid (e.g. vpws-service-id).
+    for (const [primary, secondary] of ROLES.mirrored) {
+      if (perA[primary] !== undefined && perA[primary] === perB[primary]) {
+        consistencyWarnings.push(
+          `${varLabel(primary)} and ${varLabel(secondary)} would be identical on each PE — local and remote must differ.`,
+        );
+      }
+    }
   }
 
   const advance = (patch: Partial<Selection>, clears: (keyof Selection)[]) => {

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -19,6 +19,7 @@ import {
   resolveOsBlock,
   resolveSnipIds,
   attributeOptions,
+  vlanModes,
   collectVariables,
   renderConfig,
   classifyVar,
@@ -135,6 +136,7 @@ type Selection = {
   osA?: GenOsKey;
   osB?: OsChoice;
   homing?: string;
+  vlanMode?: string;
   color?: string;
   cos: boolean;
   firewall: boolean;
@@ -285,9 +287,28 @@ export default function ConfigGenerator() {
         })
       : null;
 
-  // Attribute options = intersection of both endpoints (or just A when single).
-  const attrsA = osBlockA ? attributeOptions(osBlockA) : { homing: [], color: [] };
-  const attrsB = osBlockB ? attributeOptions(osBlockB) : null;
+  // VLAN-handling modes = intersection of both endpoints' modes (some snips
+  // only exist on one OS, so a mode is offered only when both PEs support it).
+  const modesA = osBlockA ? vlanModes(osBlockA) : [];
+  const modesB = osBlockB ? vlanModes(osBlockB) : null;
+  const modeOpts = modesB
+    ? modesA.filter((m) => modesB.some((x) => x.id === m.id))
+    : modesA;
+  // Effective (derived) VLAN mode: the user's pick if still valid, else the
+  // first available mode. Undefined when the deployment has no modes at all.
+  const vlanMode =
+    modeOpts.length > 0
+      ? modeOpts.some((m) => m.id === sel.vlanMode)
+        ? sel.vlanMode
+        : modeOpts[0].id
+      : undefined;
+
+  // Attribute options = intersection of both endpoints (or just A when single),
+  // for the currently-selected VLAN mode.
+  const attrsA = osBlockA
+    ? attributeOptions(osBlockA, vlanMode)
+    : { homing: [], color: [] };
+  const attrsB = osBlockB ? attributeOptions(osBlockB, vlanMode) : null;
   const homingOpts = attrsB
     ? attrsA.homing.filter((h) => attrsB.homing.includes(h))
     : attrsA.homing;
@@ -295,7 +316,9 @@ export default function ConfigGenerator() {
     ? attrsA.color.filter((c) => attrsB.color.includes(c))
     : attrsA.color;
 
-  const attrsComplete = Boolean(sel.homing && (!sel.firewall || sel.color));
+  const attrsComplete = Boolean(
+    sel.homing && (modeOpts.length === 0 || vlanMode) && (!sel.firewall || sel.color),
+  );
   const currentStep = STEPS[Math.min(step, STEPS.length - 1)];
   const complete = Boolean(
     sel.familyId &&
@@ -303,6 +326,7 @@ export default function ConfigGenerator() {
       sel.deploymentId &&
       sel.osA &&
       sel.homing &&
+      (modeOpts.length === 0 || vlanMode) &&
       (!sel.firewall || sel.color),
   );
 
@@ -312,6 +336,7 @@ export default function ConfigGenerator() {
     deploymentId: sel.deploymentId!,
     os,
     homing: sel.homing!,
+    vlanMode,
     color: sel.color ?? "",
     cos: sel.cos,
     firewall: sel.firewall,
@@ -356,6 +381,7 @@ export default function ConfigGenerator() {
     sel.osA,
     sel.osB,
     sel.homing,
+    vlanMode,
     sel.color,
     sel.cos,
     sel.firewall,
@@ -446,11 +472,14 @@ export default function ConfigGenerator() {
         return attrsComplete
           ? [
               HOMING_LABELS[sel.homing!] ?? sel.homing,
+              vlanMode ? modeOpts.find((m) => m.id === vlanMode)?.label : null,
               sel.cos ? "CoS" : "no CoS",
               sel.firewall
                 ? `filter (${COLOR_LABELS[sel.color!] ?? sel.color})`
                 : "no filter",
-            ].join(" · ")
+            ]
+              .filter(Boolean)
+              .join(" · ")
           : null;
       default:
         return null;
@@ -709,6 +738,24 @@ export default function ConfigGenerator() {
                   ))}
                 </div>
               </div>
+              {modeOpts.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    VLAN handling
+                  </div>
+                  <div className="space-y-2">
+                    {modeOpts.map((m) => (
+                      <Chip
+                        key={m.id}
+                        label={m.label}
+                        sub={m.description}
+                        active={vlanMode === m.id}
+                        onClick={() => setSel((p) => ({ ...p, vlanMode: m.id }))}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
               <div>
                 <div className="mb-2 text-xs font-medium text-foreground">
                   Class of Service

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -62,6 +62,7 @@ const VAR_LABELS: Record<string, string> = {
   VC_ID: "virtual-circuit-id",
   ESI_ID: "ESI value",
   FILTER_NAME: "UNI filter name",
+  MTU: "physical MTU",
 };
 const varLabel = (name: string) => VAR_LABELS[name.replace(/^\$/, "")] ?? name;
 
@@ -156,11 +157,13 @@ function VarField({
   value,
   onChange,
   hint,
+  error,
 }: {
   name: string;
   value: string;
   onChange: (v: string) => void;
   hint?: string;
+  error?: string;
 }) {
   return (
     <label className="block">
@@ -168,11 +171,25 @@ function VarField({
         <span className="text-xs font-medium text-foreground">{varLabel(name)}</span>
         <span className="font-mono text-[10px] text-muted-foreground/70">{name}</span>
       </span>
-      {hint && <span className="block text-[10px] text-muted-foreground/70">{hint}</span>}
+      {(hint || error) && (
+        <span className="flex items-baseline justify-between gap-2">
+          <span className="text-[10px] text-muted-foreground/70">{hint}</span>
+          {error && (
+            <span className="text-[10px] font-semibold text-red-600 dark:text-red-400">
+              {error}
+            </span>
+          )}
+        </span>
+      )}
       <input
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
-        className="mt-1 h-9 w-full rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+        className={[
+          "mt-1 h-9 w-full rounded-md border bg-background px-3 font-mono text-sm text-foreground focus:outline-none",
+          error
+            ? "border-red-500/60 focus:border-red-500"
+            : "border-border focus:border-primary/60",
+        ].join(" ")}
       />
     </label>
   );
@@ -334,23 +351,18 @@ export default function ConfigGenerator() {
     new Set([...(renderA?.missing ?? []), ...(renderB?.missing ?? [])]),
   );
 
-  // Consistency warnings: per-PE values that MUST differ but are identical.
-  const consistencyWarnings: string[] = [];
+  // Field-level validation: per-PE values that must differ but are identical.
+  // Keyed by bare var name so the error renders inline next to that field.
+  const fieldErrors: Record<string, string> = {};
   if (twoPe) {
     for (const bare of ROLES.distinctPerEndpoint ?? []) {
       if (perA[bare] !== undefined && perA[bare] === perB[bare]) {
-        consistencyWarnings.push(
-          `PE-A and PE-B ${varLabel(bare)} ($${bare}) are identical — they should differ per PE.`,
-        );
+        fieldErrors[bare] = `${varLabel(bare)} should differ per PE`;
       }
     }
-    // Mirrored pairs: if both PEs use the same local value, each PE ends up
-    // with local == remote, which is invalid (e.g. vpws-service-id).
-    for (const [primary, secondary] of ROLES.mirrored) {
+    for (const [primary] of ROLES.mirrored) {
       if (perA[primary] !== undefined && perA[primary] === perB[primary]) {
-        consistencyWarnings.push(
-          `${varLabel(primary)} and ${varLabel(secondary)} would be identical on each PE — local and remote must differ.`,
-        );
+        fieldErrors[primary] = `${varLabel(primary).replace(/ · local$/, "")} should be unique`;
       }
     }
   }
@@ -733,6 +745,7 @@ export default function ConfigGenerator() {
                           key={v.name}
                           name={v.name}
                           hint={mirror ? "(far-end remote auto-set)" : undefined}
+                          error={fieldErrors[bare]}
                           value={perA[bare]}
                           onChange={(val) => setPerA((p) => ({ ...p, [bare]: val }))}
                         />
@@ -755,6 +768,7 @@ export default function ConfigGenerator() {
                             key={v.name}
                             name={v.name}
                             hint={mirror ? "(far-end remote auto-set)" : undefined}
+                            error={fieldErrors[bare]}
                             value={perB[bare]}
                             onChange={(val) => setPerB((p) => ({ ...p, [bare]: val }))}
                           />
@@ -808,15 +822,6 @@ export default function ConfigGenerator() {
                   <span>Unfilled variables: {missing.join(", ")}.</span>
                 </div>
               )}
-              {consistencyWarnings.map((w) => (
-                <div
-                  key={w}
-                  className="mt-3 flex items-start gap-2 rounded-md border border-red-500/50 bg-red-500/10 p-2 text-[11px] font-medium text-red-600 dark:text-red-400"
-                >
-                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>{w}</span>
-                </div>
-              ))}
               {renderA && (
                 <div className="mt-3">
                   <div className="mb-1 text-[11px] font-semibold text-primary">

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -413,12 +413,16 @@ export default function ConfigGenerator() {
   const names = unionVars.map((v) => v.name);
   const renderA = useMemo(() => {
     if (!complete || idsA.length === 0) return null;
-    return renderConfig(idsA, endpointValues(names, ROLES, shared, perA, perB), byId);
+    return renderConfig(idsA, endpointValues(names, ROLES, shared, perA, perB), byId, {
+      stripUniFilter: !sel.firewall,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complete, idsA, shared, perA, perB, byId]);
   const renderB = useMemo(() => {
     if (!complete || !twoPe || idsB.length === 0) return null;
-    return renderConfig(idsB, endpointValues(names, ROLES, shared, perB, perA), byId);
+    return renderConfig(idsB, endpointValues(names, ROLES, shared, perB, perA), byId, {
+      stripUniFilter: !sel.firewall,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complete, twoPe, idsB, shared, perA, perB, byId]);
 
@@ -507,11 +511,15 @@ export default function ConfigGenerator() {
       const a = instanceValues(perA, ROLES, i);
       const b = instanceValues(perB, ROLES, i);
       const ra = idsA.length
-        ? renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId)
+        ? renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
+            stripUniFilter: !sel.firewall,
+          })
         : null;
       const rb =
         twoPe && idsB.length
-          ? renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId)
+          ? renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId, {
+              stripUniFilter: !sel.firewall,
+            })
           : null;
       const body = [ra?.text, rb?.text].filter(Boolean).join("\n\n");
       chunks.push(

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -22,6 +22,7 @@ import {
   vlanModes,
   collectVariables,
   renderConfig,
+  mergeJunosConfig,
   classifyVar,
   endpointValues,
   instanceValues,
@@ -426,7 +427,17 @@ export default function ConfigGenerator() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complete, twoPe, idsB, shared, perA, perB, byId]);
 
-  const fullText = [renderA?.text, renderB?.text].filter(Boolean).join("\n\n");
+  // Merged, consolidated config for display/copy (single previewed service).
+  const mergedA = useMemo(
+    () => (renderA ? mergeJunosConfig(renderA.text) : null),
+    [renderA],
+  );
+  const mergedB = useMemo(
+    () => (renderB ? mergeJunosConfig(renderB.text) : null),
+    [renderB],
+  );
+
+  const fullText = [mergedA, mergedB].filter(Boolean).join("\n\n");
   const missing = Array.from(
     new Set([...(renderA?.missing ?? []), ...(renderB?.missing ?? [])]),
   );
@@ -503,30 +514,42 @@ export default function ConfigGenerator() {
   const download = () => {
     if (!fullText) return;
     // Emit all N service instances: instance i increments every non-constant
-    // variable's trailing integer by i (instance 0 = the values entered).
+    // variable's trailing integer by i (instance 0 = the values entered). All
+    // of an endpoint's instances are merged into ONE consolidated hierarchy —
+    // a single physical interface carrying N units, MTU/filter/CoS declared
+    // once — rather than N repeated standalone stanzas.
     const n = Math.max(1, Math.min(count, 500));
-    const chunks: string[] = [];
+    const aBodies: string[] = [];
+    const bBodies: string[] = [];
     for (let i = 0; i < n; i++) {
       const sh = instanceValues(shared, ROLES, i);
       const a = instanceValues(perA, ROLES, i);
       const b = instanceValues(perB, ROLES, i);
-      const ra = idsA.length
-        ? renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
+      if (idsA.length)
+        aBodies.push(
+          renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
             stripUniFilter: !sel.firewall,
-          })
-        : null;
-      const rb =
-        twoPe && idsB.length
-          ? renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId, {
-              stripUniFilter: !sel.firewall,
-            })
-          : null;
-      const body = [ra?.text, rb?.text].filter(Boolean).join("\n\n");
-      chunks.push(
-        n > 1 ? `/* ===== service ${i + 1} of ${n} ===== */\n${body}` : body,
+          }).text,
+        );
+      if (twoPe && idsB.length)
+        bBodies.push(
+          renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId, {
+            stripUniFilter: !sel.firewall,
+          }).text,
+        );
+    }
+    const sections: string[] = [];
+    if (aBodies.length) {
+      const merged = mergeJunosConfig(aBodies.join("\n"));
+      sections.push(
+        twoPe ? `/* ===== ${peLabel(sel.osA, "PE-A")} ===== */\n${merged}` : merged,
       );
     }
-    const text = chunks.join("\n\n") + "\n";
+    if (bBodies.length) {
+      const merged = mergeJunosConfig(bBodies.join("\n"));
+      sections.push(`/* ===== ${peLabel(sel.osB as GenOsKey, "PE-B")} ===== */\n${merged}`);
+    }
+    const text = sections.join("\n\n") + "\n";
     const fname = `maas-${sel.familyId}-${sel.deploymentId}${n > 1 ? `-x${n}` : ""}.conf`;
     const blob = new Blob([text], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
@@ -978,7 +1001,7 @@ export default function ConfigGenerator() {
                     # {peLabel(sel.osA, "PE-A")}
                   </div>
                   <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
-                    {renderA.text}
+                    {mergedA}
                   </pre>
                 </div>
               )}
@@ -988,7 +1011,7 @@ export default function ConfigGenerator() {
                     # {peLabel(sel.osB as GenOsKey, "PE-B")}
                   </div>
                   <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
-                    {renderB.text}
+                    {mergedB}
                   </pre>
                 </div>
               )}

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -46,6 +46,25 @@ const COLOR_LABELS: Record<string, string> = {
 };
 const OS_LABELS: Record<GenOsKey, string> = { evo: "Junos EVO", junos: "Junos" };
 
+/** Friendly names for the cryptic $VARs (the `_VID` suffix is misleading). */
+const VAR_LABELS: Record<string, string> = {
+  INSTANCE_NAME: "service instance name",
+  VRF_TARGET: "route-target",
+  RD: "route-distinguisher",
+  AC_INTF: "attachment-circuit interface",
+  UNIT: "unit",
+  VLAN: "UNI VLAN-id",
+  INPUT_VID: "normalized S-VLAN (push)",
+  LOCAL_VID: "vpws-service-id · local",
+  REMOTE_VID: "vpws-service-id · remote",
+  SITE_ID: "L2VPN site-id · local",
+  REMOTE_SITE_ID: "L2VPN site-id · remote",
+  VC_ID: "virtual-circuit-id",
+  ESI_ID: "ESI value",
+  FILTER_NAME: "UNI filter name",
+};
+const varLabel = (name: string) => VAR_LABELS[name.replace(/^\$/, "")] ?? name;
+
 type OsChoice = GenOsKey | "none";
 
 type StepId =
@@ -145,10 +164,11 @@ function VarField({
 }) {
   return (
     <label className="block">
-      <span className="text-[11px] font-mono text-muted-foreground">
-        {name}
-        {hint && <span className="ml-1 text-muted-foreground/70">{hint}</span>}
+      <span className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium text-foreground">{varLabel(name)}</span>
+        <span className="font-mono text-[10px] text-muted-foreground/70">{name}</span>
       </span>
+      {hint && <span className="block text-[10px] text-muted-foreground/70">{hint}</span>}
       <input
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
@@ -283,7 +303,12 @@ export default function ConfigGenerator() {
       if (kind === "shared") sh[bare] = v.example;
       else if (kind !== "mirrored-secondary") {
         a[bare] = v.example;
-        b[bare] = bumpB(v.example);
+        // Only vars that MUST differ (the service-id mirror, RD) get bumped on
+        // PE-B; everything else (UNI VLAN, unit, interface) defaults the same.
+        const mustDiffer =
+          kind === "mirrored-primary" ||
+          (ROLES.distinctPerEndpoint ?? []).includes(bare);
+        b[bare] = mustDiffer ? bumpB(v.example) : v.example;
       }
     }
     setShared(sh);
@@ -308,6 +333,18 @@ export default function ConfigGenerator() {
   const missing = Array.from(
     new Set([...(renderA?.missing ?? []), ...(renderB?.missing ?? [])]),
   );
+
+  // Consistency warnings: per-PE values that MUST differ but are identical.
+  const consistencyWarnings: string[] = [];
+  if (twoPe) {
+    for (const bare of ROLES.distinctPerEndpoint ?? []) {
+      if (perA[bare] !== undefined && perA[bare] === perB[bare]) {
+        consistencyWarnings.push(
+          `PE-A and PE-B ${varLabel(bare)} ($${bare}) are identical — they should differ per PE.`,
+        );
+      }
+    }
+  }
 
   const advance = (patch: Partial<Selection>, clears: (keyof Selection)[]) => {
     setSel((prev) => {
@@ -762,6 +799,15 @@ export default function ConfigGenerator() {
                   <span>Unfilled variables: {missing.join(", ")}.</span>
                 </div>
               )}
+              {consistencyWarnings.map((w) => (
+                <div
+                  key={w}
+                  className="mt-3 flex items-start gap-2 rounded-md border border-red-500/50 bg-red-500/10 p-2 text-[11px] font-medium text-red-600 dark:text-red-400"
+                >
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{w}</span>
+                </div>
+              ))}
               {renderA && (
                 <div className="mt-3">
                   <div className="mb-1 text-[11px] font-semibold text-primary">

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -67,6 +67,51 @@ const VAR_LABELS: Record<string, string> = {
 };
 const varLabel = (name: string) => VAR_LABELS[name.replace(/^\$/, "")] ?? name;
 
+/** Per-variable format validation (syntax). Value must match `re` or the
+ *  field shows `msg` inline. Lenient — only flags clearly-malformed input. */
+const VALIDATORS: Record<string, { re: RegExp; msg: string }> = {
+  RD: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
+  VRF_TARGET: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
+  VRF_TARGET_1: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
+  VRF_TARGET_2: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
+  COMM_RT: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
+  VLAN: { re: /^\d+$/, msg: "expected a VLAN number" },
+  VLAN_1: { re: /^\d+$/, msg: "expected a VLAN number" },
+  VLAN_2: { re: /^\d+$/, msg: "expected a VLAN number" },
+  INPUT_VID: { re: /^\d+$/, msg: "expected a VLAN number" },
+  LOCAL_VID: { re: /^\d+$/, msg: "expected a number" },
+  REMOTE_VID: { re: /^\d+$/, msg: "expected a number" },
+  UNIT: { re: /^\d+$/, msg: "expected a number" },
+  UNIT_1: { re: /^\d+$/, msg: "expected a number" },
+  UNIT_2: { re: /^\d+$/, msg: "expected a number" },
+  SITE_ID: { re: /^\d+$/, msg: "expected a number" },
+  REMOTE_SITE_ID: { re: /^\d+$/, msg: "expected a number" },
+  VC_ID: { re: /^\d+$/, msg: "expected a number" },
+  MTU: { re: /^\d+$/, msg: "expected a number" },
+  LABEL_BLOCK_SIZE: { re: /^\d+$/, msg: "expected a number" },
+  AC_INTF: {
+    re: /^[a-z]{2,3}-\d+\/\d+\/\d+(:\d+)?$|^ae\d+$/,
+    msg: "expected an interface (e.g. et-0/0/13, ae11)",
+  },
+  ESI_ID: {
+    re: /^([0-9a-fA-F]{2}:){9}[0-9a-fA-F]{2}$/,
+    msg: "expected a 10-byte ESI (00:…:01)",
+  },
+  INSTANCE_NAME: { re: /^[A-Za-z0-9_-]+$/, msg: "letters, digits, _ or - only" },
+  IP_ADDRESS: {
+    re: /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/,
+    msg: "expected ip/prefix (e.g. 198.51.100.1/27)",
+  },
+  ROUTER_ID: { re: /^\d{1,3}(\.\d{1,3}){3}$/, msg: "expected an IPv4 address" },
+};
+
+/** Format error for a single field value (undefined = valid or unvalidated). */
+function formatError(bare: string, value: string | undefined): string | undefined {
+  const v = VALIDATORS[bare];
+  if (v && value && !v.re.test(value)) return v.msg;
+  return undefined;
+}
+
 type OsChoice = GenOsKey | "none";
 
 type StepId =
@@ -767,6 +812,7 @@ export default function ConfigGenerator() {
                         <VarField
                           key={v.name}
                           name={v.name}
+                          error={formatError(bare, shared[bare])}
                           value={shared[bare]}
                           onChange={(val) => setShared((p) => ({ ...p, [bare]: val }))}
                         />
@@ -790,7 +836,7 @@ export default function ConfigGenerator() {
                           key={v.name}
                           name={v.name}
                           hint={mirror ? "(far-end remote auto-set)" : undefined}
-                          error={fieldErrors[bare]}
+                          error={formatError(bare, perA[bare]) ?? fieldErrors[bare]}
                           value={perA[bare]}
                           onChange={(val) => setPerA((p) => ({ ...p, [bare]: val }))}
                         />
@@ -813,7 +859,7 @@ export default function ConfigGenerator() {
                             key={v.name}
                             name={v.name}
                             hint={mirror ? "(far-end remote auto-set)" : undefined}
-                            error={fieldErrors[bare]}
+                            error={formatError(bare, perB[bare]) ?? fieldErrors[bare]}
                             value={perB[bare]}
                             onChange={(val) => setPerB((p) => ({ ...p, [bare]: val }))}
                           />

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -370,15 +370,19 @@ export default function ConfigGenerator() {
             ))}
 
           {currentStep === "deployment" &&
-            mux?.deployments.map((d) => (
-              <Chip
-                key={d.id}
-                label={d.label}
-                sub={d.description}
-                active={sel.deploymentId === d.id}
-                onClick={() => advance({ deploymentId: d.id }, ["os", "homing", "color"])}
-              />
-            ))}
+            mux?.deployments.map((d) => {
+              const dAvailable = d.available !== false;
+              return (
+                <Chip
+                  key={d.id}
+                  label={dAvailable ? d.label : `${d.label} — coming soon`}
+                  sub={d.description}
+                  active={sel.deploymentId === d.id}
+                  disabled={!dAvailable}
+                  onClick={() => advance({ deploymentId: d.id }, ["os", "homing", "color"])}
+                />
+              );
+            })}
 
           {currentStep === "os" &&
             (["junos", "evo"] as GenOsKey[]).map((os) => (

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -15,6 +15,7 @@ import {
   type GenCatalog,
   type GenOsKey,
   type GenSelection,
+  type VarSpec,
   resolveOsBlock,
   resolveSnipIds,
   attributeOptions,
@@ -23,10 +24,22 @@ import {
   classifyVar,
   endpointValues,
   instanceValues,
+  validateSpec,
 } from "@/lib/generator";
 
 const CATALOG = maasCatalog as unknown as GenCatalog;
 const ROLES = CATALOG.variableRoles;
+const IFACE_SPEC = CATALOG.interfaceSpec;
+const VAR_SPECS = (CATALOG.varSpecs ?? {}) as Record<string, unknown>;
+
+/** The validated field spec for a bare var name (skips the `_note` key). */
+function specFor(bare: string): VarSpec | undefined {
+  const s = VAR_SPECS[bare];
+  return s && typeof s === "object" && "type" in (s as object)
+    ? (s as VarSpec)
+    : undefined;
+}
+
 
 const JVDS = [
   {
@@ -67,48 +80,19 @@ const VAR_LABELS: Record<string, string> = {
 };
 const varLabel = (name: string) => VAR_LABELS[name.replace(/^\$/, "")] ?? name;
 
-/** Per-variable format validation (syntax). Value must match `re` or the
- *  field shows `msg` inline. Lenient — only flags clearly-malformed input. */
-const VALIDATORS: Record<string, { re: RegExp; msg: string }> = {
-  RD: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
-  VRF_TARGET: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
-  VRF_TARGET_1: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
-  VRF_TARGET_2: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
-  COMM_RT: { re: /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/, msg: "expected <ip|asn>:<number>" },
-  VLAN: { re: /^\d+$/, msg: "expected a VLAN number" },
-  VLAN_1: { re: /^\d+$/, msg: "expected a VLAN number" },
-  VLAN_2: { re: /^\d+$/, msg: "expected a VLAN number" },
-  INPUT_VID: { re: /^\d+$/, msg: "expected a VLAN number" },
-  LOCAL_VID: { re: /^\d+$/, msg: "expected a number" },
-  REMOTE_VID: { re: /^\d+$/, msg: "expected a number" },
-  UNIT: { re: /^\d+$/, msg: "expected a number" },
-  UNIT_1: { re: /^\d+$/, msg: "expected a number" },
-  UNIT_2: { re: /^\d+$/, msg: "expected a number" },
-  SITE_ID: { re: /^\d+$/, msg: "expected a number" },
-  REMOTE_SITE_ID: { re: /^\d+$/, msg: "expected a number" },
-  VC_ID: { re: /^\d+$/, msg: "expected a number" },
-  MTU: { re: /^\d+$/, msg: "expected a number" },
-  LABEL_BLOCK_SIZE: { re: /^\d+$/, msg: "expected a number" },
-  AC_INTF: {
-    re: /^[a-z]{2,3}-\d+\/\d+\/\d+(:\d+)?$|^ae\d+$/,
-    msg: "expected an interface (e.g. et-0/0/13, ae11)",
-  },
-  ESI_ID: {
-    re: /^([0-9a-fA-F]{2}:){9}[0-9a-fA-F]{2}$/,
-    msg: "expected a 10-byte ESI (00:…:01)",
-  },
-  INSTANCE_NAME: { re: /^[A-Za-z0-9_-]+$/, msg: "letters, digits, _ or - only" },
-  IP_ADDRESS: {
-    re: /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/,
-    msg: "expected ip/prefix (e.g. 198.51.100.1/27)",
-  },
-  ROUTER_ID: { re: /^\d{1,3}(\.\d{1,3}){3}$/, msg: "expected an IPv4 address" },
-};
-
-/** Format error for a single field value (undefined = valid or unvalidated). */
+/** Soft validation warning for a field value (undefined = valid/unvalidated).
+ *  Domain-aware: dropdown choices, numeric ranges, interface slot ranges. */
 function formatError(bare: string, value: string | undefined): string | undefined {
-  const v = VALIDATORS[bare];
-  if (v && value && !v.re.test(value)) return v.msg;
+  return validateSpec(value, specFor(bare), IFACE_SPEC);
+}
+
+/** A short hint describing the validated domain of a field (for interface /
+ *  numeric-range fields). undefined = no hint. */
+function fieldHint(bare: string): string | undefined {
+  const spec = specFor(bare);
+  if (spec?.type === "interface" && IFACE_SPEC)
+    return `${IFACE_SPEC.media.join(" / ")} · 0/0/0`;
+  if (spec?.type === "range") return `${spec.min}–${spec.max}`;
   return undefined;
 }
 
@@ -211,6 +195,14 @@ function VarField({
   hint?: string;
   error?: string;
 }) {
+  const bare = name.replace(/^\$/, "");
+  const spec = specFor(bare);
+  const inputCls = [
+    "mt-1 h-9 w-full rounded-md border bg-background px-3 font-mono text-sm text-foreground focus:outline-none",
+    error
+      ? "border-red-500/60 focus:border-red-500"
+      : "border-border focus:border-primary/60",
+  ].join(" ");
   return (
     <label className="block">
       <span className="flex items-baseline justify-between gap-2">
@@ -227,16 +219,27 @@ function VarField({
           )}
         </span>
       )}
-      <input
-        value={value ?? ""}
-        onChange={(e) => onChange(e.target.value)}
-        className={[
-          "mt-1 h-9 w-full rounded-md border bg-background px-3 font-mono text-sm text-foreground focus:outline-none",
-          error
-            ? "border-red-500/60 focus:border-red-500"
-            : "border-border focus:border-primary/60",
-        ].join(" ")}
-      />
+      {spec?.type === "enum" ? (
+        <select
+          value={value ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+          className={inputCls}
+        >
+          {Array.from(new Set([value, ...spec.values].filter(Boolean))).map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+              {!spec.values.includes(opt) ? " (custom)" : ""}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          value={value ?? ""}
+          inputMode={spec?.type === "range" ? "numeric" : undefined}
+          onChange={(e) => onChange(e.target.value)}
+          className={inputCls}
+        />
+      )}
     </label>
   );
 }
@@ -812,6 +815,7 @@ export default function ConfigGenerator() {
                         <VarField
                           key={v.name}
                           name={v.name}
+                          hint={fieldHint(bare)}
                           error={formatError(bare, shared[bare])}
                           value={shared[bare]}
                           onChange={(val) => setShared((p) => ({ ...p, [bare]: val }))}
@@ -835,7 +839,7 @@ export default function ConfigGenerator() {
                         <VarField
                           key={v.name}
                           name={v.name}
-                          hint={mirror ? "(far-end remote auto-set)" : undefined}
+                          hint={mirror ? "(far-end remote auto-set)" : fieldHint(bare)}
                           error={formatError(bare, perA[bare]) ?? fieldErrors[bare]}
                           value={perA[bare]}
                           onChange={(val) => setPerA((p) => ({ ...p, [bare]: val }))}
@@ -858,7 +862,7 @@ export default function ConfigGenerator() {
                           <VarField
                             key={v.name}
                             name={v.name}
-                            hint={mirror ? "(far-end remote auto-set)" : undefined}
+                              hint={mirror ? "(far-end remote auto-set)" : fieldHint(bare)}
                             error={formatError(bare, perB[bare]) ?? fieldErrors[bare]}
                             value={perB[bare]}
                             onChange={(val) => setPerB((p) => ({ ...p, [bare]: val }))}

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -9,21 +9,24 @@ import {
   ChevronRight,
   RotateCcw,
 } from "lucide-react";
-import { snipBundle, type SnipRecord } from "@/lib/snips";
+import { snipBundle, type SnipRecord, type SnipVariable } from "@/lib/snips";
 import maasCatalog from "@/data/generator/metro_as_a_service.json";
 import {
   type GenCatalog,
   type GenOsKey,
+  type GenSelection,
   resolveOsBlock,
   resolveSnipIds,
   attributeOptions,
   collectVariables,
   renderConfig,
+  classifyVar,
+  endpointValues,
 } from "@/lib/generator";
 
 const CATALOG = maasCatalog as unknown as GenCatalog;
+const ROLES = CATALOG.variableRoles;
 
-/** JVDs available in the generator. Only MaaS has a catalog today. */
 const JVDS = [
   {
     id: "metro_as_a_service",
@@ -43,12 +46,14 @@ const COLOR_LABELS: Record<string, string> = {
 };
 const OS_LABELS: Record<GenOsKey, string> = { evo: "Junos EVO", junos: "Junos" };
 
+type OsChoice = GenOsKey | "none";
+
 type StepId =
   | "jvd"
   | "family"
   | "mux"
   | "deployment"
-  | "os"
+  | "endpoints"
   | "attributes"
   | "params";
 
@@ -57,7 +62,7 @@ const STEP_TITLES: Record<StepId, string> = {
   family: "Service type",
   mux: "Service profile",
   deployment: "Deployment",
-  os: "Device OS",
+  endpoints: "Endpoints",
   attributes: "Service attributes",
   params: "Parameters",
 };
@@ -67,7 +72,7 @@ const STEPS: StepId[] = [
   "family",
   "mux",
   "deployment",
-  "os",
+  "endpoints",
   "attributes",
   "params",
 ];
@@ -77,12 +82,19 @@ type Selection = {
   familyId?: string;
   muxId?: string;
   deploymentId?: string;
-  os?: GenOsKey;
+  osA?: GenOsKey;
+  osB?: OsChoice;
   homing?: string;
   color?: string;
   cos: boolean;
   firewall: boolean;
 };
+
+/** Bump a trailing integer so PE-B defaults differ from PE-A. */
+function bumpB(example: string): string {
+  const m = example.match(/^(.*?)(\d+)$/);
+  return m ? m[1] + String(parseInt(m[2], 10) + 1) : example;
+}
 
 function Chip({
   label,
@@ -120,6 +132,32 @@ function Chip({
   );
 }
 
+function VarField({
+  name,
+  value,
+  onChange,
+  hint,
+}: {
+  name: string;
+  value: string;
+  onChange: (v: string) => void;
+  hint?: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-[11px] font-mono text-muted-foreground">
+        {name}
+        {hint && <span className="ml-1 text-muted-foreground/70">{hint}</span>}
+      </span>
+      <input
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1 h-9 w-full rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+      />
+    </label>
+  );
+}
+
 export default function ConfigGenerator() {
   const byId = useMemo(() => {
     const m = new Map<string, SnipRecord>();
@@ -128,7 +166,9 @@ export default function ConfigGenerator() {
   }, []);
 
   const [sel, setSel] = useState<Selection>({ cos: true, firewall: true });
-  const [vars, setVars] = useState<Record<string, string>>({});
+  const [shared, setShared] = useState<Record<string, string>>({});
+  const [perA, setPerA] = useState<Record<string, string>>({});
+  const [perB, setPerB] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState(false);
   const [step, setStep] = useState(0);
 
@@ -136,71 +176,139 @@ export default function ConfigGenerator() {
   const mux = family?.multiplexing.find((m) => m.id === sel.muxId);
   const deployment = mux?.deployments.find((d) => d.id === sel.deploymentId);
   const osOptions = deployment ? (Object.keys(deployment.os) as GenOsKey[]) : [];
-  const osBlock =
-    sel.familyId && sel.muxId && sel.deploymentId && sel.os
+
+  const twoPe = sel.osB && sel.osB !== "none";
+
+  const osBlockA =
+    sel.familyId && sel.muxId && sel.deploymentId && sel.osA
       ? resolveOsBlock(CATALOG, {
           familyId: sel.familyId,
           muxId: sel.muxId,
           deploymentId: sel.deploymentId,
-          os: sel.os,
+          os: sel.osA,
         })
       : null;
-  const attrs = osBlock ? attributeOptions(osBlock) : { homing: [], color: [] };
+  const osBlockB =
+    twoPe && sel.familyId && sel.muxId && sel.deploymentId
+      ? resolveOsBlock(CATALOG, {
+          familyId: sel.familyId,
+          muxId: sel.muxId,
+          deploymentId: sel.deploymentId,
+          os: sel.osB as GenOsKey,
+        })
+      : null;
+
+  // Attribute options = intersection of both endpoints (or just A when single).
+  const attrsA = osBlockA ? attributeOptions(osBlockA) : { homing: [], color: [] };
+  const attrsB = osBlockB ? attributeOptions(osBlockB) : null;
+  const homingOpts = attrsB
+    ? attrsA.homing.filter((h) => attrsB.homing.includes(h))
+    : attrsA.homing;
+  const colorOpts = attrsB
+    ? attrsA.color.filter((c) => attrsB.color.includes(c))
+    : attrsA.color;
 
   const attrsComplete = Boolean(sel.homing && (!sel.firewall || sel.color));
   const currentStep = STEPS[Math.min(step, STEPS.length - 1)];
-
   const complete = Boolean(
     sel.familyId &&
       sel.muxId &&
       sel.deploymentId &&
-      sel.os &&
+      sel.osA &&
       sel.homing &&
       (!sel.firewall || sel.color),
   );
 
-  const resolvedIds = useMemo(() => {
-    if (!complete) return [];
-    return resolveSnipIds(CATALOG, {
-      familyId: sel.familyId!,
-      muxId: sel.muxId!,
-      deploymentId: sel.deploymentId!,
-      os: sel.os!,
-      homing: sel.homing!,
-      color: sel.color ?? "",
-      cos: sel.cos,
-      firewall: sel.firewall,
-    });
-  }, [complete, sel]);
+  const selFor = (os: GenOsKey): GenSelection => ({
+    familyId: sel.familyId!,
+    muxId: sel.muxId!,
+    deploymentId: sel.deploymentId!,
+    os,
+    homing: sel.homing!,
+    color: sel.color ?? "",
+    cos: sel.cos,
+    firewall: sel.firewall,
+  });
 
-  const variables = useMemo(
-    () => collectVariables(resolvedIds, byId),
-    [resolvedIds, byId],
+  const idsA = useMemo(
+    () => (complete && sel.osA ? resolveSnipIds(CATALOG, selFor(sel.osA)) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [complete, sel],
   );
+  const idsB = useMemo(
+    () => (complete && twoPe ? resolveSnipIds(CATALOG, selFor(sel.osB as GenOsKey)) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [complete, sel],
+  );
+
+  // Union of variables across both endpoints.
+  const unionVars: SnipVariable[] = useMemo(() => {
+    const seen = new Set<string>();
+    const out: SnipVariable[] = [];
+    for (const v of [...collectVariables(idsA, byId), ...collectVariables(idsB, byId)]) {
+      if (!seen.has(v.name)) {
+        seen.add(v.name);
+        out.push(v);
+      }
+    }
+    return out;
+  }, [idsA, idsB, byId]);
+
+  const sharedFields = unionVars.filter(
+    (v) => classifyVar(v.name, ROLES).kind === "shared",
+  );
+  const perFields = unionVars.filter((v) => {
+    const k = classifyVar(v.name, ROLES).kind;
+    return k === "per-endpoint" || k === "mirrored-primary";
+  });
 
   const pathKey = JSON.stringify([
     sel.familyId,
     sel.muxId,
     sel.deploymentId,
-    sel.os,
+    sel.osA,
+    sel.osB,
     sel.homing,
     sel.color,
     sel.cos,
     sel.firewall,
   ]);
   useEffect(() => {
-    const seed: Record<string, string> = {};
-    for (const v of variables) seed[v.name] = v.example;
-    setVars(seed);
+    const sh: Record<string, string> = {};
+    const a: Record<string, string> = {};
+    const b: Record<string, string> = {};
+    for (const v of unionVars) {
+      const bare = v.name.replace(/^\$/, "");
+      const kind = classifyVar(v.name, ROLES).kind;
+      if (kind === "shared") sh[bare] = v.example;
+      else if (kind !== "mirrored-secondary") {
+        a[bare] = v.example;
+        b[bare] = bumpB(v.example);
+      }
+    }
+    setShared(sh);
+    setPerA(a);
+    setPerB(b);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathKey]);
 
-  const render = useMemo(() => {
-    if (!complete || resolvedIds.length === 0) return null;
-    return renderConfig(resolvedIds, vars, byId);
-  }, [complete, resolvedIds, vars, byId]);
+  const names = unionVars.map((v) => v.name);
+  const renderA = useMemo(() => {
+    if (!complete || idsA.length === 0) return null;
+    return renderConfig(idsA, endpointValues(names, ROLES, shared, perA, perB), byId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [complete, idsA, shared, perA, perB, byId]);
+  const renderB = useMemo(() => {
+    if (!complete || !twoPe || idsB.length === 0) return null;
+    return renderConfig(idsB, endpointValues(names, ROLES, shared, perB, perA), byId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [complete, twoPe, idsB, shared, perA, perB, byId]);
 
-  // Update selection, clearing downstream fields, then advance one step.
+  const fullText = [renderA?.text, renderB?.text].filter(Boolean).join("\n\n");
+  const missing = Array.from(
+    new Set([...(renderA?.missing ?? []), ...(renderB?.missing ?? [])]),
+  );
+
   const advance = (patch: Partial<Selection>, clears: (keyof Selection)[]) => {
     setSel((prev) => {
       const next = { ...prev, ...patch };
@@ -220,8 +328,12 @@ export default function ConfigGenerator() {
         return mux?.label ?? null;
       case "deployment":
         return deployment?.label ?? null;
-      case "os":
-        return sel.os ? OS_LABELS[sel.os] : null;
+      case "endpoints":
+        return sel.osA
+          ? twoPe
+            ? `${OS_LABELS[sel.osA]} ↔ ${OS_LABELS[sel.osB as GenOsKey]}`
+            : `${OS_LABELS[sel.osA]} (single)`
+          : null;
       case "attributes":
         return attrsComplete
           ? [
@@ -236,19 +348,20 @@ export default function ConfigGenerator() {
         return null;
     }
   };
-
   const crumbs = STEPS.slice(0, step).filter((id) => crumbValue(id) !== null);
 
   const reset = () => {
     setSel({ cos: true, firewall: true });
-    setVars({});
+    setShared({});
+    setPerA({});
+    setPerB({});
     setStep(0);
   };
 
   const download = () => {
-    if (!render) return;
-    const fname = `maas-${sel.familyId}-${sel.deploymentId}-${sel.os}.conf`;
-    const blob = new Blob([render.text], { type: "text/plain" });
+    if (!fullText) return;
+    const fname = `maas-${sel.familyId}-${sel.deploymentId}.conf`;
+    const blob = new Blob([fullText + "\n"], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -258,17 +371,19 @@ export default function ConfigGenerator() {
   };
 
   const copy = async () => {
-    if (!render) return;
-    await navigator.clipboard.writeText(render.text);
+    if (!fullText) return;
+    await navigator.clipboard.writeText(fullText + "\n");
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
 
+  const peLabel = (os: GenOsKey | undefined, tag: string) =>
+    os ? `${tag} · ${OS_LABELS[os]}` : tag;
+
   return (
-    <div className="mt-10 grid gap-6 lg:grid-cols-[1fr_minmax(22rem,32rem)]">
-      {/* Left: the wizard (one step at a time) */}
+    <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_minmax(22rem,34rem)]">
+      {/* Left: the wizard */}
       <div className="rounded-lg border border-border bg-surface p-6">
-        {/* Breadcrumb of prior choices */}
         {crumbs.length > 0 && (
           <div className="mb-4 flex flex-wrap items-center gap-1.5 text-xs">
             {crumbs.map((id, i) => (
@@ -288,7 +403,6 @@ export default function ConfigGenerator() {
           </div>
         )}
 
-        {/* Header: back + step counter + start over */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             {step > 0 && (
@@ -313,7 +427,6 @@ export default function ConfigGenerator() {
           )}
         </div>
 
-        {/* Current step body */}
         <div className="mt-4 space-y-3">
           {currentStep === "jvd" &&
             JVDS.map((j) => (
@@ -328,7 +441,8 @@ export default function ConfigGenerator() {
                     "familyId",
                     "muxId",
                     "deploymentId",
-                    "os",
+                    "osA",
+                    "osB",
                     "homing",
                     "color",
                   ])
@@ -348,7 +462,8 @@ export default function ConfigGenerator() {
                   advance({ familyId: f.id }, [
                     "muxId",
                     "deploymentId",
-                    "os",
+                    "osA",
+                    "osB",
                     "homing",
                     "color",
                   ])
@@ -364,7 +479,13 @@ export default function ConfigGenerator() {
                 sub={m.description}
                 active={sel.muxId === m.id}
                 onClick={() =>
-                  advance({ muxId: m.id }, ["deploymentId", "os", "homing", "color"])
+                  advance({ muxId: m.id }, [
+                    "deploymentId",
+                    "osA",
+                    "osB",
+                    "homing",
+                    "color",
+                  ])
                 }
               />
             ))}
@@ -379,35 +500,76 @@ export default function ConfigGenerator() {
                   sub={d.description}
                   active={sel.deploymentId === d.id}
                   disabled={!dAvailable}
-                  onClick={() => advance({ deploymentId: d.id }, ["os", "homing", "color"])}
+                  onClick={() =>
+                    advance({ deploymentId: d.id }, ["osA", "osB", "homing", "color"])
+                  }
                 />
               );
             })}
 
-          {currentStep === "os" &&
-            (["junos", "evo"] as GenOsKey[]).map((os) => (
-              <Chip
-                key={os}
-                label={OS_LABELS[os]}
-                sub={
-                  osOptions.includes(os)
-                    ? os === "evo"
-                      ? "ACX 7xxx"
-                      : "MX, ACX 5xxx / 710"
-                    : "not validated for this service"
-                }
-                active={sel.os === os}
-                disabled={!osOptions.includes(os)}
-                onClick={() => advance({ os }, ["homing", "color"])}
-              />
-            ))}
+          {currentStep === "endpoints" && (
+            <div className="space-y-4">
+              <div>
+                <div className="mb-2 text-xs font-medium text-foreground">
+                  PE-A (device OS)
+                </div>
+                <div className="space-y-2">
+                  {(["junos", "evo"] as GenOsKey[]).map((os) => (
+                    <Chip
+                      key={os}
+                      label={OS_LABELS[os]}
+                      sub={osOptions.includes(os) ? undefined : "not validated for this service"}
+                      active={sel.osA === os}
+                      disabled={!osOptions.includes(os)}
+                      onClick={() => setSel((p) => ({ ...p, osA: os }))}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div className="mb-2 text-xs font-medium text-foreground">
+                  PE-B (far endpoint)
+                </div>
+                <div className="space-y-2">
+                  <Chip
+                    label="Single device only"
+                    sub="Generate just PE-A (brownfield add)"
+                    active={sel.osB === "none"}
+                    onClick={() => setSel((p) => ({ ...p, osB: "none" }))}
+                  />
+                  {(["junos", "evo"] as GenOsKey[]).map((os) => (
+                    <Chip
+                      key={os}
+                      label={OS_LABELS[os]}
+                      sub={osOptions.includes(os) ? "Match identifiers automatically" : "not validated for this service"}
+                      active={sel.osB === os}
+                      disabled={!osOptions.includes(os)}
+                      onClick={() => setSel((p) => ({ ...p, osB: os }))}
+                    />
+                  ))}
+                </div>
+              </div>
+              <button
+                disabled={!sel.osA || !sel.osB}
+                onClick={() => setStep((s) => s + 1)}
+                className={[
+                  "inline-flex items-center gap-1.5 rounded-md px-4 py-2 text-sm font-medium",
+                  sel.osA && sel.osB
+                    ? "border border-primary/40 bg-primary/10 text-primary hover:bg-primary/20"
+                    : "cursor-not-allowed border border-border text-muted-foreground opacity-60",
+                ].join(" ")}
+              >
+                Continue <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          )}
 
-          {currentStep === "attributes" && osBlock && (
+          {currentStep === "attributes" && osBlockA && (
             <div className="space-y-4">
               <div>
                 <div className="mb-2 text-xs font-medium text-foreground">Homing</div>
                 <div className="space-y-2">
-                  {attrs.homing.map((h) => (
+                  {homingOpts.map((h) => (
                     <Chip
                       key={h}
                       label={HOMING_LABELS[h] ?? h}
@@ -417,7 +579,6 @@ export default function ConfigGenerator() {
                   ))}
                 </div>
               </div>
-
               <div>
                 <div className="mb-2 text-xs font-medium text-foreground">
                   Class of Service
@@ -437,7 +598,6 @@ export default function ConfigGenerator() {
                   />
                 </div>
               </div>
-
               <div>
                 <div className="mb-2 text-xs font-medium text-foreground">
                   UNI firewall filter
@@ -457,12 +617,11 @@ export default function ConfigGenerator() {
                   />
                 </div>
               </div>
-
               {sel.firewall && (
                 <div>
                   <div className="mb-2 text-xs font-medium text-foreground">Color mode</div>
                   <div className="space-y-2">
-                    {attrs.color.map((c) => (
+                    {colorOpts.map((c) => (
                       <Chip
                         key={c}
                         label={COLOR_LABELS[c] ?? c}
@@ -473,7 +632,6 @@ export default function ConfigGenerator() {
                   </div>
                 </div>
               )}
-
               <button
                 disabled={!attrsComplete}
                 onClick={() => setStep((s) => s + 1)}
@@ -490,35 +648,76 @@ export default function ConfigGenerator() {
           )}
 
           {currentStep === "params" && (
-            <div>
-              {variables.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No variables for this selection — the config on the right is ready.
-                </p>
-              ) : (
-                <>
-                  <p className="mb-3 text-xs text-muted-foreground">
-                    Prefilled with lab-safe example values — edit any field for your
-                    deployment. The config updates live on the right.
-                  </p>
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    {variables.map((v) => (
-                      <label key={v.name} className="block">
-                        <span className="text-[11px] font-mono text-muted-foreground">
-                          {v.name}
-                        </span>
-                        <input
-                          value={vars[v.name] ?? ""}
-                          onChange={(e) =>
-                            setVars((p) => ({ ...p, [v.name]: e.target.value }))
-                          }
-                          className="mt-1 h-9 w-full rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
-                        />
-                      </label>
-                    ))}
+            <div className="space-y-5">
+              {sharedFields.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    Shared{" "}
+                    <span className="font-normal text-muted-foreground">
+                      — identical on both PEs
+                    </span>
                   </div>
-                </>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {sharedFields.map((v) => {
+                      const bare = v.name.replace(/^\$/, "");
+                      return (
+                        <VarField
+                          key={v.name}
+                          name={v.name}
+                          value={shared[bare]}
+                          onChange={(val) => setShared((p) => ({ ...p, [bare]: val }))}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
               )}
+
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    {peLabel(sel.osA, "PE-A")}
+                  </div>
+                  <div className="space-y-3">
+                    {perFields.map((v) => {
+                      const bare = v.name.replace(/^\$/, "");
+                      const mirror = classifyVar(v.name, ROLES).kind === "mirrored-primary";
+                      return (
+                        <VarField
+                          key={v.name}
+                          name={v.name}
+                          hint={mirror ? "(far-end remote auto-set)" : undefined}
+                          value={perA[bare]}
+                          onChange={(val) => setPerA((p) => ({ ...p, [bare]: val }))}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+                {twoPe && (
+                  <div>
+                    <div className="mb-2 text-xs font-medium text-foreground">
+                      {peLabel(sel.osB as GenOsKey, "PE-B")}
+                    </div>
+                    <div className="space-y-3">
+                      {perFields.map((v) => {
+                        const bare = v.name.replace(/^\$/, "");
+                        const mirror =
+                          classifyVar(v.name, ROLES).kind === "mirrored-primary";
+                        return (
+                          <VarField
+                            key={v.name}
+                            name={v.name}
+                            hint={mirror ? "(far-end remote auto-set)" : undefined}
+                            value={perB[bare]}
+                            onChange={(val) => setPerB((p) => ({ ...p, [bare]: val }))}
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </div>
@@ -531,7 +730,7 @@ export default function ConfigGenerator() {
             <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
               Generated config
             </span>
-            {render && (
+            {fullText && (
               <div className="flex gap-2">
                 <button
                   onClick={copy}
@@ -557,17 +756,34 @@ export default function ConfigGenerator() {
             </div>
           ) : (
             <>
-              {render && render.missing.length > 0 && (
+              {missing.length > 0 && (
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
                   <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>Unfilled variables: {render.missing.join(", ")}.</span>
+                  <span>Unfilled variables: {missing.join(", ")}.</span>
                 </div>
               )}
-              <pre className="mt-3 max-h-[32rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
-                {render?.text}
-              </pre>
+              {renderA && (
+                <div className="mt-3">
+                  <div className="mb-1 text-[11px] font-semibold text-primary">
+                    # {peLabel(sel.osA, "PE-A")}
+                  </div>
+                  <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
+                    {renderA.text}
+                  </pre>
+                </div>
+              )}
+              {renderB && (
+                <div className="mt-4">
+                  <div className="mb-1 text-[11px] font-semibold text-primary">
+                    # {peLabel(sel.osB as GenOsKey, "PE-B")}
+                  </div>
+                  <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
+                    {renderB.text}
+                  </pre>
+                </div>
+              )}
               <div className="mt-2 text-[11px] text-muted-foreground">
-                {resolvedIds.length} snip{resolvedIds.length === 1 ? "" : "s"} ·{" "}
+                {twoPe ? "2 endpoints · matched identifiers" : "single device"} ·{" "}
                 {[sel.cos && "CoS", sel.firewall && "firewall filter"]
                   .filter(Boolean)
                   .join(" + ") || "service only"}{" "}

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import jvds from "@/data/jvds.json";
-import { ArrowRight, Github, ExternalLink, Network, Layers } from "lucide-react";
+import { ArrowRight, Github, ExternalLink, Network, Layers, Info } from "lucide-react";
 import brandLogo from "@/assets/hpe-juniper-networking.avif";
 import SnipLibrary from "@/components/SnipLibrary";
 import ByoaiSection from "@/components/ByoaiSection";
@@ -343,6 +343,16 @@ export default function JvdPortal() {
             Metro-as-a-Service E-Line is available first — more services and
             JVDs coming.
           </p>
+
+          <div className="mt-5 flex max-w-2xl items-start gap-2 rounded-md border border-border bg-surface p-3 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <span>
+              Configurations are strictly based on what was built and validated
+              in the JVD. Some otherwise-supported service, platform, or feature
+              combinations may not appear here because they were not covered by
+              the validated design.
+            </span>
+          </div>
 
           <ConfigGenerator />
         </div>

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -89,8 +89,30 @@
                 "evo": {
                   "service": ["evo/services/evpn-vpws-vlan-based"],
                   "interface": {
-                    "single-homed": "evo/interfaces/vlan-ccc-vlan-map",
-                    "multihomed": "evo/interfaces/vlan-ccc-vlan-map-esi"
+                    "single-homed": "evo/interfaces/vlan-ccc",
+                    "multihomed": "evo/interfaces/vlan-ccc-esi"
+                  },
+                  "uni": {
+                    "modes": [
+                      {
+                        "id": "single-vlan",
+                        "label": "Single VLAN",
+                        "description": "One customer VLAN, matched end-to-end (no S-VLAN translation).",
+                        "interface": {
+                          "single-homed": "evo/interfaces/vlan-ccc",
+                          "multihomed": "evo/interfaces/vlan-ccc-esi"
+                        }
+                      },
+                      {
+                        "id": "vlan-map",
+                        "label": "VLAN map (S-VLAN push/pop)",
+                        "description": "Normalize the customer VLAN to a provider S-VLAN (input push / output pop).",
+                        "interface": {
+                          "single-homed": "evo/interfaces/vlan-ccc-vlan-map",
+                          "multihomed": "evo/interfaces/vlan-ccc-vlan-map-esi"
+                        }
+                      }
+                    ]
                   },
                   "interfaceExtras": ["evo/interfaces/physical-mtu"],
                   "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }
@@ -100,6 +122,19 @@
                   "interface": {
                     "single-homed": "junos/interfaces/vlan-ccc-vlan-map",
                     "multihomed": "junos/interfaces/vlan-ccc-vlan-map-esi"
+                  },
+                  "uni": {
+                    "modes": [
+                      {
+                        "id": "vlan-map",
+                        "label": "VLAN map (S-VLAN push/pop)",
+                        "description": "Normalize the customer VLAN to a provider S-VLAN (input push / output pop).",
+                        "interface": {
+                          "single-homed": "junos/interfaces/vlan-ccc-vlan-map",
+                          "multihomed": "junos/interfaces/vlan-ccc-vlan-map-esi"
+                        }
+                      }
+                    ]
                   },
                   "interfaceExtras": [],
                   "filter": {

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -12,13 +12,14 @@
     "junos": ["junos/cos/classifiers", "junos/cos/cos-binding-ieee8021p", "junos/cos/rewrite-rules"]
   },
   "variableRoles": {
-    "_note": "Classifies each $VAR for two-endpoint (PE-A / PE-B) rendering. 'shared' = identical on both PEs (must match). 'mirrored' pairs = each PE's local value; the partner is auto-filled from the other PE's local value (e.g. PE-A remote-site-id = PE-B site-id). 'distinctPerEndpoint' = per-PE values that MUST differ (default bumped + warned if identical). Everything not listed = per-endpoint, defaults the same on both PEs.",
+    "_note": "Classifies each $VAR for two-endpoint (PE-A / PE-B) rendering. 'shared' = identical on both PEs (must match). VLAN is shared because the MaaS JVD's captured configs use matching UNI VLANs — differing VLANs would require input/output vlan-map normalization snips the JVD does not include. 'mirrored' pairs = each PE's local value; the partner is auto-filled from the other PE's local value. 'distinctPerEndpoint' = per-PE values that MUST differ for L2 services (RD) — default bumped + warned if identical. NOTE: for future L3 services (L3VPN/EVPN Type-5), same RD is valid, so this rule must be scoped per service type. Everything not listed = per-endpoint, defaults the same on both PEs.",
     "shared": [
       "INSTANCE_NAME",
       "VRF_TARGET",
       "VRF_TARGET_1",
       "VRF_TARGET_2",
       "VC_ID",
+      "VLAN",
       "LABEL_BLOCK_SIZE",
       "SITE_RANGE",
       "COMM_RT",

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -73,6 +73,85 @@
                   }
                 }
               }
+            },
+            {
+              "id": "bgp-vpls-p2p",
+              "label": "BGP-VPLS (P2P)",
+              "description": "Point-to-point delivered over BGP-VPLS (RFC 4761 virtual-switch).",
+              "os": {
+                "evo": {
+                  "service": ["evo/services/bgp-vpls-p2p"],
+                  "interface": { "single-homed": "evo/interfaces/vlan-bridge" },
+                  "interfaceExtras": [],
+                  "filter": { "color-blind": "evo/firewall/filter-eswitch-color-blind" }
+                },
+                "junos": {
+                  "service": ["junos/services/bgp-vpls-p2p"],
+                  "interface": { "single-homed": "junos/interfaces/vlan-bridge" },
+                  "interfaceExtras": [],
+                  "filter": { "color-aware": "junos/firewall/filter-bridge-color-aware" }
+                }
+              }
+            },
+            {
+              "id": "evpn-fxc",
+              "label": "EVPN-FXC",
+              "description": "Flexible Cross-Connect — many VLAN UNIs bundled under one EVPN-VPWS.",
+              "available": false,
+              "os": {
+                "evo": {
+                  "service": ["evo/services/evpn-fxc-vlan-unaware"],
+                  "interface": { "single-homed": "evo/interfaces/vlan-ccc-2-units" },
+                  "interfaceExtras": ["evo/interfaces/physical-mtu"],
+                  "filter": { "color-blind": "evo/firewall/filter-eswitch-color-blind" }
+                }
+              }
+            },
+            {
+              "id": "l2circuit-hot-standby",
+              "label": "L2Circuit (hot-standby)",
+              "description": "LDP pseudowire with a primary + backup neighbor for fast failover.",
+              "os": {
+                "evo": {
+                  "service": [
+                    "evo/services/l2circuit-hot-standby-primary",
+                    "evo/services/l2circuit-hot-standby-backup"
+                  ],
+                  "interface": { "single-homed": "evo/interfaces/vlan-ccc-vlan-map" },
+                  "interfaceExtras": ["evo/interfaces/physical-mtu"],
+                  "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }
+                }
+              }
+            },
+            {
+              "id": "l2circuit-floating-pw",
+              "label": "L2Circuit (floating PW)",
+              "description": "Static-label pseudowire landing on a pseudowire-subscriber anchor.",
+              "os": {
+                "evo": {
+                  "service": ["evo/services/l2circuit-floating-pw"],
+                  "interface": { "single-homed": "evo/interfaces/vlan-ccc" },
+                  "interfaceExtras": [],
+                  "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }
+                }
+              }
+            },
+            {
+              "id": "evpn-floating-pw",
+              "label": "EVPN Floating PW",
+              "description": "EVPN-ELAN landing on a floating pseudowire (ps anchor); Junos head-end.",
+              "available": false,
+              "os": {
+                "junos": {
+                  "service": [
+                    "junos/services/evpn-elan-vlan-based-floating-pw",
+                    "junos/services/l2circuit-floating-pw"
+                  ],
+                  "interface": { "single-homed": "junos/interfaces/vlan-bridge-esi" },
+                  "interfaceExtras": ["junos/interfaces/pseudowire-subscriber"],
+                  "filter": {}
+                }
+              }
             }
           ]
         },

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -12,7 +12,7 @@
     "junos": ["junos/cos/classifiers", "junos/cos/cos-binding-ieee8021p", "junos/cos/rewrite-rules"]
   },
   "variableRoles": {
-    "_note": "Classifies each $VAR for two-endpoint (PE-A / PE-B) rendering. 'shared' = identical on both PEs (must match). 'mirrored' pairs = each PE's local value; the partner is auto-filled from the other PE's local value (e.g. PE-A remote-site-id = PE-B site-id). Everything not listed = per-endpoint (each PE has its own value).",
+    "_note": "Classifies each $VAR for two-endpoint (PE-A / PE-B) rendering. 'shared' = identical on both PEs (must match). 'mirrored' pairs = each PE's local value; the partner is auto-filled from the other PE's local value (e.g. PE-A remote-site-id = PE-B site-id). 'distinctPerEndpoint' = per-PE values that MUST differ (default bumped + warned if identical). Everything not listed = per-endpoint, defaults the same on both PEs.",
     "shared": [
       "INSTANCE_NAME",
       "VRF_TARGET",
@@ -27,7 +27,8 @@
     "mirrored": [
       ["LOCAL_VID", "REMOTE_VID"],
       ["SITE_ID", "REMOTE_SITE_ID"]
-    ]
+    ],
+    "distinctPerEndpoint": ["RD"]
   },
   "families": [
     {

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -29,7 +29,8 @@
       ["LOCAL_VID", "REMOTE_VID"],
       ["SITE_ID", "REMOTE_SITE_ID"]
     ],
-    "distinctPerEndpoint": ["RD"]
+    "distinctPerEndpoint": ["RD"],
+    "instanceConstant": ["MTU", "LABEL_BLOCK_SIZE", "FILTER_NAME", "SITE_RANGE", "AC_INTF"]
   },
   "families": [
     {

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -20,6 +20,7 @@
       "VRF_TARGET_2",
       "VC_ID",
       "VLAN",
+      "INPUT_VID",
       "LABEL_BLOCK_SIZE",
       "SITE_RANGE",
       "COMM_RT",
@@ -31,6 +32,41 @@
     ],
     "distinctPerEndpoint": ["RD"],
     "instanceConstant": ["MTU", "LABEL_BLOCK_SIZE", "FILTER_NAME", "SITE_RANGE", "AC_INTF"]
+  },
+  "interfaceSpec": {
+    "_note": "Validated attachment-circuit interface domain for the MaaS PE platforms (ACX7024/7100, MX304). media = permitted port-type prefixes; the slot/pic/port ranges catch clearly-out-of-range typos (e.g. et-99/99/99) while staying wide enough not to false-flag valid ports. Values outside this domain still render but are flagged 'not JVD-validated'.",
+    "media": ["ge", "xe", "et", "ae"],
+    "fpcMax": 11,
+    "picMax": 3,
+    "portMax": 71,
+    "channelMax": 7,
+    "aeMax": 1023
+  },
+  "varSpecs": {
+    "_note": "Per-variable field type + validated domain. type: enum (dropdown of JVD-valid choices) | range (bounded integer) | interface (uses interfaceSpec) | rd | rt | esi | name | text. Anything not listed is a free text field. Out-of-domain values render but show a soft 'not JVD-validated' warning — never blocked.",
+    "INSTANCE_NAME": { "type": "name" },
+    "AC_INTF": { "type": "interface" },
+    "RD": { "type": "rd" },
+    "VRF_TARGET": { "type": "rt" },
+    "VRF_TARGET_1": { "type": "rt" },
+    "VRF_TARGET_2": { "type": "rt" },
+    "COMM_RT": { "type": "rt" },
+    "VPN_RT_COMM": { "type": "rt" },
+    "ESI_ID": { "type": "esi" },
+    "VLAN": { "type": "range", "min": 1, "max": 4094 },
+    "VLAN_1": { "type": "range", "min": 1, "max": 4094 },
+    "VLAN_2": { "type": "range", "min": 1, "max": 4094 },
+    "INPUT_VID": { "type": "range", "min": 1, "max": 4094 },
+    "UNIT": { "type": "range", "min": 0, "max": 16385 },
+    "UNIT_1": { "type": "range", "min": 0, "max": 16385 },
+    "UNIT_2": { "type": "range", "min": 0, "max": 16385 },
+    "LOCAL_VID": { "type": "range", "min": 1, "max": 16777215 },
+    "REMOTE_VID": { "type": "range", "min": 1, "max": 16777215 },
+    "SITE_ID": { "type": "range", "min": 1, "max": 65534 },
+    "REMOTE_SITE_ID": { "type": "range", "min": 1, "max": 65534 },
+    "VC_ID": { "type": "range", "min": 1, "max": 4294967295 },
+    "MTU": { "type": "enum", "values": ["1522", "2000", "9102", "9192", "9500"] },
+    "LABEL_BLOCK_SIZE": { "type": "enum", "values": ["2", "4", "8", "16", "32", "64"] }
   },
   "families": [
     {
@@ -53,8 +89,8 @@
                 "evo": {
                   "service": ["evo/services/evpn-vpws-vlan-based"],
                   "interface": {
-                    "single-homed": "evo/interfaces/vlan-ccc",
-                    "multihomed": "evo/interfaces/vlan-ccc-esi"
+                    "single-homed": "evo/interfaces/vlan-ccc-vlan-map",
+                    "multihomed": "evo/interfaces/vlan-ccc-vlan-map-esi"
                   },
                   "interfaceExtras": ["evo/interfaces/physical-mtu"],
                   "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -11,6 +11,24 @@
     "evo": ["evo/cos/classifiers", "evo/cos/cos-binding-ieee8021p", "evo/cos/rewrite-rules"],
     "junos": ["junos/cos/classifiers", "junos/cos/cos-binding-ieee8021p", "junos/cos/rewrite-rules"]
   },
+  "variableRoles": {
+    "_note": "Classifies each $VAR for two-endpoint (PE-A / PE-B) rendering. 'shared' = identical on both PEs (must match). 'mirrored' pairs = each PE's local value; the partner is auto-filled from the other PE's local value (e.g. PE-A remote-site-id = PE-B site-id). Everything not listed = per-endpoint (each PE has its own value).",
+    "shared": [
+      "INSTANCE_NAME",
+      "VRF_TARGET",
+      "VRF_TARGET_1",
+      "VRF_TARGET_2",
+      "VC_ID",
+      "LABEL_BLOCK_SIZE",
+      "SITE_RANGE",
+      "COMM_RT",
+      "VPN_RT_COMM"
+    ],
+    "mirrored": [
+      ["LOCAL_VID", "REMOTE_VID"],
+      ["SITE_ID", "REMOTE_SITE_ID"]
+    ]
+  },
   "families": [
     {
       "id": "e-line",

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -51,8 +51,65 @@ export type GenCatalog = {
   version: number;
   tiers: Record<string, { label: string; description: string }>;
   cosSnips: Record<GenOsKey, string[]>;
+  variableRoles: VariableRoles;
   families: GenFamily[];
 };
+
+/**
+ * Classifies each $VAR for two-endpoint rendering:
+ *  - shared: identical on both PEs (route-target, instance name, …)
+ *  - mirrored pairs: each PE's local value; the partner is the OTHER PE's
+ *    local value (e.g. PE-A remote-site-id = PE-B site-id)
+ *  - anything not listed = per-endpoint (each PE has its own)
+ */
+export type VariableRoles = {
+  shared: string[];
+  mirrored: [string, string][];
+};
+
+export type VarKind =
+  | "shared"
+  | "mirrored-primary"
+  | "mirrored-secondary"
+  | "per-endpoint";
+
+/** Classify a variable name (with or without leading $). */
+export function classifyVar(
+  name: string,
+  roles: VariableRoles,
+): { kind: VarKind; partner?: string } {
+  const bare = name.replace(/^\$/, "");
+  if (roles.shared.includes(bare)) return { kind: "shared" };
+  for (const [a, b] of roles.mirrored) {
+    if (bare === a) return { kind: "mirrored-primary", partner: b };
+    if (bare === b) return { kind: "mirrored-secondary", partner: a };
+  }
+  return { kind: "per-endpoint" };
+}
+
+/**
+ * Build the concrete value map for one endpoint. `shared` applies to both
+ * PEs; `own` holds this PE's per-endpoint + mirrored-primary values;
+ * `other` supplies the far PE's values so mirrored-secondary vars
+ * (REMOTE_*) resolve to the far end's local value.
+ */
+export function endpointValues(
+  varNames: string[],
+  roles: VariableRoles,
+  shared: Record<string, string>,
+  own: Record<string, string>,
+  other: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...shared, ...own };
+  for (const name of varNames) {
+    const bare = name.replace(/^\$/, "");
+    const c = classifyVar(bare, roles);
+    if (c.kind === "mirrored-secondary" && c.partner && other[c.partner] !== undefined) {
+      out[bare] = other[c.partner];
+    }
+  }
+  return out;
+}
 
 export type GenSelection = {
   familyId: string;

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -14,11 +14,26 @@ import type { SnipRecord, SnipVariable } from "@/lib/snips";
 
 export type GenOsKey = "evo" | "junos";
 
+/**
+ * A UNI VLAN-handling mode (single VLAN vs VLAN-map normalization, and later
+ * QinQ / bundle variants). Each mode maps a homing key to the interface snip
+ * that implements it. When an OS block declares `uni.modes`, the wizard shows
+ * a "VLAN handling" selector and the interface is resolved from the chosen
+ * mode; otherwise the flat `interface` map is used (legacy single-mode).
+ */
+export type UniMode = {
+  id: string;
+  label: string;
+  description: string;
+  interface: Record<string, string>; // homing key -> snip id (relative to jvd)
+};
+
 export type GenOsBlock = {
   service: string[];
   interface: Record<string, string>; // homing key -> snip id (relative to jvd)
   interfaceExtras: string[];
   filter: Record<string, string>; // color key -> snip id (relative to jvd)
+  uni?: { modes: UniMode[] };
 };
 
 export type GenDeployment = {
@@ -249,6 +264,7 @@ export type GenSelection = {
   deploymentId: string;
   os: GenOsKey;
   homing: string; // key into osBlock.interface
+  vlanMode?: string; // id of the chosen uni.mode (when the OS block has them)
   cos: boolean; // include CoS binding snips (classifiers, scheduler binding)
   firewall: boolean; // include the UNI firewall filter
   color: string; // key into osBlock.filter (required when firewall = true)
@@ -265,6 +281,25 @@ export function resolveOsBlock(
   return dep?.os[sel.os] ?? null;
 }
 
+/** The VLAN-handling modes an OS block offers (empty when it has none). */
+export function vlanModes(osb: GenOsBlock): UniMode[] {
+  return osb.uni?.modes ?? [];
+}
+
+/** The homing→snip interface map for the chosen VLAN mode (or the flat/legacy
+ *  map when the block has no `uni.modes`). */
+export function osInterfaceMap(
+  osb: GenOsBlock,
+  vlanMode?: string,
+): Record<string, string> {
+  if (osb.uni) {
+    const mode =
+      osb.uni.modes.find((m) => m.id === vlanMode) ?? osb.uni.modes[0];
+    return mode?.interface ?? {};
+  }
+  return osb.interface;
+}
+
 /**
  * Resolve the ordered list of jvd-qualified snip IDs for a full selection.
  * Order: service(s) → attachment-circuit interface → interface extras →
@@ -275,7 +310,7 @@ export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[]
   if (!osb) return [];
   const rel: string[] = [];
   rel.push(...osb.service);
-  const iface = osb.interface[sel.homing];
+  const iface = osInterfaceMap(osb, sel.vlanMode)[sel.homing];
   if (iface) rel.push(iface);
   rel.push(...osb.interfaceExtras);
   if (sel.firewall) {
@@ -298,13 +333,17 @@ export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[]
   return out;
 }
 
-/** The homing / color attribute options that are valid for a given OS block. */
-export function attributeOptions(osb: GenOsBlock): {
+/** The homing / color attribute options that are valid for a given OS block
+ *  (homing depends on the chosen VLAN mode when the block has `uni.modes`). */
+export function attributeOptions(
+  osb: GenOsBlock,
+  vlanMode?: string,
+): {
   homing: string[];
   color: string[];
 } {
   return {
-    homing: Object.keys(osb.interface),
+    homing: Object.keys(osInterfaceMap(osb, vlanMode)),
     color: Object.keys(osb.filter),
   };
 }

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -67,6 +67,9 @@ export type VariableRoles = {
   mirrored: [string, string][];
   /** Per-endpoint vars that MUST differ between PEs (e.g. RD). */
   distinctPerEndpoint?: string[];
+  /** Vars that stay the SAME across service instances (N-count) — e.g. the
+   *  physical port, MTU, filter name. Everything else increments per instance. */
+  instanceConstant?: string[];
 };
 
 export type VarKind =
@@ -87,6 +90,32 @@ export function classifyVar(
     if (bare === b) return { kind: "mirrored-secondary", partner: a };
   }
   return { kind: "per-endpoint" };
+}
+
+/** Increment the trailing integer of a value by `by` (0 = unchanged). */
+export function bumpInt(value: string, by: number): string {
+  if (by === 0) return value;
+  const m = value.match(/^(.*?)(\d+)$/);
+  return m ? m[1] + String(parseInt(m[2], 10) + by) : value;
+}
+
+/**
+ * Shift a value map to the Nth service instance: every variable's trailing
+ * integer is incremented by `i`, except those listed as instanceConstant
+ * (physical port, MTU, filter name, …). Instance 0 = unchanged (the values
+ * the user entered are the starting point for service #1).
+ */
+export function instanceValues(
+  values: Record<string, string>,
+  roles: VariableRoles,
+  i: number,
+): Record<string, string> {
+  const constant = new Set(roles.instanceConstant ?? []);
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(values)) {
+    out[k] = constant.has(k) ? v : bumpInt(v, i);
+  }
+  return out;
 }
 
 /**

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -444,6 +444,13 @@ export function renderConfig(
     if (opts?.stripUniFilter && snip.category === "interfaces") {
       body = stripUniFilterBinding(body);
     }
+    // Normalise interface snips under an `interfaces { … }` wrapper so they
+    // merge with each other (and with the CoS binding, which is already
+    // wrapped) into one physical-interface stanza. Some snips already carry
+    // the wrapper — don't double-wrap those.
+    if (snip.category === "interfaces" && !/^\s*interfaces\s*\{/.test(body)) {
+      body = `interfaces {\n${body}\n}`;
+    }
     const rendered = body.replace(/\s+$/, "");
     blocks.push(`/* snips/${shortPath} */\n${rendered}`);
   }
@@ -451,4 +458,98 @@ export function renderConfig(
   const text = blocks.join("\n\n") + "\n";
   const missing = Array.from(new Set(text.match(/\$\{?[A-Z_][A-Z0-9_]*\}?/g) ?? []));
   return { text, missing, usedSnipIds: used };
+}
+
+/* ------------------------------------------------------------------ *
+ * Junos config merger
+ *
+ * Folds a concatenation of rendered snip bodies into one proper Junos
+ * hierarchy: same-key stanzas merge (so N services on one physical port
+ * become a single `et-0/0/13 { … }` carrying N units + one `mtu`), and
+ * identical leaf statements de-duplicate (the physical MTU, the firewall
+ * filter definition, the CoS classifiers are emitted once). This is the
+ * deterministic equivalent of hand-consolidating the config before load.
+ * ------------------------------------------------------------------ */
+
+type JBlock = { type: "block"; key: string; children: JNode[] };
+type JLeaf = { type: "leaf"; key: string };
+type JNode = JBlock | JLeaf;
+
+/** Tokenise + parse Junos text into a node tree (blocks and leaf statements). */
+function parseJunos(text: string): JNode[] {
+  const tokens = text.match(/\{|\}|;|[^\s{};]+/g) ?? [];
+  const root: JBlock = { type: "block", key: "", children: [] };
+  const stack: JBlock[] = [root];
+  let buf: string[] = [];
+  for (const t of tokens) {
+    if (t === "{") {
+      const node: JBlock = { type: "block", key: buf.join(" "), children: [] };
+      stack[stack.length - 1].children.push(node);
+      stack.push(node);
+      buf = [];
+    } else if (t === "}") {
+      if (stack.length > 1) stack.pop();
+      buf = [];
+    } else if (t === ";") {
+      if (buf.length) stack[stack.length - 1].children.push({ type: "leaf", key: buf.join(" ") });
+      buf = [];
+    } else {
+      buf.push(t);
+    }
+  }
+  return root.children;
+}
+
+/** Merge a list of sibling nodes: same-key blocks combine their children
+ *  (recursively); identical leaves collapse to one. Order is preserved. */
+function mergeJunosNodes(nodes: JNode[]): JNode[] {
+  const order: string[] = [];
+  const byKey = new Map<string, JNode>();
+  for (const n of nodes) {
+    const existing = byKey.get(n.key);
+    if (!existing) {
+      byKey.set(
+        n.key,
+        n.type === "block"
+          ? { type: "block", key: n.key, children: [...n.children] }
+          : { type: "leaf", key: n.key },
+      );
+      order.push(n.key);
+    } else if (existing.type === "block" && n.type === "block") {
+      existing.children.push(...n.children);
+    }
+    // leaf duplicate, or leaf/block key clash: keep the first, drop the rest.
+  }
+  return order.map((k) => {
+    const n = byKey.get(k)!;
+    if (n.type === "block") n.children = mergeJunosNodes(n.children);
+    return n;
+  });
+}
+
+/** Emit a node tree back to indented Junos text (leaf statements first, then
+ *  nested blocks — order-independent for these stanzas and reads cleaner). */
+function emitJunos(nodes: JNode[], indent = ""): string {
+  const lines: string[] = [];
+  for (const n of nodes) if (n.type === "leaf") lines.push(`${indent}${n.key};`);
+  for (const n of nodes) {
+    if (n.type === "block") {
+      lines.push(`${indent}${n.key} {`);
+      lines.push(emitJunos(n.children, indent + "    "));
+      lines.push(`${indent}}`);
+    }
+  }
+  return lines.filter((l) => l !== "").join("\n");
+}
+
+/**
+ * Consolidate rendered Junos snip text into one merged hierarchy. Strips
+ * `/* … *\/` provenance comments, parses, merges same-key stanzas, and
+ * re-emits. Safe to run on a single service (collapses the split physical
+ * interface + MTU) or on an N-service batch (nests all units under one port).
+ */
+export function mergeJunosConfig(text: string): string {
+  const noComments = text.replace(/\/\*[\s\S]*?\*\//g, " ");
+  const merged = mergeJunosNodes(parseJunos(noComments));
+  return emitJunos(merged) + "\n";
 }

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -52,6 +52,8 @@ export type GenCatalog = {
   tiers: Record<string, { label: string; description: string }>;
   cosSnips: Record<GenOsKey, string[]>;
   variableRoles: VariableRoles;
+  varSpecs?: Record<string, VarSpec>;
+  interfaceSpec?: InterfaceSpec;
   families: GenFamily[];
 };
 
@@ -71,6 +73,105 @@ export type VariableRoles = {
    *  physical port, MTU, filter name. Everything else increments per instance. */
   instanceConstant?: string[];
 };
+
+/**
+ * Validated domain for a single variable. Drives the field UI (dropdown vs
+ * bounded number vs structured interface) and the soft "not JVD-validated"
+ * warning. Anything not covered here is a free text field.
+ */
+export type VarSpec =
+  | { type: "enum"; values: string[] }
+  | { type: "range"; min: number; max: number }
+  | { type: "interface" }
+  | { type: "rd" }
+  | { type: "rt" }
+  | { type: "esi" }
+  | { type: "name" }
+  | { type: "text" };
+
+/** Validated attachment-circuit interface domain for the JVD's PE platforms. */
+export type InterfaceSpec = {
+  media: string[];
+  fpcMax: number;
+  picMax: number;
+  portMax: number;
+  channelMax: number;
+  aeMax: number;
+};
+
+const RD_RT_RE = /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/;
+const ESI_RE = /^([0-9a-fA-F]{2}:){9}[0-9a-fA-F]{2}$/;
+const NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Validate one interface string against the platform capability table.
+ * Returns a warning message when the media type or a slot/pic/port index is
+ * outside the JVD-validated domain, else undefined. Catches e.g. et-99/99/99
+ * (port 99 > portMax) that a shape-only regex would accept.
+ */
+export function validateInterface(
+  value: string,
+  spec: InterfaceSpec,
+): string | undefined {
+  const ae = value.match(/^ae(\d+)$/);
+  if (ae) {
+    if (!spec.media.includes("ae")) return "aggregated interfaces not validated here";
+    return Number(ae[1]) > spec.aeMax
+      ? `ae index > ${spec.aeMax} — not JVD-validated`
+      : undefined;
+  }
+  const m = value.match(/^([a-z]{2,3})-(\d+)\/(\d+)\/(\d+)(?::(\d+))?$/);
+  if (!m) return `expected e.g. ${spec.media[0]}-0/0/0 or ae0`;
+  const [, media, fpc, pic, port, ch] = m;
+  if (!spec.media.includes(media))
+    return `port-type "${media}" not in ${spec.media.join("/")}`;
+  if (Number(fpc) > spec.fpcMax) return `FPC ${fpc} > ${spec.fpcMax} — not JVD-validated`;
+  if (Number(pic) > spec.picMax) return `PIC ${pic} > ${spec.picMax} — not JVD-validated`;
+  if (Number(port) > spec.portMax)
+    return `port ${port} > ${spec.portMax} — not JVD-validated`;
+  if (ch !== undefined && Number(ch) > spec.channelMax)
+    return `channel ${ch} > ${spec.channelMax} — not JVD-validated`;
+  return undefined;
+}
+
+/**
+ * Validate a value against its spec. Returns a soft warning message (the
+ * config still renders) or undefined when the value is within the validated
+ * JVD domain. Empty values are treated as valid (unfilled, not wrong).
+ */
+export function validateSpec(
+  value: string | undefined,
+  spec: VarSpec | undefined,
+  ifaceSpec: InterfaceSpec | undefined,
+): string | undefined {
+  if (!spec || value === undefined || value === "") return undefined;
+  switch (spec.type) {
+    case "enum":
+      return spec.values.includes(value)
+        ? undefined
+        : `not a validated value (${spec.values.join(", ")})`;
+    case "range": {
+      if (!/^\d+$/.test(value)) return "expected a number";
+      const n = Number(value);
+      return n < spec.min || n > spec.max
+        ? `outside validated range ${spec.min}–${spec.max}`
+        : undefined;
+    }
+    case "interface":
+      return ifaceSpec ? validateInterface(value, ifaceSpec) : undefined;
+    case "rd":
+      return RD_RT_RE.test(value) ? undefined : "expected <ip|asn>:<number>";
+    case "rt":
+      return RD_RT_RE.test(value) ? undefined : "expected <ip|asn>:<number>";
+    case "esi":
+      return ESI_RE.test(value) ? undefined : "expected a 10-byte ESI (00:…:01)";
+    case "name":
+      return NAME_RE.test(value) ? undefined : "letters, digits, _ or - only";
+    default:
+      return undefined;
+  }
+}
+
 
 export type VarKind =
   | "shared"

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -25,6 +25,7 @@ export type GenDeployment = {
   id: string;
   label: string;
   description: string;
+  available?: boolean;
   os: Partial<Record<GenOsKey, GenOsBlock>>;
 };
 

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -65,6 +65,8 @@ export type GenCatalog = {
 export type VariableRoles = {
   shared: string[];
   mirrored: [string, string][];
+  /** Per-endpoint vars that MUST differ between PEs (e.g. RD). */
+  distinctPerEndpoint?: string[];
 };
 
 export type VarKind =

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -391,6 +391,20 @@ function substitute(body: string, values: Record<string, string>): string {
   return out;
 }
 
+/**
+ * Remove the UNI firewall-filter binding from an interface body. The JVD
+ * interface snips carry the filter binding inline as `family <fam> { filter {
+ * input f_…; } }`; when the user opts out of the UNI filter we skip the filter
+ * definition snip, so the binding must be dropped too (else it references a
+ * filter that no longer exists). Collapses the family stanza to `family <fam>;`.
+ */
+function stripUniFilterBinding(body: string): string {
+  return body.replace(
+    /(family\s+[\w-]+)\s*\{\s*filter\s*\{[^{}]*\}\s*\}/g,
+    "$1;",
+  );
+}
+
 export type RenderResult = {
   text: string;
   /** Variable names still present as $VAR after substitution. */
@@ -409,6 +423,7 @@ export function renderConfig(
   snipIds: string[],
   values: Record<string, string>,
   byId: Map<string, SnipRecord>,
+  opts?: { stripUniFilter?: boolean },
 ): RenderResult {
   // Normalise value keys to bare names (no leading $).
   const norm: Record<string, string> = {};
@@ -423,7 +438,13 @@ export function renderConfig(
     if (!snip) continue;
     used.push(id);
     const shortPath = `${snip.osKey}/${snip.category}/${snip.name}.conf`;
-    const rendered = substitute(stripHeader(snip.body), norm).replace(/\s+$/, "");
+    let body = substitute(stripHeader(snip.body), norm);
+    // Drop the inline UNI filter binding on interface snips when the user
+    // opted out of the firewall filter (else it dangles).
+    if (opts?.stripUniFilter && snip.category === "interfaces") {
+      body = stripUniFilterBinding(body);
+    }
+    const rendered = body.replace(/\s+$/, "");
     blocks.push(`/* snips/${shortPath} */\n${rendered}`);
   }
 


### PR DESCRIPTION
## What's New

Expands the deterministic **Config Generator** into a complete, validated E-Line experience — the point where it reliably produces JVD-grounded config .

- **Full E-Line deployment set** — EVPN-VPWS, L2VPN (Kompella), BGP-VPLS (P2P), L2Circuit hot-standby and floating-PW, across EVPL and EPL (EVPN-FXC / EVPN Floating-PW previewed as "coming soon").
- **Two-endpoint generation** — build PE-A and PE-B together with guaranteed matched identifiers (shared route-target/instance, mirrored vpws-service-id, distinct route-distinguisher), including cross-OS Junos ↔ Junos EVO.
- **Optional VLAN handling** — choose **Single VLAN** (matched end-to-end) or **VLAN map** (normalized S-VLAN push/pop); the right interface + fields appear for each. Extensible to more UNI modes later.
- **Field validation** — dropdowns for fixed choices (MTU, label-block-size), bounded numeric ranges (VLAN, unit, service-id), and an interface capability check so invalid ports (e.g. `et-99/99/99`) are flagged as not JVD-validated.
- **Batch generation** — set a service count to emit N numbered, auto-incremented services and download them all at once.

## Why

Moves the funnel into deterministic code: the generator can only offer what the JVD actually validated, and clearly warns when a value falls outside the validated domain.

## Details

- `src/data/generator/metro_as_a_service.json` — E-Line decision tree; per-variable field specs (`varSpecs`), interface capability table (`interfaceSpec`), and a `uni.modes` dimension for VLAN handling. Every snip ID validated (0 unresolved).
- `src/lib/generator.ts` — pure render engine: two-endpoint value resolution (shared / mirrored / distinct), per-instance increment for batch generation, VLAN-mode interface resolution, and `validateSpec`/`validateInterface` domain checks.
- `src/components/ConfigGenerator.tsx` — stepped wizard (breadcrumb + back), VLAN-handling selector, dropdown/range/interface fields with inline warnings, count-N + download-all.

## Testing

- Catalog integrity: all snip refs resolve, 0 dangling `$VAR`s across render paths.
- Two-endpoint: matched route-target/instance, mirrored service-id, distinct route-distinguisher verified (Junos EVO ↔ Junos EVO).
- VLAN handling: Single-VLAN renders plain `vlan-ccc`; VLAN-map renders `input-vlan-map push` / `output-vlan-map pop` on both PEs with the S-VLAN field surfaced.
- Validation: `et-99/99/99` → "FPC 99 > 11 — not JVD-validated"; bad port-type rejected; MTU/label-block-size constrained to validated values.
- `bun run build`: clean; browser-verified against the production preview build.

## Notes

- EVPN-FXC and EVPN Floating-PW are shown greyed ("coming soon") — they need multi-UNI (`$UNIT_1/$UNIT_2`) and a small `cos-binding-mpls` engine addition, intentionally deferred.
- Other families (Access E-Line, E-LAN, E-Tree) remain placeholders for a follow-up.
