### PR TITLE
feat(portal): PWHT category + E-Line VRF route-export tiers & CoS fix

### DIFF
--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -33,6 +33,18 @@ const CATALOG = maasCatalog as unknown as GenCatalog;
 const ROLES = CATALOG.variableRoles;
 const IFACE_SPEC = CATALOG.interfaceSpec;
 const VAR_SPECS = (CATALOG.varSpecs ?? {}) as Record<string, unknown>;
+const ROUTE_POLICY = (CATALOG.routePolicySnips ?? {}) as Partial<
+  Record<GenOsKey, Record<string, string>>
+>;
+/** Variables computed automatically (never shown as editable form fields). */
+const DERIVED_VARS = new Set(
+  Object.keys(CATALOG.derivedVars ?? {}).filter((k) => !k.startsWith("_")),
+);
+/** Friendly labels for the VPN color options. */
+const COLOR_POLICY_LABELS: Record<string, string> = {
+  gold: "Gold — priority / low-latency",
+  bronze: "Bronze — TE path",
+};
 
 /** The validated field spec for a bare var name (skips the `_note` key). */
 function specFor(bare: string): VarSpec | undefined {
@@ -138,6 +150,7 @@ type Selection = {
   osB?: OsChoice;
   homing?: string;
   vlanMode?: string;
+  rtPolicy?: string;
   color?: string;
   cos: boolean;
   firewall: boolean;
@@ -304,6 +317,32 @@ export default function ConfigGenerator() {
         : modeOpts[0].id
       : undefined;
 
+  // VRF route-export: "route-target only" vs a colored export policy. Colors
+  // are the intersection of what both PEs' OS support (Junos = gold only).
+  const colorPolA = sel.osA ? Object.keys(ROUTE_POLICY[sel.osA] ?? {}) : [];
+  const colorPolB =
+    twoPe && sel.osB && sel.osB !== "none"
+      ? Object.keys(ROUTE_POLICY[sel.osB as GenOsKey] ?? {})
+      : null;
+  const colorPolOpts = colorPolB
+    ? colorPolA.filter((c) => colorPolB.includes(c))
+    : colorPolA;
+  // Only offer the choice when the deployment's service actually emits a
+  // `vrf-export` (i.e. it's RT-policy driven).
+  const serviceHasVrfExport = Boolean(
+    osBlockA?.service.some((rel) =>
+      /vrf-export/.test(byId.get(`${CATALOG.jvd}/${rel}`)?.body ?? ""),
+    ),
+  );
+  const rtPolicyApplies = serviceHasVrfExport && colorPolOpts.length > 0;
+  // Effective route policy: "rt-only" (default, strips vrf-export) or a valid
+  // color id. Falls back to rt-only when the pick isn't supported.
+  const rtPolicy = !rtPolicyApplies
+    ? "rt-only"
+    : sel.rtPolicy && colorPolOpts.includes(sel.rtPolicy)
+      ? sel.rtPolicy
+      : "rt-only";
+
   // Attribute options = intersection of both endpoints (or just A when single),
   // for the currently-selected VLAN mode.
   const attrsA = osBlockA
@@ -338,6 +377,7 @@ export default function ConfigGenerator() {
     os,
     homing: sel.homing!,
     vlanMode,
+    rtPolicy,
     color: sel.color ?? "",
     cos: sel.cos,
     firewall: sel.firewall,
@@ -368,9 +408,12 @@ export default function ConfigGenerator() {
   }, [idsA, idsB, byId]);
 
   const sharedFields = unionVars.filter(
-    (v) => classifyVar(v.name, ROLES).kind === "shared",
+    (v) =>
+      !DERIVED_VARS.has(v.name.replace(/^\$/, "")) &&
+      classifyVar(v.name, ROLES).kind === "shared",
   );
   const perFields = unionVars.filter((v) => {
+    if (DERIVED_VARS.has(v.name.replace(/^\$/, ""))) return false;
     const k = classifyVar(v.name, ROLES).kind;
     return k === "per-endpoint" || k === "mirrored-primary";
   });
@@ -383,6 +426,7 @@ export default function ConfigGenerator() {
     sel.osB,
     sel.homing,
     vlanMode,
+    rtPolicy,
     sel.color,
     sel.cos,
     sel.firewall,
@@ -416,6 +460,8 @@ export default function ConfigGenerator() {
     if (!complete || idsA.length === 0) return null;
     return renderConfig(idsA, endpointValues(names, ROLES, shared, perA, perB), byId, {
       stripUniFilter: !sel.firewall,
+      stripVrfExport: rtPolicy === "rt-only",
+      derived: CATALOG.derivedVars,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complete, idsA, shared, perA, perB, byId]);
@@ -423,6 +469,8 @@ export default function ConfigGenerator() {
     if (!complete || !twoPe || idsB.length === 0) return null;
     return renderConfig(idsB, endpointValues(names, ROLES, shared, perB, perA), byId, {
       stripUniFilter: !sel.firewall,
+      stripVrfExport: rtPolicy === "rt-only",
+      derived: CATALOG.derivedVars,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [complete, twoPe, idsB, shared, perA, perB, byId]);
@@ -488,6 +536,11 @@ export default function ConfigGenerator() {
           ? [
               HOMING_LABELS[sel.homing!] ?? sel.homing,
               vlanMode ? modeOpts.find((m) => m.id === vlanMode)?.label : null,
+              rtPolicyApplies
+                ? rtPolicy === "rt-only"
+                  ? "Uncolored"
+                  : `${rtPolicy[0].toUpperCase()}${rtPolicy.slice(1)} policy`
+                : null,
               sel.cos ? "CoS" : "no CoS",
               sel.firewall
                 ? `filter (${COLOR_LABELS[sel.color!] ?? sel.color})`
@@ -529,12 +582,16 @@ export default function ConfigGenerator() {
         aBodies.push(
           renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
             stripUniFilter: !sel.firewall,
+            stripVrfExport: rtPolicy === "rt-only",
+            derived: CATALOG.derivedVars,
           }).text,
         );
       if (twoPe && idsB.length)
         bBodies.push(
           renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId, {
             stripUniFilter: !sel.firewall,
+            stripVrfExport: rtPolicy === "rt-only",
+            derived: CATALOG.derivedVars,
           }).text,
         );
     }
@@ -784,6 +841,44 @@ export default function ConfigGenerator() {
                         onClick={() => setSel((p) => ({ ...p, vlanMode: m.id }))}
                       />
                     ))}
+                  </div>
+                </div>
+              )}
+              {rtPolicyApplies && (
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    VRF route-export
+                  </div>
+                  <div className="space-y-2">
+                    <Chip
+                      label="Uncolored (route-target only)"
+                      sub="vrf-target only — no color community (best-effort)"
+                      active={rtPolicy === "rt-only"}
+                      onClick={() => setSel((p) => ({ ...p, rtPolicy: "rt-only" }))}
+                    />
+                    <Chip
+                      label="Color community"
+                      sub="Export policy adds a traffic-class color community (+ RT)"
+                      active={rtPolicy !== "rt-only"}
+                      onClick={() =>
+                        setSel((p) => ({ ...p, rtPolicy: colorPolOpts[0] }))
+                      }
+                    />
+                    {rtPolicy !== "rt-only" && (
+                      <select
+                        value={rtPolicy}
+                        onChange={(e) =>
+                          setSel((p) => ({ ...p, rtPolicy: e.target.value }))
+                        }
+                        className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                      >
+                        {colorPolOpts.map((c) => (
+                          <option key={c} value={c}>
+                            {COLOR_POLICY_LABELS[c] ?? c}
+                          </option>
+                        ))}
+                      </select>
+                    )}
                   </div>
                 </div>
               )}

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -27,7 +27,7 @@ import {
   classifyVar,
   endpointValues,
   instanceValues,
-  gridInstanceValues,
+  bumpInt,
   validateSpec,
 } from "@/lib/generator";
 
@@ -47,6 +47,60 @@ const COLOR_POLICY_LABELS: Record<string, string> = {
   gold: "Gold — priority / low-latency",
   bronze: "Bronze — TE path",
 };
+
+/** PWHT color options (batch-level: one color per generated batch). */
+const PWHT_COLORS = ["uncolored", "gold", "bronze"] as const;
+const PWHT_COLOR_LABELS: Record<string, string> = {
+  uncolored: "Uncolored (best-effort)",
+  gold: "Gold — priority / low-latency",
+  bronze: "Bronze — TE path",
+};
+/** Variables the PWHT fan-out computes automatically (not user form fields). */
+const PWHT_COMPUTED = new Set([
+  "UNIT",
+  "PS_SERVICE",
+  "VLAN_LIST_START",
+  "VLAN_LIST_END",
+  "COLOR_COMM",
+]);
+
+/**
+ * Compute the value map for one PWHT role instance in the transport×service
+ * fan-out. Transport vars (PS IFD, VC-ID, PW labels) bump per PW (t); the
+ * access side carries the whole VLAN range on one unit (vlan-id-list); the
+ * headend side has one service unit + ELAN per VLAN (bumped by the global
+ * service index i). ESIs/RD increment per service.
+ */
+function pwhtInstanceValues(
+  role: "access" | "headend",
+  base: Record<string, string>,
+  transportVars: Set<string>,
+  t: number,
+  s: number,
+  S: number,
+  baseVlan: number,
+  colorComm: string,
+): Record<string, string> {
+  const rangeStart = baseVlan + t * S;
+  const vlan = rangeStart + s;
+  const i = t * S + s;
+  const out: Record<string, string> = { ...base };
+  for (const k of Object.keys(out)) if (transportVars.has(k)) out[k] = bumpInt(out[k], t);
+  if (role === "access") {
+    out.UNIT = String(rangeStart);
+    out.VLAN_LIST_START = String(rangeStart);
+    out.VLAN_LIST_END = String(rangeStart + S - 1);
+    out.VLAN = String(rangeStart);
+    if (colorComm) out.COLOR_COMM = colorComm;
+  } else {
+    out.VLAN = String(vlan);
+    out.PS_SERVICE = String(vlan);
+    out.UNIT = String(vlan);
+    for (const k of ["RD", "VESI_ID", "ESI_ID"])
+      if (base[k] !== undefined) out[k] = bumpInt(base[k], i);
+  }
+  return out;
+}
 
 /** The validated field spec for a bare var name (skips the `_note` key). */
 function specFor(bare: string): VarSpec | undefined {
@@ -164,6 +218,7 @@ type Selection = {
   homing?: string;
   vlanMode?: string;
   rtPolicy?: string;
+  pwColor?: string;
   color?: string;
   cos: boolean;
   firewall: boolean;
@@ -407,16 +462,43 @@ export default function ConfigGenerator() {
     firewall: sel.firewall,
   });
 
+  // PWHT batch color (uncolored / gold / bronze) → community name for the ACX
+  // l2circuit + whether to pull the community-definition snip.
+  const pwColor = roleBased ? sel.pwColor ?? "uncolored" : "uncolored";
+  const pwColorComm =
+    roleBased && pwColor !== "uncolored"
+      ? family?.colorComms?.[pwColor] ?? ""
+      : "";
+  const qd = (rel: string[]) => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const r of rel) {
+      const id = `${CATALOG.jvd}/${r}`;
+      if (!seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+    return out;
+  };
+
   const idsA = useMemo(
     () => {
-      if (roleBased)
-        return roles[0]
-          ? resolveRoleSnipIds(CATALOG, roles[0], { cos: sel.cos, firewall: false })
-          : [];
+      if (roleBased) {
+        const r = roles[0];
+        if (!r) return [];
+        const useList = count > 1; // vlan-id-list when a PW carries >1 VLAN
+        return qd([
+          ...r.service,
+          ...(useList && r.interfaceList ? r.interfaceList : r.interface),
+          ...(pwColorComm && family?.colorCommDef ? [family.colorCommDef] : []),
+          ...(sel.cos ? r.cosSnips ?? [] : []),
+        ]);
+      }
       return complete && sel.osA ? resolveSnipIds(CATALOG, selFor(sel.osA)) : [];
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [complete, sel, roleBased],
+    [complete, sel, roleBased, count, pwColorComm],
   );
   const idsB = useMemo(
     () => {
@@ -443,13 +525,14 @@ export default function ConfigGenerator() {
     return out;
   }, [idsA, idsB, byId]);
 
-  const sharedFields = unionVars.filter(
-    (v) =>
-      !DERIVED_VARS.has(v.name.replace(/^\$/, "")) &&
-      classifyVar(v.name, ROLES).kind === "shared",
-  );
+  const sharedFields = unionVars.filter((v) => {
+    const bare = v.name.replace(/^\$/, "");
+    if (DERIVED_VARS.has(bare) || (roleBased && PWHT_COMPUTED.has(bare))) return false;
+    return classifyVar(v.name, ROLES).kind === "shared";
+  });
   const perFields = unionVars.filter((v) => {
-    if (DERIVED_VARS.has(v.name.replace(/^\$/, ""))) return false;
+    const bare = v.name.replace(/^\$/, "");
+    if (DERIVED_VARS.has(bare) || (roleBased && PWHT_COMPUTED.has(bare))) return false;
     const k = classifyVar(v.name, ROLES).kind;
     return k === "per-endpoint" || k === "mirrored-primary";
   });
@@ -479,6 +562,8 @@ export default function ConfigGenerator() {
     sel.homing,
     vlanMode,
     rtPolicy,
+    sel.pwColor,
+    count > 1,
     sel.color,
     sel.cos,
     sel.firewall,
@@ -528,24 +613,43 @@ export default function ConfigGenerator() {
   }, [pathKey]);
 
   const names = unionVars.map((v) => v.name);
+  const transportVars = useMemo(
+    () => new Set(family?.transportVars ?? []),
+    [family],
+  );
+  const baseVlan = Number(shared.VLAN) || 0;
   const renderA = useMemo(() => {
     if (!complete || idsA.length === 0) return null;
+    if (roleBased)
+      return renderConfig(
+        idsA,
+        pwhtInstanceValues("access", { ...shared, ...perA }, transportVars, 0, 0, count, baseVlan, pwColorComm),
+        byId,
+        { stripUniFilter: !sel.firewall, stripCommunity: !pwColorComm },
+      );
     return renderConfig(idsA, endpointValues(names, ROLES, shared, perA, perB), byId, {
       stripUniFilter: !sel.firewall,
       stripVrfExport: rtPolicy === "rt-only",
       derived: CATALOG.derivedVars,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [complete, idsA, shared, perA, perB, byId]);
+  }, [complete, idsA, shared, perA, perB, byId, roleBased, count, pwColorComm]);
   const renderB = useMemo(() => {
     if (!complete || !twoPe || idsB.length === 0) return null;
+    if (roleBased)
+      return renderConfig(
+        idsB,
+        pwhtInstanceValues("headend", { ...shared, ...perB }, transportVars, 0, 0, count, baseVlan, ""),
+        byId,
+        { stripUniFilter: !sel.firewall },
+      );
     return renderConfig(idsB, endpointValues(names, ROLES, shared, perB, perA), byId, {
       stripUniFilter: !sel.firewall,
       stripVrfExport: rtPolicy === "rt-only",
       derived: CATALOG.derivedVars,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [complete, twoPe, idsB, shared, perA, perB, byId]);
+  }, [complete, twoPe, idsB, shared, perA, perB, byId, roleBased, count, pwColorComm]);
 
   // Merged, consolidated config for display/copy (single previewed service).
   const mergedA = useMemo(
@@ -619,9 +723,9 @@ export default function ConfigGenerator() {
       case "attributes":
         return attrsComplete
           ? roleBased
-            ? sel.cos
-              ? "CoS"
-              : "no CoS"
+            ? [pwColor === "uncolored" ? "Uncolored" : `${pwColor[0].toUpperCase()}${pwColor.slice(1)}`, sel.cos ? "CoS" : "no CoS"]
+                .filter(Boolean)
+                .join(" · ")
             : [
               HOMING_LABELS[sel.homing!] ?? sel.homing,
               vlanMode ? modeOpts.find((m) => m.id === vlanMode)?.label : null,
@@ -657,25 +761,49 @@ export default function ConfigGenerator() {
   const download = () => {
     if (!fullText) return;
     // Emit all service instances, merged into one consolidated hierarchy per
-    // endpoint. Symmetric families: a 1-D batch of `count` services. Role-based
-    // (PWHT): a 2-D grid of `pwCount` transport PWs × `count` services each —
-    // transport vars bump per PW, service vars bump globally so every EVPN-ELAN
-    // stays unique.
-    const S = roleBased ? 1 : Math.max(1, Math.min(count, 500));
-    const T = 1;
-    const transportVars = family?.transportVars ?? [];
-    const shift = (m: Record<string, string>, t: number, i: number) =>
-      roleBased
-        ? gridInstanceValues(m, ROLES, transportVars, t, i)
-        : instanceValues(m, ROLES, i);
+    // endpoint. Symmetric families (E-Line): a 1-D batch of `count` services.
+    // PWHT: an ASYMMETRIC fan-out — the access side renders once per transport
+    // PW (one l2circuit + one vlan-id-list unit), the headend renders once per
+    // VLAN (transport stanzas dedupe per-PW via the merger; service stanzas are
+    // per-VLAN). Two knobs: pwCount PWs × count VLANs-per-PW.
     const aBodies: string[] = [];
     const bBodies: string[] = [];
-    for (let t = 0; t < T; t++) {
-      for (let s = 0; s < S; s++) {
-        const i = t * S + s;
-        const sh = shift(shared, t, i);
-        const a = shift(perA, t, i);
-        const b = shift(perB, t, i);
+    let total = 1;
+    if (roleBased) {
+      const S = Math.max(1, Math.min(count, 500));
+      const T = Math.max(1, Math.min(pwCount, 100));
+      total = T * S;
+      const accessBase = { ...shared, ...perA };
+      const headendBase = { ...shared, ...perB };
+      for (let t = 0; t < T; t++) {
+        if (idsA.length)
+          aBodies.push(
+            renderConfig(
+              idsA,
+              pwhtInstanceValues("access", accessBase, transportVars, t, 0, S, baseVlan, pwColorComm),
+              byId,
+              { stripUniFilter: !sel.firewall, stripCommunity: !pwColorComm },
+            ).text,
+          );
+        for (let s = 0; s < S; s++) {
+          if (idsB.length)
+            bBodies.push(
+              renderConfig(
+                idsB,
+                pwhtInstanceValues("headend", headendBase, transportVars, t, s, S, baseVlan, ""),
+                byId,
+                { stripUniFilter: !sel.firewall },
+              ).text,
+            );
+        }
+      }
+    } else {
+      const S = Math.max(1, Math.min(count, 500));
+      total = S;
+      for (let i = 0; i < S; i++) {
+        const sh = instanceValues(shared, ROLES, i);
+        const a = instanceValues(perA, ROLES, i);
+        const b = instanceValues(perB, ROLES, i);
         if (idsA.length)
           aBodies.push(
             renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
@@ -694,7 +822,6 @@ export default function ConfigGenerator() {
           );
       }
     }
-    const total = T * S;
     const sections: string[] = [];
     if (aBodies.length) {
       const merged = mergeJunosConfig(aBodies.join("\n"));
@@ -822,6 +949,7 @@ export default function ConfigGenerator() {
                       homing: undefined,
                       vlanMode: undefined,
                       rtPolicy: undefined,
+                      pwColor: "uncolored",
                       color: undefined,
                       firewall: false,
                       cos: true,
@@ -963,6 +1091,31 @@ export default function ConfigGenerator() {
                   />
                 </div>
               </div>
+              {family?.colorComms && (
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    Transport color{" "}
+                    <span className="font-normal text-muted-foreground">
+                      — one per batch
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    {PWHT_COLORS.map((c) => (
+                      <Chip
+                        key={c}
+                        label={PWHT_COLOR_LABELS[c]}
+                        sub={
+                          c === "uncolored"
+                            ? "No community on the l2circuit"
+                            : `community ${family.colorComms![c]} on each PW`
+                        }
+                        active={pwColor === c}
+                        onClick={() => setSel((p) => ({ ...p, pwColor: c }))}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
               <button
                 onClick={() => setStep((s) => s + 1)}
                 className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
@@ -1114,10 +1267,45 @@ export default function ConfigGenerator() {
           {currentStep === "params" && (
             <div className="space-y-5">
               {roleBased ? (
-                <div className="rounded-md border border-border bg-background p-3 text-[11px] text-muted-foreground">
-                  Generating a single service (one transport PW, one VLAN).
-                  Multi-PW batch generation (N transport PWs ×
-                  VLANs-per-PW with vlan-id-list + color) is coming next.
+                <div className="rounded-md border border-border bg-background p-3">
+                  <div className="flex flex-wrap items-center gap-4">
+                    <label className="flex items-center gap-2 text-xs font-medium text-foreground">
+                      Transport PWs
+                      <input
+                        type="number"
+                        min={1}
+                        max={100}
+                        value={pwCount}
+                        onChange={(e) =>
+                          setPwCount(Math.max(1, Math.min(100, Number(e.target.value) || 1)))
+                        }
+                        className="h-8 w-16 rounded-md border border-border bg-surface px-2 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                      />
+                    </label>
+                    <span className="text-muted-foreground">×</span>
+                    <label className="flex items-center gap-2 text-xs font-medium text-foreground">
+                      VLANs / PW
+                      <input
+                        type="number"
+                        min={1}
+                        max={500}
+                        value={count}
+                        onChange={(e) =>
+                          setCount(Math.max(1, Math.min(500, Number(e.target.value) || 1)))
+                        }
+                        className="h-8 w-16 rounded-md border border-border bg-surface px-2 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                      />
+                    </label>
+                    <span className="text-[11px] font-medium text-primary">
+                      = {pwCount * count} EVPN-ELAN{pwCount * count > 1 ? "s" : ""}
+                    </span>
+                  </div>
+                  <span className="mt-2 block text-[11px] text-muted-foreground">
+                    Values below are the starting service. Each PW gets its own
+                    PS interface, VC-ID and PW labels; VLANs increment globally
+                    ({count > 1 ? "vlan-id-list per PW" : "one vlan-id per PW"}).
+                    The download includes all {pwCount * count}.
+                  </span>
                 </div>
               ) : (
                 <div className="flex flex-wrap items-center gap-3 rounded-md border border-border bg-background p-3">

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -27,6 +27,7 @@ import {
   classifyVar,
   endpointValues,
   instanceValues,
+  gridInstanceValues,
   validateSpec,
 } from "@/lib/generator";
 
@@ -286,6 +287,7 @@ export default function ConfigGenerator() {
   const [copied, setCopied] = useState(false);
   const [step, setStep] = useState(0);
   const [count, setCount] = useState(1);
+  const [pwCount, setPwCount] = useState(1);
 
   const family = CATALOG.families.find((f) => f.id === sel.familyId);
   const mux = family?.multiplexing.find((m) => m.id === sel.muxId);
@@ -648,40 +650,51 @@ export default function ConfigGenerator() {
     setPerA({});
     setPerB({});
     setCount(1);
+    setPwCount(1);
     setStep(0);
   };
 
   const download = () => {
     if (!fullText) return;
-    // Emit all N service instances: instance i increments every non-constant
-    // variable's trailing integer by i (instance 0 = the values entered). All
-    // of an endpoint's instances are merged into ONE consolidated hierarchy —
-    // a single physical interface carrying N units, MTU/filter/CoS declared
-    // once — rather than N repeated standalone stanzas.
-    const n = Math.max(1, Math.min(count, 500));
+    // Emit all service instances, merged into one consolidated hierarchy per
+    // endpoint. Symmetric families: a 1-D batch of `count` services. Role-based
+    // (PWHT): a 2-D grid of `pwCount` transport PWs × `count` services each —
+    // transport vars bump per PW, service vars bump globally so every EVPN-ELAN
+    // stays unique.
+    const S = roleBased ? 1 : Math.max(1, Math.min(count, 500));
+    const T = 1;
+    const transportVars = family?.transportVars ?? [];
+    const shift = (m: Record<string, string>, t: number, i: number) =>
+      roleBased
+        ? gridInstanceValues(m, ROLES, transportVars, t, i)
+        : instanceValues(m, ROLES, i);
     const aBodies: string[] = [];
     const bBodies: string[] = [];
-    for (let i = 0; i < n; i++) {
-      const sh = instanceValues(shared, ROLES, i);
-      const a = instanceValues(perA, ROLES, i);
-      const b = instanceValues(perB, ROLES, i);
-      if (idsA.length)
-        aBodies.push(
-          renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
-            stripUniFilter: !sel.firewall,
-            stripVrfExport: rtPolicy === "rt-only",
-            derived: CATALOG.derivedVars,
-          }).text,
-        );
-      if (twoPe && idsB.length)
-        bBodies.push(
-          renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId, {
-            stripUniFilter: !sel.firewall,
-            stripVrfExport: rtPolicy === "rt-only",
-            derived: CATALOG.derivedVars,
-          }).text,
-        );
+    for (let t = 0; t < T; t++) {
+      for (let s = 0; s < S; s++) {
+        const i = t * S + s;
+        const sh = shift(shared, t, i);
+        const a = shift(perA, t, i);
+        const b = shift(perB, t, i);
+        if (idsA.length)
+          aBodies.push(
+            renderConfig(idsA, endpointValues(names, ROLES, sh, a, b), byId, {
+              stripUniFilter: !sel.firewall,
+              stripVrfExport: rtPolicy === "rt-only",
+              derived: CATALOG.derivedVars,
+            }).text,
+          );
+        if (twoPe && idsB.length)
+          bBodies.push(
+            renderConfig(idsB, endpointValues(names, ROLES, sh, b, a), byId, {
+              stripUniFilter: !sel.firewall,
+              stripVrfExport: rtPolicy === "rt-only",
+              derived: CATALOG.derivedVars,
+            }).text,
+          );
+      }
     }
+    const total = T * S;
     const sections: string[] = [];
     if (aBodies.length) {
       const merged = mergeJunosConfig(aBodies.join("\n"));
@@ -694,7 +707,7 @@ export default function ConfigGenerator() {
       sections.push(`/* ===== ${peLabel(sel.osB as GenOsKey, tagB)} ===== */\n${merged}`);
     }
     const text = sections.join("\n\n") + "\n";
-    const fname = `maas-${sel.familyId}-${sel.deploymentId}${n > 1 ? `-x${n}` : ""}.conf`;
+    const fname = `maas-${sel.familyId}-${sel.deploymentId ?? "pwht"}${total > 1 ? `-x${total}` : ""}.conf`;
     const blob = new Blob([text], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -1100,33 +1113,41 @@ export default function ConfigGenerator() {
 
           {currentStep === "params" && (
             <div className="space-y-5">
-              <div className="flex flex-wrap items-center gap-3 rounded-md border border-border bg-background p-3">
-                <label className="text-xs font-medium text-foreground">
-                  Number of services
-                </label>
-                <input
-                  type="number"
-                  min={1}
-                  max={500}
-                  value={count}
-                  onChange={(e) =>
-                    setCount(Math.max(1, Math.min(500, Number(e.target.value) || 1)))
-                  }
-                  className="h-8 w-20 rounded-md border border-border bg-surface px-2 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
-                />
-                <span className="text-[11px] text-muted-foreground">
-                  {count > 1
-                    ? `The values below are service #1. Services #2–${count} increment automatically; the download includes all ${count}.`
-                    : "The values below are your service. Increase the count to generate a numbered batch."}
-                </span>
-              </div>
+              {roleBased ? (
+                <div className="rounded-md border border-border bg-background p-3 text-[11px] text-muted-foreground">
+                  Generating a single service (one transport PW, one VLAN).
+                  Multi-PW batch generation (N transport PWs ×
+                  VLANs-per-PW with vlan-id-list + color) is coming next.
+                </div>
+              ) : (
+                <div className="flex flex-wrap items-center gap-3 rounded-md border border-border bg-background p-3">
+                  <label className="text-xs font-medium text-foreground">
+                    Number of services
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={500}
+                    value={count}
+                    onChange={(e) =>
+                      setCount(Math.max(1, Math.min(500, Number(e.target.value) || 1)))
+                    }
+                    className="h-8 w-20 rounded-md border border-border bg-surface px-2 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                  />
+                  <span className="text-[11px] text-muted-foreground">
+                    {count > 1
+                      ? `The values below are service #1. Services #2–${count} increment automatically; the download includes all ${count}.`
+                      : "The values below are your service. Increase the count to generate a numbered batch."}
+                  </span>
+                </div>
+              )}
 
               {sharedFields.length > 0 && (
                 <div>
                   <div className="mb-2 text-xs font-medium text-foreground">
                     Shared{" "}
                     <span className="font-normal text-muted-foreground">
-                      — identical on both PEs
+                      {roleBased ? "— common to both roles" : "— identical on both PEs"}
                     </span>
                   </div>
                   <div className="grid gap-3 sm:grid-cols-2">
@@ -1259,14 +1280,28 @@ export default function ConfigGenerator() {
                 </div>
               )}
               <div className="mt-2 text-[11px] text-muted-foreground">
-                {count > 1 ? `Previewing service 1 of ${count} · ` : ""}
-                {twoPe ? "2 endpoints · matched identifiers" : "single device"} ·{" "}
+                {count > 1 || (roleBased && pwCount > 1)
+                  ? `Previewing service 1${roleBased && pwCount > 1 ? " (PW 1)" : ""} · `
+                  : ""}
+                {roleBased
+                  ? `${tagA} + ${tagB}`
+                  : twoPe
+                    ? "2 endpoints · matched identifiers"
+                    : "single device"}{" "}
+                ·{" "}
                 {[sel.cos && "CoS", sel.firewall && "firewall filter"]
                   .filter(Boolean)
                   .join(" + ") || "service only"}{" "}
                 · rendered client-side from the JVD snip library
               </div>
-              {count > 1 && (
+              {roleBased && pwCount * count > 1 && (
+                <div className="mt-1 text-[11px] font-medium text-primary">
+                  Download includes all {pwCount * count} EVPN-ELANs ({pwCount}{" "}
+                  transport PW{pwCount > 1 ? "s" : ""} × {count} service
+                  {count > 1 ? "s" : ""}).
+                </div>
+              )}
+              {!roleBased && count > 1 && (
                 <div className="mt-1 text-[11px] font-medium text-primary">
                   Download includes all {count} services (#2–{count} auto-incremented).
                 </div>

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -18,6 +18,7 @@ import {
   type VarSpec,
   resolveOsBlock,
   resolveSnipIds,
+  resolveRoleSnipIds,
   attributeOptions,
   vlanModes,
   collectVariables,
@@ -91,6 +92,13 @@ const VAR_LABELS: Record<string, string> = {
   ESI_ID: "ESI value",
   FILTER_NAME: "UNI filter name",
   MTU: "physical MTU",
+  PS_TRANSPORT: "PS interface (IFD)",
+  PS_SERVICE: "PS service unit",
+  PS_ANCHOR: "PS anchor (LT)",
+  PW_LABEL_IN: "PW label · incoming",
+  PW_LABEL_OUT: "PW label · outgoing",
+  PW_NEIGHBOR: "PW neighbor",
+  VESI_ID: "PS virtual-ESI",
 };
 const varLabel = (name: string) => VAR_LABELS[name.replace(/^\$/, "")] ?? name;
 
@@ -140,6 +148,10 @@ const STEPS: StepId[] = [
   "attributes",
   "params",
 ];
+
+/** Role-based families (PWHT) skip mux/deployment/endpoint selection — the
+ *  two roles are fixed — so they use a shorter step flow. */
+const STEPS_ROLE: StepId[] = ["jvd", "family", "attributes", "params"];
 
 type Selection = {
   jvd?: string;
@@ -280,6 +292,11 @@ export default function ConfigGenerator() {
   const deployment = mux?.deployments.find((d) => d.id === sel.deploymentId);
   const osOptions = deployment ? (Object.keys(deployment.os) as GenOsKey[]) : [];
 
+  // Role-based families (PWHT) render one config per fixed role (Access /
+  // Headend) instead of the symmetric PE-A / PE-B model.
+  const roleBased = !!family?.roleBased;
+  const roles = family?.roles ?? [];
+
   const twoPe = sel.osB && sel.osB !== "none";
 
   const osBlockA =
@@ -356,19 +373,24 @@ export default function ConfigGenerator() {
     ? attrsA.color.filter((c) => attrsB.color.includes(c))
     : attrsA.color;
 
-  const attrsComplete = Boolean(
-    sel.homing && (modeOpts.length === 0 || vlanMode) && (!sel.firewall || sel.color),
-  );
-  const currentStep = STEPS[Math.min(step, STEPS.length - 1)];
-  const complete = Boolean(
-    sel.familyId &&
-      sel.muxId &&
-      sel.deploymentId &&
-      sel.osA &&
-      sel.homing &&
-      (modeOpts.length === 0 || vlanMode) &&
-      (!sel.firewall || sel.color),
-  );
+  const attrsComplete = roleBased
+    ? true
+    : Boolean(
+        sel.homing && (modeOpts.length === 0 || vlanMode) && (!sel.firewall || sel.color),
+      );
+  const steps = roleBased ? STEPS_ROLE : STEPS;
+  const currentStep = steps[Math.min(step, steps.length - 1)];
+  const complete = roleBased
+    ? Boolean(sel.familyId && roles.length >= 2)
+    : Boolean(
+        sel.familyId &&
+          sel.muxId &&
+          sel.deploymentId &&
+          sel.osA &&
+          sel.homing &&
+          (modeOpts.length === 0 || vlanMode) &&
+          (!sel.firewall || sel.color),
+      );
 
   const selFor = (os: GenOsKey): GenSelection => ({
     familyId: sel.familyId!,
@@ -384,14 +406,26 @@ export default function ConfigGenerator() {
   });
 
   const idsA = useMemo(
-    () => (complete && sel.osA ? resolveSnipIds(CATALOG, selFor(sel.osA)) : []),
+    () => {
+      if (roleBased)
+        return roles[0]
+          ? resolveRoleSnipIds(CATALOG, roles[0], { cos: sel.cos, firewall: false })
+          : [];
+      return complete && sel.osA ? resolveSnipIds(CATALOG, selFor(sel.osA)) : [];
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [complete, sel],
+    [complete, sel, roleBased],
   );
   const idsB = useMemo(
-    () => (complete && twoPe ? resolveSnipIds(CATALOG, selFor(sel.osB as GenOsKey)) : []),
+    () => {
+      if (roleBased)
+        return roles[1]
+          ? resolveRoleSnipIds(CATALOG, roles[1], { cos: sel.cos, firewall: false })
+          : [];
+      return complete && twoPe ? resolveSnipIds(CATALOG, selFor(sel.osB as GenOsKey)) : [];
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [complete, sel],
+    [complete, sel, roleBased],
   );
 
   // Union of variables across both endpoints.
@@ -417,6 +451,22 @@ export default function ConfigGenerator() {
     const k = classifyVar(v.name, ROLES).kind;
     return k === "per-endpoint" || k === "mirrored-primary";
   });
+  // For role-based families, each column shows only the variables its own role
+  // actually uses (the access side has no PS/RD/vESI fields, etc.).
+  const varsInA = useMemo(
+    () => new Set(collectVariables(idsA, byId).map((v) => v.name.replace(/^\$/, ""))),
+    [idsA, byId],
+  );
+  const varsInB = useMemo(
+    () => new Set(collectVariables(idsB, byId).map((v) => v.name.replace(/^\$/, ""))),
+    [idsB, byId],
+  );
+  const perFieldsA = roleBased
+    ? perFields.filter((v) => varsInA.has(v.name.replace(/^\$/, "")))
+    : perFields;
+  const perFieldsB = roleBased
+    ? perFields.filter((v) => varsInB.has(v.name.replace(/^\$/, "")))
+    : perFields;
 
   const pathKey = JSON.stringify([
     sel.familyId,
@@ -435,18 +485,38 @@ export default function ConfigGenerator() {
     const sh: Record<string, string> = {};
     const a: Record<string, string> = {};
     const b: Record<string, string> = {};
-    for (const v of unionVars) {
-      const bare = v.name.replace(/^\$/, "");
-      const kind = classifyVar(v.name, ROLES).kind;
-      if (kind === "shared") sh[bare] = v.example;
-      else if (kind !== "mirrored-secondary") {
-        a[bare] = v.example;
-        // Only vars that MUST differ (the service-id mirror, RD) get bumped on
-        // PE-B; everything else (UNI VLAN, unit, interface) defaults the same.
-        const mustDiffer =
-          kind === "mirrored-primary" ||
-          (ROLES.distinctPerEndpoint ?? []).includes(bare);
-        b[bare] = mustDiffer ? bumpB(v.example) : v.example;
+    if (roleBased) {
+      // Asymmetric roles: each side's default comes from ITS OWN snips (access
+      // AC_INTF = et-0/0/12, headend AC_INTF = ae10; no distinct-bump/mirror).
+      const exA = new Map(
+        collectVariables(idsA, byId).map((v) => [v.name.replace(/^\$/, ""), v.example]),
+      );
+      const exB = new Map(
+        collectVariables(idsB, byId).map((v) => [v.name.replace(/^\$/, ""), v.example]),
+      );
+      for (const v of unionVars) {
+        const bare = v.name.replace(/^\$/, "");
+        if (classifyVar(v.name, ROLES).kind === "shared")
+          sh[bare] = exA.get(bare) ?? exB.get(bare) ?? v.example;
+        else {
+          a[bare] = exA.get(bare) ?? v.example;
+          b[bare] = exB.get(bare) ?? v.example;
+        }
+      }
+    } else {
+      for (const v of unionVars) {
+        const bare = v.name.replace(/^\$/, "");
+        const kind = classifyVar(v.name, ROLES).kind;
+        if (kind === "shared") sh[bare] = v.example;
+        else if (kind !== "mirrored-secondary") {
+          a[bare] = v.example;
+          // Only vars that MUST differ (the service-id mirror, RD) get bumped on
+          // PE-B; everything else (UNI VLAN, unit, interface) defaults the same.
+          const mustDiffer =
+            kind === "mirrored-primary" ||
+            (ROLES.distinctPerEndpoint ?? []).includes(bare);
+          b[bare] = mustDiffer ? bumpB(v.example) : v.example;
+        }
       }
     }
     setShared(sh);
@@ -506,6 +576,19 @@ export default function ConfigGenerator() {
     }
   }
 
+  // Shared-field consistency — PWHT uses anycast PW labels, so incoming and
+  // outgoing must match.
+  const sharedErrors: Record<string, string> = {};
+  if (
+    roleBased &&
+    shared.PW_LABEL_IN &&
+    shared.PW_LABEL_OUT &&
+    shared.PW_LABEL_IN !== shared.PW_LABEL_OUT
+  ) {
+    sharedErrors.PW_LABEL_IN = "anycast — in/out must match";
+    sharedErrors.PW_LABEL_OUT = "anycast — in/out must match";
+  }
+
   const advance = (patch: Partial<Selection>, clears: (keyof Selection)[]) => {
     setSel((prev) => {
       const next = { ...prev, ...patch };
@@ -533,7 +616,11 @@ export default function ConfigGenerator() {
           : null;
       case "attributes":
         return attrsComplete
-          ? [
+          ? roleBased
+            ? sel.cos
+              ? "CoS"
+              : "no CoS"
+            : [
               HOMING_LABELS[sel.homing!] ?? sel.homing,
               vlanMode ? modeOpts.find((m) => m.id === vlanMode)?.label : null,
               rtPolicyApplies
@@ -553,7 +640,7 @@ export default function ConfigGenerator() {
         return null;
     }
   };
-  const crumbs = STEPS.slice(0, step).filter((id) => crumbValue(id) !== null);
+  const crumbs = steps.slice(0, step).filter((id) => crumbValue(id) !== null);
 
   const reset = () => {
     setSel({ cos: true, firewall: true });
@@ -599,12 +686,12 @@ export default function ConfigGenerator() {
     if (aBodies.length) {
       const merged = mergeJunosConfig(aBodies.join("\n"));
       sections.push(
-        twoPe ? `/* ===== ${peLabel(sel.osA, "PE-A")} ===== */\n${merged}` : merged,
+        twoPe ? `/* ===== ${peLabel(sel.osA, tagA)} ===== */\n${merged}` : merged,
       );
     }
     if (bBodies.length) {
       const merged = mergeJunosConfig(bBodies.join("\n"));
-      sections.push(`/* ===== ${peLabel(sel.osB as GenOsKey, "PE-B")} ===== */\n${merged}`);
+      sections.push(`/* ===== ${peLabel(sel.osB as GenOsKey, tagB)} ===== */\n${merged}`);
     }
     const text = sections.join("\n\n") + "\n";
     const fname = `maas-${sel.familyId}-${sel.deploymentId}${n > 1 ? `-x${n}` : ""}.conf`;
@@ -626,6 +713,9 @@ export default function ConfigGenerator() {
 
   const peLabel = (os: GenOsKey | undefined, tag: string) =>
     os ? `${tag} · ${OS_LABELS[os]}` : tag;
+  // Endpoint column / section tags — role names for PWHT, PE-A/PE-B otherwise.
+  const tagA = roleBased ? roles[0]?.label ?? "Access" : "PE-A";
+  const tagB = roleBased ? roles[1]?.label ?? "Headend" : "PE-B";
 
   return (
     <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_minmax(22rem,34rem)]">
@@ -636,7 +726,7 @@ export default function ConfigGenerator() {
             {crumbs.map((id, i) => (
               <span key={id} className="flex items-center gap-1.5">
                 <button
-                  onClick={() => setStep(STEPS.indexOf(id))}
+                  onClick={() => setStep(steps.indexOf(id))}
                   className="rounded-full border border-border bg-background px-2.5 py-0.5 text-muted-foreground hover:border-primary/50 hover:text-primary"
                   title={`Back to ${STEP_TITLES[id]}`}
                 >
@@ -661,7 +751,7 @@ export default function ConfigGenerator() {
               </button>
             )}
             <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Step {step + 1} of {STEPS.length} · {STEP_TITLES[currentStep]}
+              Step {step + 1} of {steps.length} · {STEP_TITLES[currentStep]}
             </span>
           </div>
           {step > 0 && (
@@ -705,16 +795,36 @@ export default function ConfigGenerator() {
                 sub={`${f.tagline} · ${f.description}`}
                 active={sel.familyId === f.id}
                 disabled={!f.available}
-                onClick={() =>
-                  advance({ familyId: f.id }, [
-                    "muxId",
-                    "deploymentId",
-                    "osA",
-                    "osB",
-                    "homing",
-                    "color",
-                  ])
-                }
+                onClick={() => {
+                  if (f.roleBased && f.roles) {
+                    // Role-based (PWHT): fix the two role OSes, skip
+                    // mux/deployment/endpoints, jump straight to attributes.
+                    setSel((p) => ({
+                      ...p,
+                      familyId: f.id,
+                      muxId: undefined,
+                      deploymentId: undefined,
+                      osA: f.roles![0].os,
+                      osB: f.roles![1].os,
+                      homing: undefined,
+                      vlanMode: undefined,
+                      rtPolicy: undefined,
+                      color: undefined,
+                      firewall: false,
+                      cos: true,
+                    }));
+                    setStep((s) => s + 1);
+                  } else {
+                    advance({ familyId: f.id }, [
+                      "muxId",
+                      "deploymentId",
+                      "osA",
+                      "osB",
+                      "homing",
+                      "color",
+                    ]);
+                  }
+                }}
               />
             ))}
 
@@ -811,7 +921,45 @@ export default function ConfigGenerator() {
             </div>
           )}
 
-          {currentStep === "attributes" && osBlockA && (
+          {currentStep === "attributes" && roleBased && (
+            <div className="space-y-4">
+              <div className="rounded-md border border-border bg-background p-3 text-[11px] text-muted-foreground">
+                <span className="font-medium text-foreground">
+                  {roles[0]?.label} ↔ {roles[1]?.label}
+                </span>
+                <br />
+                Two fixed roles — one config each (the headend applies to both
+                anycast MX). UNI firewall filter is deferred for PWHT.
+              </div>
+              <div>
+                <div className="mb-2 text-xs font-medium text-foreground">
+                  Class of Service
+                </div>
+                <div className="space-y-2">
+                  <Chip
+                    label="With CoS"
+                    sub="Classifiers, IEEE 802.1p + MPLS binding, rewrite rules"
+                    active={sel.cos}
+                    onClick={() => setSel((p) => ({ ...p, cos: true }))}
+                  />
+                  <Chip
+                    label="Without CoS"
+                    sub="Skip class-of-service"
+                    active={!sel.cos}
+                    onClick={() => setSel((p) => ({ ...p, cos: false }))}
+                  />
+                </div>
+              </div>
+              <button
+                onClick={() => setStep((s) => s + 1)}
+                className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-medium text-primary hover:bg-primary/20"
+              >
+                Continue to parameters <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          )}
+
+          {currentStep === "attributes" && !roleBased && osBlockA && (
             <div className="space-y-4">
               <div>
                 <div className="mb-2 text-xs font-medium text-foreground">Homing</div>
@@ -989,7 +1137,7 @@ export default function ConfigGenerator() {
                           key={v.name}
                           name={v.name}
                           hint={fieldHint(bare)}
-                          error={formatError(bare, shared[bare])}
+                          error={formatError(bare, shared[bare]) ?? sharedErrors[bare]}
                           value={shared[bare]}
                           onChange={(val) => setShared((p) => ({ ...p, [bare]: val }))}
                         />
@@ -1002,10 +1150,10 @@ export default function ConfigGenerator() {
               <div className="grid gap-5 sm:grid-cols-2">
                 <div>
                   <div className="mb-2 text-xs font-medium text-foreground">
-                    {peLabel(sel.osA, "PE-A")}
+                    {peLabel(sel.osA, tagA)}
                   </div>
                   <div className="space-y-3">
-                    {perFields.map((v) => {
+                    {perFieldsA.map((v) => {
                       const bare = v.name.replace(/^\$/, "");
                       const mirror = classifyVar(v.name, ROLES).kind === "mirrored-primary";
                       return (
@@ -1024,10 +1172,10 @@ export default function ConfigGenerator() {
                 {twoPe && (
                   <div>
                     <div className="mb-2 text-xs font-medium text-foreground">
-                      {peLabel(sel.osB as GenOsKey, "PE-B")}
+                      {peLabel(sel.osB as GenOsKey, tagB)}
                     </div>
                     <div className="space-y-3">
-                      {perFields.map((v) => {
+                      {perFieldsB.map((v) => {
                         const bare = v.name.replace(/^\$/, "");
                         const mirror =
                           classifyVar(v.name, ROLES).kind === "mirrored-primary";
@@ -1093,7 +1241,7 @@ export default function ConfigGenerator() {
               {renderA && (
                 <div className="mt-3">
                   <div className="mb-1 text-[11px] font-semibold text-primary">
-                    # {peLabel(sel.osA, "PE-A")}
+                    # {peLabel(sel.osA, tagA)}
                   </div>
                   <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
                     {mergedA}
@@ -1103,7 +1251,7 @@ export default function ConfigGenerator() {
               {renderB && (
                 <div className="mt-4">
                   <div className="mb-1 text-[11px] font-semibold text-primary">
-                    # {peLabel(sel.osB as GenOsKey, "PE-B")}
+                    # {peLabel(sel.osB as GenOsKey, tagB)}
                   </div>
                   <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
                     {mergedB}

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -344,6 +344,8 @@
       "available": true,
       "roleBased": true,
       "transportVars": ["PS_TRANSPORT", "VC_ID", "PW_LABEL_IN", "PW_LABEL_OUT"],
+      "colorCommDef": "evo/policy/communities-tc-color",
+      "colorComms": { "gold": "CM-TC-MAP2GOLD", "bronze": "CM-TC-MAP2BRONZE" },
       "roles": [
         {
           "id": "access",
@@ -351,6 +353,7 @@
           "os": "evo",
           "service": ["evo/services/l2circuit-floating-pw"],
           "interface": ["evo/interfaces/vlan-ccc-v2"],
+          "interfaceList": ["evo/interfaces/vlan-ccc-list"],
           "cosSnips": ["evo/cos/classifiers", "evo/cos/cos-binding-ieee8021p", "evo/cos/rewrite-rules"]
         },
         {

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -40,14 +40,16 @@
       "LABEL_BLOCK_SIZE",
       "SITE_RANGE",
       "COMM_RT",
-      "VPN_RT_COMM"
+      "VPN_RT_COMM",
+      "PW_LABEL_IN",
+      "PW_LABEL_OUT"
     ],
     "mirrored": [
       ["LOCAL_VID", "REMOTE_VID"],
       ["SITE_ID", "REMOTE_SITE_ID"]
     ],
     "distinctPerEndpoint": ["RD"],
-    "instanceConstant": ["MTU", "LABEL_BLOCK_SIZE", "FILTER_NAME", "SITE_RANGE", "AC_INTF"]
+    "instanceConstant": ["MTU", "LABEL_BLOCK_SIZE", "FILTER_NAME", "SITE_RANGE", "AC_INTF", "PS_TRANSPORT", "PS_ANCHOR", "PW_NEIGHBOR"]
   },
   "interfaceSpec": {
     "_note": "Validated attachment-circuit interface domain for the MaaS PE platforms (ACX7024/7100, MX304). media = permitted port-type prefixes; the slot/pic/port ranges catch clearly-out-of-range typos (e.g. et-99/99/99) while staying wide enough not to false-flag valid ports. Values outside this domain still render but are flagged 'not JVD-validated'.",
@@ -82,7 +84,13 @@
     "REMOTE_SITE_ID": { "type": "range", "min": 1, "max": 65534 },
     "VC_ID": { "type": "range", "min": 1, "max": 4294967295 },
     "MTU": { "type": "enum", "values": ["1522", "2000", "9102", "9192", "9500"] },
-    "LABEL_BLOCK_SIZE": { "type": "enum", "values": ["2", "4", "8", "16", "32", "64"] }
+    "LABEL_BLOCK_SIZE": { "type": "enum", "values": ["2", "4", "8", "16", "32", "64"] },
+    "PS_SERVICE": { "type": "range", "min": 1, "max": 16385 },
+    "PW_LABEL_IN": { "type": "range", "min": 16, "max": 1048575 },
+    "PW_LABEL_OUT": { "type": "range", "min": 16, "max": 1048575 },
+    "PW_NEIGHBOR": { "type": "ip" },
+    "VESI_ID": { "type": "esi" },
+    "PS_TRANSPORT": { "type": "psintf" }
   },
   "families": [
     {
@@ -326,6 +334,44 @@
       "tagline": "Operator hand-off",
       "description": "Access / ENNI segment carrying a customer's VLANs (often QinQ) into the metro (MEF E-Access).",
       "available": false,
+      "multiplexing": []
+    },
+    {
+      "id": "pwht",
+      "label": "PWHT",
+      "tagline": "Pseudowire Headend Termination",
+      "description": "Access L2Circuit pseudowire headed on an MX pair via a pseudowire-subscriber (PS) interface — anycast label/IP + virtual-ESI multihome the headend — then stitched per-VLAN into EVPN-ELAN.",
+      "available": true,
+      "roleBased": true,
+      "roles": [
+        {
+          "id": "access",
+          "label": "Access node (ACX)",
+          "os": "evo",
+          "service": ["evo/services/l2circuit-floating-pw"],
+          "interface": ["evo/interfaces/vlan-ccc-v2"],
+          "cosSnips": ["evo/cos/classifiers", "evo/cos/cos-binding-ieee8021p", "evo/cos/rewrite-rules"]
+        },
+        {
+          "id": "headend",
+          "label": "Headend (MX ×2, anycast)",
+          "os": "junos",
+          "service": [
+            "junos/services/l2circuit-floating-pw",
+            "junos/services/evpn-elan-vlan-based-floating-pw"
+          ],
+          "interface": [
+            "junos/interfaces/pseudowire-subscriber",
+            "junos/interfaces/vlan-bridge-esi-v3"
+          ],
+          "cosSnips": [
+            "junos/cos/classifiers",
+            "junos/cos/cos-binding-ieee8021p",
+            "junos/cos/cos-binding-mpls",
+            "junos/cos/rewrite-rules"
+          ]
+        }
+      ],
       "multiplexing": []
     }
   ]

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -11,6 +11,22 @@
     "evo": ["evo/cos/classifiers", "evo/cos/cos-binding-ieee8021p", "evo/cos/rewrite-rules"],
     "junos": ["junos/cos/classifiers", "junos/cos/cos-binding-ieee8021p", "junos/cos/rewrite-rules"]
   },
+  "routePolicySnips": {
+    "_note": "VRF route-export policy per OS, keyed by color id. The policy defines the policy-statement the service's `vrf-export` references, adding the RT community + the color-mapping community (gold/bronze). Junos has gold only; EVO has gold + bronze.",
+    "evo": {
+      "gold": "evo/policy/policy-vpn-rt-export-gold",
+      "bronze": "evo/policy/policy-vpn-rt-export-bronze"
+    },
+    "junos": {
+      "gold": "junos/policy/policy-vpn-rt-export-gold"
+    }
+  },
+  "derivedVars": {
+    "_note": "Auto-computed variables — not shown as form fields. POLICY_NAME + the RT community follow the instance name; COMM_RT mirrors the route-target so the color policy and the service agree.",
+    "POLICY_NAME": { "from": "INSTANCE_NAME" },
+    "COMM_RT": { "from": "VRF_TARGET" },
+    "VPN_RT_COMM": { "from": "INSTANCE_NAME", "suffix": "_RT" }
+  },
   "variableRoles": {
     "_note": "Classifies each $VAR for two-endpoint (PE-A / PE-B) rendering. 'shared' = identical on both PEs (must match). VLAN is shared because the MaaS JVD's captured configs use matching UNI VLANs — differing VLANs would require input/output vlan-map normalization snips the JVD does not include. 'mirrored' pairs = each PE's local value; the partner is auto-filled from the other PE's local value. 'distinctPerEndpoint' = per-PE values that MUST differ for L2 services (RD) — default bumped + warned if identical. NOTE: for future L3 services (L3VPN/EVPN Type-5), same RD is valid, so this rule must be scoped per service type. Everything not listed = per-endpoint, defaults the same on both PEs.",
     "shared": [

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -343,6 +343,7 @@
       "description": "Access L2Circuit pseudowire headed on an MX pair via a pseudowire-subscriber (PS) interface — anycast label/IP + virtual-ESI multihome the headend — then stitched per-VLAN into EVPN-ELAN.",
       "available": true,
       "roleBased": true,
+      "transportVars": ["PS_TRANSPORT", "VC_ID", "PW_LABEL_IN", "PW_LABEL_OUT"],
       "roles": [
         {
           "id": "access",

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-06T21:59:27.402Z",
+  "generatedAt": "2026-07-07T13:44:23.945Z",
   "counts": {
     "total": 515,
     "junos": 248,
@@ -23307,7 +23307,7 @@
       },
       "highlights": [
         "Community-driven RT policy",
-        "Color-mapping community is OPTIONAL — VPN works with or without it"
+        "Defines + adds the bronze color-mapping community (color:0:6000)"
       ],
       "pairWith": [],
       "variables": [
@@ -23325,10 +23325,10 @@
         }
       ],
       "jvdServiceMapping": [],
-      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2BRONZE;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2BRONZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 340,
-      "lineCount": 15,
+      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2BRONZE;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n    community CM-TC-MAP2BRONZE members color:0:6000;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2BRONZE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2BRONZE members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">6000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 393,
+      "lineCount": 16,
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
@@ -23358,7 +23358,7 @@
       },
       "highlights": [
         "Community-driven RT policy",
-        "Color-mapping community is OPTIONAL — VPN works with or without it"
+        "Defines + adds the gold color-mapping community (color:0:4000)"
       ],
       "pairWith": [],
       "variables": [
@@ -23376,10 +23376,10 @@
         }
       ],
       "jvdServiceMapping": [],
-      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2GOLD;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2GOLD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 338,
-      "lineCount": 15,
+      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2GOLD;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n    community CM-TC-MAP2GOLD members color:0:4000;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2GOLD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2GOLD members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">4000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 389,
+      "lineCount": 16,
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
@@ -27579,7 +27579,7 @@
       },
       "highlights": [
         "Community-driven RT policy",
-        "Color-mapping community is OPTIONAL — VPN works with or without it"
+        "Defines + adds the gold color-mapping community (color:0:4000)"
       ],
       "pairWith": [],
       "variables": [
@@ -27597,10 +27597,10 @@
         }
       ],
       "jvdServiceMapping": [],
-      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2GOLD;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2GOLD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 338,
-      "lineCount": 15,
+      "body": "policy-options {\n    policy-statement $POLICY_NAME {\n        term a {\n            then {\n                community add $VPN_RT_COMM;\n                community add CM-TC-MAP2GOLD;\n                accept;\n            }\n        }\n        term b {\n            then reject;\n        }\n    }\n    community $VPN_RT_COMM members target:$COMM_RT;\n    community CM-TC-MAP2GOLD members color:0:4000;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    policy-statement $POLICY_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term a {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add $VPN_RT_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community add CM-TC-MAP2GOLD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                accept;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        term b {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            then reject;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community $VPN_RT_COMM members target:$COMM_RT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2GOLD members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">4000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 389,
+      "lineCount": 16,
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-07T18:47:11.240Z",
+  "generatedAt": "2026-07-07T19:02:31.842Z",
   "counts": {
     "total": 517,
     "junos": 248,
@@ -25020,6 +25020,10 @@
           "example": "et-0/0/12"
         },
         {
+          "name": "$COLOR_COMM",
+          "example": "CM-TC-MAP2GOLD"
+        },
+        {
           "name": "$PW_LABEL_IN",
           "example": "1000022"
         },
@@ -25047,10 +25051,10 @@
         "    PEs (Evo): MA1.2 (ACX7024)",
         "    PEs (Junos): MSE1 (MX304), MSE2 (MX304)"
       ],
-      "body": "protocols {\n    l2circuit {\n        neighbor $PW_NEIGHBOR {\n            interface $AC_INTF.$UNIT {\n                static {\n                    incoming-label $PW_LABEL_IN;\n                    outgoing-label $PW_LABEL_OUT;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor $PW_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label $PW_LABEL_IN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label $PW_LABEL_OUT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 365,
-      "lineCount": 14,
+      "body": "protocols {\n    l2circuit {\n        neighbor $PW_NEIGHBOR {\n            interface $AC_INTF.$UNIT {\n                static {\n                    incoming-label $PW_LABEL_IN;\n                    outgoing-label $PW_LABEL_OUT;\n                }\n                virtual-circuit-id $VC_ID;\n                community $COLOR_COMM;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor $PW_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label $PW_LABEL_IN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label $PW_LABEL_OUT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                community $COLOR_COMM;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 404,
+      "lineCount": 15,
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-07-07T17:10:19.378Z",
+  "generatedAt": "2026-07-07T18:47:11.240Z",
   "counts": {
-    "total": 515,
+    "total": 517,
     "junos": 248,
-    "evo": 267,
+    "evo": 269,
     "jvds": 9
   },
   "categories": [
@@ -124,8 +124,8 @@
       "repoPath": "service_provider/metro_as_a_service",
       "counts": {
         "junos": 50,
-        "evo": 62,
-        "total": 112
+        "evo": 64,
+        "total": 114
       }
     },
     {
@@ -22471,6 +22471,67 @@
       "parseWarnings": []
     },
     {
+      "id": "metro_as_a_service/evo/interfaces/vlan-ccc-list",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-list",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-list.conf",
+      "topic": "Interface: vlan ccc list (MEF E-Line / PWHT access)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "encapsulation vlan-ccc",
+        "vlan-id-list — one attachment-circuit unit carries a VLAN range"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/l2circuit-floating-pw.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-floating-pw",
+          "note": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "et-0/0/14"
+        },
+        {
+          "name": "$UNIT",
+          "example": "300"
+        },
+        {
+          "name": "$VLAN_LIST_START",
+          "example": "300"
+        },
+        {
+          "name": "$VLAN_LIST_END",
+          "example": "309"
+        }
+      ],
+      "jvdServiceMapping": [],
+      "body": "$AC_INTF {\n    flexible-vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT {\n        encapsulation vlan-ccc;\n        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 194,
+      "lineCount": 8,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
       "id": "metro_as_a_service/evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid",
       "jvd": "metro_as_a_service",
       "jvdLabel": "Metro as a Service",
@@ -23222,6 +23283,49 @@
       "lineCount": 11,
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/evo/policy/communities-tc-color",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos EVO",
+      "osKey": "evo",
+      "category": "policy",
+      "name": "communities-tc-color",
+      "path": "service_provider/metro_as_a_service/configuration/snips/evo/policy/communities-tc-color.conf",
+      "topic": "Policy: transport-class color communities (gold / bronze)",
+      "seenOn": {
+        "junos": [],
+        "evo": [
+          "MA1.2"
+        ]
+      },
+      "highlights": [
+        "Defines the BGP-CT color-mapping communities referenced by a colored l2circuit / VRF-export (color:0:4000 gold, color:0:6000 bronze)"
+      ],
+      "pairWith": [
+        {
+          "raw": "evo/services/l2circuit-floating-pw.conf",
+          "id": "metro_as_a_service/evo/services/l2circuit-floating-pw",
+          "note": null
+        }
+      ],
+      "variables": [],
+      "jvdServiceMapping": [],
+      "body": "policy-options {\n    community CM-TC-MAP2BRONZE members color:0:6000;\n    community CM-TC-MAP2GOLD members color:0:4000;\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">policy-options {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2BRONZE members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">6000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    community CM-TC-MAP2GOLD members color:</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">:</span><span style=\"color:#79C0FF\">4000</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 122,
+      "lineCount": 4,
+      "techFamily": "Policy & Routing",
+      "subfamily": "Policy",
       "usecases": [
         "Service Provider",
         "Metro",
@@ -28081,10 +28185,6 @@
           "example": "ae10"
         },
         {
-          "name": "$INSTANCE_NAME",
-          "example": "4004-evpn-floating-pw"
-        },
-        {
           "name": "$PS_SERVICE",
           "example": "4004"
         },
@@ -28116,9 +28216,9 @@
         "    PEs (Evo): MA1.2 (ACX7024)",
         "    PEs (Junos): MSE1 (MX304), MSE2 (MX304)"
       ],
-      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn;\n        }\n        vlan-id $VLAN;\n        interface $AC_INTF.$UNIT;\n        interface $PS_TRANSPORT.$PS_SERVICE;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $PS_TRANSPORT.$PS_SERVICE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 298,
+      "body": "routing-instances {\n    $VLAN-evpn-floating-pw {\n        instance-type evpn;\n        protocols {\n            evpn;\n        }\n        vlan-id $VLAN;\n        interface $AC_INTF.$UNIT;\n        interface $PS_TRANSPORT.$PS_SERVICE;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $VLAN-evpn-floating-pw {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $PS_TRANSPORT.$PS_SERVICE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 306,
       "lineCount": 13,
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-07T13:44:23.945Z",
+  "generatedAt": "2026-07-07T17:10:19.378Z",
   "counts": {
     "total": 515,
     "junos": 248,
@@ -24916,6 +24916,18 @@
           "example": "et-0/0/12"
         },
         {
+          "name": "$PW_LABEL_IN",
+          "example": "1000022"
+        },
+        {
+          "name": "$PW_LABEL_OUT",
+          "example": "1000022"
+        },
+        {
+          "name": "$PW_NEIGHBOR",
+          "example": "1.1.10.10"
+        },
+        {
           "name": "$UNIT",
           "example": "4004"
         },
@@ -24931,9 +24943,9 @@
         "    PEs (Evo): MA1.2 (ACX7024)",
         "    PEs (Junos): MSE1 (MX304), MSE2 (MX304)"
       ],
-      "body": "protocols {\n    l2circuit {\n        neighbor 1.1.10.10 {\n            interface $AC_INTF.$UNIT {\n                static {\n                    incoming-label 1000022;\n                    outgoing-label 1000022;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor </span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">1</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 351,
+      "body": "protocols {\n    l2circuit {\n        neighbor $PW_NEIGHBOR {\n            interface $AC_INTF.$UNIT {\n                static {\n                    incoming-label $PW_LABEL_IN;\n                    outgoing-label $PW_LABEL_OUT;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor $PW_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $AC_INTF.$UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label $PW_LABEL_IN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label $PW_LABEL_OUT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 365,
       "lineCount": 14,
       "techFamily": "Service Overlay",
       "subfamily": "Services",
@@ -26547,16 +26559,20 @@
       ],
       "variables": [
         {
-          "name": "$ESI_ID",
-          "example": "00:11:11:11:44:11:11:30:02:0a"
+          "name": "$PS_ANCHOR",
+          "example": "lt-0/0/0"
         },
         {
-          "name": "$UNIT_1",
-          "example": "0"
-        },
-        {
-          "name": "$UNIT_2",
+          "name": "$PS_SERVICE",
           "example": "4004"
+        },
+        {
+          "name": "$PS_TRANSPORT",
+          "example": "ps22"
+        },
+        {
+          "name": "$VESI_ID",
+          "example": "00:11:11:11:44:11:11:30:02:0a"
         },
         {
           "name": "$VLAN",
@@ -26564,9 +26580,9 @@
         }
       ],
       "jvdServiceMapping": [],
-      "body": "ps22 {\n    anchor-point {\n        lt-0/0/0;\n    }\n    vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit $UNIT_1 {\n        encapsulation ethernet-ccc;\n    }\n    unit $UNIT_2 {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $ESI_ID;\n            all-active;\n        }\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">ps22 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    anchor-point {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        lt-</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">/</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_1 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation ethernet-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT_2 {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $ESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 328,
+      "body": "$PS_TRANSPORT {\n    anchor-point {\n        $PS_ANCHOR;\n    }\n    vlan-tagging;\n    encapsulation flexible-ethernet-services;\n    unit 0 {\n        encapsulation ethernet-ccc;\n    }\n    unit $PS_SERVICE {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        esi {\n            $VESI_ID;\n            all-active;\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$PS_TRANSPORT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    anchor-point {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        $PS_ANCHOR;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit </span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation ethernet-ccc;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $PS_SERVICE {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        esi {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            $VESI_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            all-active;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 338,
       "lineCount": 18,
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
@@ -28069,6 +28085,14 @@
           "example": "4004-evpn-floating-pw"
         },
         {
+          "name": "$PS_SERVICE",
+          "example": "4004"
+        },
+        {
+          "name": "$PS_TRANSPORT",
+          "example": "ps22"
+        },
+        {
           "name": "$RD",
           "example": "10.0.0.10:40004"
         },
@@ -28092,9 +28116,9 @@
         "    PEs (Evo): MA1.2 (ACX7024)",
         "    PEs (Junos): MSE1 (MX304), MSE2 (MX304)"
       ],
-      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn;\n        }\n        vlan-id $VLAN;\n        interface $AC_INTF.$UNIT;\n        interface ps22.4004;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface ps22.</span><span style=\"color:#79C0FF\">4004</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 282,
+      "body": "routing-instances {\n    $INSTANCE_NAME {\n        instance-type evpn;\n        protocols {\n            evpn;\n        }\n        vlan-id $VLAN;\n        interface $AC_INTF.$UNIT;\n        interface $PS_TRANSPORT.$PS_SERVICE;\n        route-distinguisher $RD;\n        vrf-target target:$VRF_TARGET;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">routing-instances {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    $INSTANCE_NAME {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        instance-type evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            evpn;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $AC_INTF.$UNIT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        interface $PS_TRANSPORT.$PS_SERVICE;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        route-distinguisher $RD;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vrf-target target:$VRF_TARGET;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 298,
       "lineCount": 13,
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
@@ -28524,6 +28548,22 @@
       ],
       "variables": [
         {
+          "name": "$PS_TRANSPORT",
+          "example": "ps22"
+        },
+        {
+          "name": "$PW_LABEL_IN",
+          "example": "1000022"
+        },
+        {
+          "name": "$PW_LABEL_OUT",
+          "example": "1000022"
+        },
+        {
+          "name": "$PW_NEIGHBOR",
+          "example": "10.0.0.18"
+        },
+        {
           "name": "$VC_ID",
           "example": "10120"
         }
@@ -28535,9 +28575,9 @@
         "    PEs (Evo): MA1.2 (ACX7024)",
         "    PEs (Junos): MSE1 (MX304), MSE2 (MX304)"
       ],
-      "body": "protocols {\n    l2circuit {\n        neighbor 10.0.0.18 {\n            interface ps22.0 {\n                static {\n                    incoming-label 1000022;\n                    outgoing-label 1000022;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
-      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor </span><span style=\"color:#79C0FF\">10</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\">.</span><span style=\"color:#79C0FF\">18</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface ps22.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label </span><span style=\"color:#79C0FF\">1000022</span><span style=\"color:#E6EDF3\">;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
-      "bytes": 343,
+      "body": "protocols {\n    l2circuit {\n        neighbor $PW_NEIGHBOR {\n            interface $PS_TRANSPORT.0 {\n                static {\n                    incoming-label $PW_LABEL_IN;\n                    outgoing-label $PW_LABEL_OUT;\n                }\n                virtual-circuit-id $VC_ID;\n                encapsulation-type ethernet-vlan;\n            }\n        }\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">protocols {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    l2circuit {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        neighbor $PW_NEIGHBOR {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            interface $PS_TRANSPORT.</span><span style=\"color:#79C0FF\">0</span><span style=\"color:#E6EDF3\"> {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                static {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    incoming-label $PW_LABEL_IN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                    outgoing-label $PW_LABEL_OUT;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                virtual-circuit-id $VC_ID;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                encapsulation-type ethernet-vlan;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 366,
       "lineCount": 14,
       "techFamily": "Service Overlay",
       "subfamily": "Services",

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -65,6 +65,9 @@ export type GenFamily = {
   /** Variables that increment per transport PW (not per service) in the
    *  two-dimensional PWHT fan-out — the PS IFD, VC-ID, PW labels. */
   transportVars?: string[];
+  /** PWHT color: the community-definition snip + color→community-name map. */
+  colorCommDef?: string;
+  colorComms?: Record<string, string>;
 };
 
 /** One endpoint role of a role-based family (e.g. PWHT Access vs Headend).
@@ -75,6 +78,9 @@ export type GenRole = {
   os: GenOsKey;
   service: string[];
   interface: string[];
+  /** Alternate interface snip(s) used when a PW carries a VLAN range
+   *  (vlan-id-list) instead of a single VLAN. */
+  interfaceList?: string[];
   cosSnips?: string[];
   filter?: string;
 };

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -66,11 +66,18 @@ export type GenCatalog = {
   version: number;
   tiers: Record<string, { label: string; description: string }>;
   cosSnips: Record<GenOsKey, string[]>;
+  /** VRF route-export policy snips, per OS, keyed by color id (gold/bronze). */
+  routePolicySnips?: Partial<Record<GenOsKey, Record<string, string>>>;
+  /** Variables auto-derived from other variables (not shown as form fields). */
+  derivedVars?: Record<string, DerivedVar>;
   variableRoles: VariableRoles;
   varSpecs?: Record<string, VarSpec>;
   interfaceSpec?: InterfaceSpec;
   families: GenFamily[];
 };
+
+/** A variable whose value is computed from another variable's value. */
+export type DerivedVar = { from: string; prefix?: string; suffix?: string };
 
 /**
  * Classifies each $VAR for two-endpoint rendering:
@@ -265,6 +272,7 @@ export type GenSelection = {
   os: GenOsKey;
   homing: string; // key into osBlock.interface
   vlanMode?: string; // id of the chosen uni.mode (when the OS block has them)
+  rtPolicy?: string; // "rt-only" (strip vrf-export) or a color id (gold/bronze)
   cos: boolean; // include CoS binding snips (classifiers, scheduler binding)
   firewall: boolean; // include the UNI firewall filter
   color: string; // key into osBlock.filter (required when firewall = true)
@@ -310,6 +318,12 @@ export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[]
   if (!osb) return [];
   const rel: string[] = [];
   rel.push(...osb.service);
+  // Colored VRF export: pull the gold/bronze policy that defines the
+  // `vrf-export` policy-statement the service references.
+  if (sel.rtPolicy && sel.rtPolicy !== "rt-only") {
+    const pol = catalog.routePolicySnips?.[sel.os]?.[sel.rtPolicy];
+    if (pol) rel.push(pol);
+  }
   const iface = osInterfaceMap(osb, sel.vlanMode)[sel.homing];
   if (iface) rel.push(iface);
   rel.push(...osb.interfaceExtras);
@@ -405,6 +419,30 @@ function stripUniFilterBinding(body: string): string {
   );
 }
 
+/** Remove the `vrf-export <policy>;` line from a service body. Used in the
+ *  "route-target only" mode, where the RT alone drives import/export and no
+ *  export policy is defined. */
+function stripVrfExport(body: string): string {
+  return body.replace(/\n?[^\S\n]*vrf-export\s+\S+;/g, "");
+}
+
+/** Compute auto-derived variable values (e.g. POLICY_NAME = INSTANCE_NAME,
+ *  VPN_RT_COMM = INSTANCE_NAME + "_RT") from the resolved base values. */
+function applyDerived(
+  values: Record<string, string>,
+  derived?: Record<string, DerivedVar>,
+): Record<string, string> {
+  if (!derived) return values;
+  const out = { ...values };
+  for (const [key, d] of Object.entries(derived)) {
+    if (key.startsWith("_") || !d || !d.from) continue;
+    const base = values[d.from];
+    if (base !== undefined && base !== "")
+      out[key] = `${d.prefix ?? ""}${base}${d.suffix ?? ""}`;
+  }
+  return out;
+}
+
 export type RenderResult = {
   text: string;
   /** Variable names still present as $VAR after substitution. */
@@ -423,13 +461,19 @@ export function renderConfig(
   snipIds: string[],
   values: Record<string, string>,
   byId: Map<string, SnipRecord>,
-  opts?: { stripUniFilter?: boolean },
+  opts?: {
+    stripUniFilter?: boolean;
+    stripVrfExport?: boolean;
+    derived?: Record<string, DerivedVar>;
+  },
 ): RenderResult {
-  // Normalise value keys to bare names (no leading $).
+  // Normalise value keys to bare names (no leading $), then fold in any
+  // auto-derived variables (policy name, RT community, …).
   const norm: Record<string, string> = {};
   for (const [k, v] of Object.entries(values)) {
     norm[k.startsWith("$") ? k.slice(1) : k] = v;
   }
+  const resolved = applyDerived(norm, opts?.derived);
 
   const blocks: string[] = [];
   const used: string[] = [];
@@ -438,18 +482,26 @@ export function renderConfig(
     if (!snip) continue;
     used.push(id);
     const shortPath = `${snip.osKey}/${snip.category}/${snip.name}.conf`;
-    let body = substitute(stripHeader(snip.body), norm);
+    let body = substitute(stripHeader(snip.body), resolved);
     // Drop the inline UNI filter binding on interface snips when the user
     // opted out of the firewall filter (else it dangles).
     if (opts?.stripUniFilter && snip.category === "interfaces") {
       body = stripUniFilterBinding(body);
     }
+    // Route-target-only mode: drop the vrf-export policy reference.
+    if (opts?.stripVrfExport && snip.category === "services") {
+      body = stripVrfExport(body);
+    }
     // Normalise interface snips under an `interfaces { … }` wrapper so they
-    // merge with each other (and with the CoS binding, which is already
-    // wrapped) into one physical-interface stanza. Some snips already carry
-    // the wrapper — don't double-wrap those.
+    // merge with each other into one physical-interface stanza. Some snips
+    // already carry the wrapper — don't double-wrap those.
     if (snip.category === "interfaces" && !/^\s*interfaces\s*\{/.test(body)) {
       body = `interfaces {\n${body}\n}`;
+    }
+    // CoS snips belong under `class-of-service { … }` (classifiers, rewrite
+    // rules, and the per-interface binding) — not under `[edit interfaces]`.
+    if (snip.category === "cos" && !/^\s*class-of-service\s*\{/.test(body)) {
+      body = `class-of-service {\n${body}\n}`;
     }
     const rendered = body.replace(/\s+$/, "");
     blocks.push(`/* snips/${shortPath} */\n${rendered}`);

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -58,6 +58,22 @@ export type GenFamily = {
   description: string;
   available: boolean;
   multiplexing: GenMux[];
+  /** Asymmetric role-based families (e.g. PWHT) render one config per role
+   *  instead of the symmetric PE-A / PE-B model. */
+  roleBased?: boolean;
+  roles?: GenRole[];
+};
+
+/** One endpoint role of a role-based family (e.g. PWHT Access vs Headend).
+ *  Unlike symmetric E-Line PEs, each role has its own snip bundle + OS. */
+export type GenRole = {
+  id: string;
+  label: string;
+  os: GenOsKey;
+  service: string[];
+  interface: string[];
+  cosSnips?: string[];
+  filter?: string;
 };
 
 export type GenCatalog = {
@@ -108,6 +124,8 @@ export type VarSpec =
   | { type: "rd" }
   | { type: "rt" }
   | { type: "esi" }
+  | { type: "ip" }
+  | { type: "psintf" }
   | { type: "name" }
   | { type: "text" };
 
@@ -124,6 +142,8 @@ export type InterfaceSpec = {
 const RD_RT_RE = /^(\d{1,3}(\.\d{1,3}){3}|\d+):\d+$/;
 const ESI_RE = /^([0-9a-fA-F]{2}:){9}[0-9a-fA-F]{2}$/;
 const NAME_RE = /^[A-Za-z0-9_-]+$/;
+const IP_RE = /^\d{1,3}(\.\d{1,3}){3}$/;
+const PS_INTF_RE = /^ps\d+$/;
 
 /**
  * Validate one interface string against the platform capability table.
@@ -187,6 +207,12 @@ export function validateSpec(
       return RD_RT_RE.test(value) ? undefined : "expected <ip|asn>:<number>";
     case "esi":
       return ESI_RE.test(value) ? undefined : "expected a 10-byte ESI (00:…:01)";
+    case "ip":
+      return IP_RE.test(value) ? undefined : "expected an IPv4 address";
+    case "psintf":
+      return PS_INTF_RE.test(value)
+        ? undefined
+        : "expected a PS interface (e.g. ps22)";
     case "name":
       return NAME_RE.test(value) ? undefined : "letters, digits, _ or - only";
     default:
@@ -292,6 +318,31 @@ export function resolveOsBlock(
 /** The VLAN-handling modes an OS block offers (empty when it has none). */
 export function vlanModes(osb: GenOsBlock): UniMode[] {
   return osb.uni?.modes ?? [];
+}
+
+/**
+ * Resolve the ordered jvd-qualified snip IDs for one role of a role-based
+ * family (e.g. PWHT Access or Headend). Order: service(s) → interface(s) →
+ * (if firewall) filter → (if CoS) CoS snips. De-duped + jvd-qualified.
+ */
+export function resolveRoleSnipIds(
+  catalog: GenCatalog,
+  role: GenRole,
+  opts: { cos: boolean; firewall: boolean },
+): string[] {
+  const rel: string[] = [...role.service, ...role.interface];
+  if (opts.firewall && role.filter) rel.push(role.filter);
+  if (opts.cos && role.cosSnips) rel.push(...role.cosSnips);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rel) {
+    const qualified = `${catalog.jvd}/${r}`;
+    if (!seen.has(qualified)) {
+      seen.add(qualified);
+      out.push(qualified);
+    }
+  }
+  return out;
 }
 
 /** The homing→snip interface map for the chosen VLAN mode (or the flat/legacy

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -62,6 +62,9 @@ export type GenFamily = {
    *  instead of the symmetric PE-A / PE-B model. */
   roleBased?: boolean;
   roles?: GenRole[];
+  /** Variables that increment per transport PW (not per service) in the
+   *  two-dimensional PWHT fan-out — the PS IFD, VC-ID, PW labels. */
+  transportVars?: string[];
 };
 
 /** One endpoint role of a role-based family (e.g. PWHT Access vs Headend).
@@ -241,11 +244,15 @@ export function classifyVar(
   return { kind: "per-endpoint" };
 }
 
-/** Increment the trailing integer of a value by `by` (0 = unchanged). */
+/** Increment the trailing integer of a value by `by` (0 = unchanged),
+ *  preserving zero-padding width (so an ESI byte …:01 bumps to …:02, not …:2,
+ *  and an RD :40004 → :40005). */
 export function bumpInt(value: string, by: number): string {
   if (by === 0) return value;
   const m = value.match(/^(.*?)(\d+)$/);
-  return m ? m[1] + String(parseInt(m[2], 10) + by) : value;
+  if (!m) return value;
+  const width = m[2].length;
+  return m[1] + String(parseInt(m[2], 10) + by).padStart(width, "0");
 }
 
 /**
@@ -263,6 +270,31 @@ export function instanceValues(
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(values)) {
     out[k] = constant.has(k) ? v : bumpInt(v, i);
+  }
+  return out;
+}
+
+/**
+ * Two-dimensional fan-out for role-based families (PWHT): a grid of
+ * `transport` × `service` instances. `transportVars` (the PS IFD, VC-ID, PW
+ * labels) increment by the transport index `t`; every other non-constant
+ * variable increments by the global service index `i` (so each EVPN-ELAN is
+ * unique across all transport PWs); instanceConstant vars stay fixed.
+ */
+export function gridInstanceValues(
+  values: Record<string, string>,
+  roles: VariableRoles,
+  transportVars: string[],
+  t: number,
+  i: number,
+): Record<string, string> {
+  const constant = new Set(roles.instanceConstant ?? []);
+  const transport = new Set(transportVars);
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(values)) {
+    if (transport.has(k)) out[k] = bumpInt(v, t);
+    else if (constant.has(k)) out[k] = v;
+    else out[k] = bumpInt(v, i);
   }
   return out;
 }
@@ -477,6 +509,12 @@ function stripVrfExport(body: string): string {
   return body.replace(/\n?[^\S\n]*vrf-export\s+\S+;/g, "");
 }
 
+/** Remove a bare `community <name>;` binding line (e.g. an uncolored PWHT
+ *  l2circuit). Leaves `community <name> members …;` definitions untouched. */
+function stripCommunity(body: string): string {
+  return body.replace(/\n?[^\S\n]*community\s+\S+;/g, "");
+}
+
 /** Compute auto-derived variable values (e.g. POLICY_NAME = INSTANCE_NAME,
  *  VPN_RT_COMM = INSTANCE_NAME + "_RT") from the resolved base values. */
 function applyDerived(
@@ -515,6 +553,7 @@ export function renderConfig(
   opts?: {
     stripUniFilter?: boolean;
     stripVrfExport?: boolean;
+    stripCommunity?: boolean;
     derived?: Record<string, DerivedVar>;
   },
 ): RenderResult {
@@ -542,6 +581,10 @@ export function renderConfig(
     // Route-target-only mode: drop the vrf-export policy reference.
     if (opts?.stripVrfExport && snip.category === "services") {
       body = stripVrfExport(body);
+    }
+    // Uncolored PWHT: drop the l2circuit color-community binding.
+    if (opts?.stripCommunity && snip.category === "services") {
+      body = stripCommunity(body);
     }
     // Normalise interface snips under an `interfaces { … }` wrapper so they
     // merge with each other into one physical-interface stanza. Some snips

--- a/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-list.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-list.conf
@@ -1,0 +1,27 @@
+/*
+ * Topic:   Interface: vlan ccc list (MEF E-Line / PWHT access)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-id-list — one attachment-circuit unit carries a VLAN range
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/l2circuit-floating-pw.conf
+ *
+ * Variables:
+ *   $AC_INTF          e.g. et-0/0/14
+ *   $UNIT             e.g. 300
+ *   $VLAN_LIST_START  e.g. 300
+ *   $VLAN_LIST_END    e.g. 309
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;
+    }
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/communities-tc-color.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/communities-tc-color.conf
@@ -1,0 +1,19 @@
+/*
+ * Topic:   Policy: transport-class color communities (gold / bronze)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - Defines the BGP-CT color-mapping communities referenced by a colored
+ *     l2circuit / VRF-export (color:0:4000 gold, color:0:6000 bronze)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/l2circuit-floating-pw.conf
+ *
+ * Variables: none — JVD-wide constants.
+ */
+policy-options {
+    community CM-TC-MAP2BRONZE members color:0:6000;
+    community CM-TC-MAP2GOLD members color:0:4000;
+}

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf
@@ -6,7 +6,7 @@
  *
  * Highlights:
  *   - Community-driven RT policy
- *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *   - Defines + adds the bronze color-mapping community (color:0:6000)
  *
  * Pair with (same-device dependencies):
  *   (none derived)
@@ -33,4 +33,5 @@ policy-options {
         }
     }
     community $VPN_RT_COMM members target:$COMM_RT;
+    community CM-TC-MAP2BRONZE members color:0:6000;
 }

--- a/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf
@@ -6,7 +6,7 @@
  *
  * Highlights:
  *   - Community-driven RT policy
- *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *   - Defines + adds the gold color-mapping community (color:0:4000)
  *
  * Pair with (same-device dependencies):
  *   (none derived)
@@ -33,4 +33,5 @@ policy-options {
         }
     }
     community $VPN_RT_COMM members target:$COMM_RT;
+    community CM-TC-MAP2GOLD members color:0:4000;
 }

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
@@ -23,6 +23,7 @@
  *
  * Variables:
  *   $AC_INTF       e.g. et-0/0/12
+ *   $COLOR_COMM    e.g. CM-TC-MAP2GOLD
  *   $PW_LABEL_IN   e.g. 1000022
  *   $PW_LABEL_OUT  e.g. 1000022
  *   $PW_NEIGHBOR   e.g. 1.1.10.10
@@ -38,6 +39,7 @@ protocols {
                     outgoing-label $PW_LABEL_OUT;
                 }
                 virtual-circuit-id $VC_ID;
+                community $COLOR_COMM;
                 encapsulation-type ethernet-vlan;
             }
         }

--- a/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf
@@ -22,17 +22,20 @@
  *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
  *
  * Variables:
- *   $AC_INTF  e.g. et-0/0/12
- *   $UNIT     e.g. 4004
- *   $VC_ID    e.g. 10120
+ *   $AC_INTF       e.g. et-0/0/12
+ *   $PW_LABEL_IN   e.g. 1000022
+ *   $PW_LABEL_OUT  e.g. 1000022
+ *   $PW_NEIGHBOR   e.g. 1.1.10.10
+ *   $UNIT          e.g. 4004
+ *   $VC_ID         e.g. 10120
  */
 protocols {
     l2circuit {
-        neighbor 1.1.10.10 {
+        neighbor $PW_NEIGHBOR {
             interface $AC_INTF.$UNIT {
                 static {
-                    incoming-label 1000022;
-                    outgoing-label 1000022;
+                    incoming-label $PW_LABEL_IN;
+                    outgoing-label $PW_LABEL_OUT;
                 }
                 virtual-circuit-id $VC_ID;
                 encapsulation-type ethernet-vlan;

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf
@@ -13,25 +13,26 @@
  *   - junos/services/l2circuit-floating-pw.conf
  *
  * Variables:
- *   $ESI_ID  e.g. 00:11:11:11:44:11:11:30:02:0a
- *   $UNIT_1  e.g. 0
- *   $UNIT_2  e.g. 4004
- *   $VLAN    e.g. 4004
+ *   $PS_ANCHOR     e.g. lt-0/0/0
+ *   $PS_SERVICE    e.g. 4004
+ *   $PS_TRANSPORT  e.g. ps22
+ *   $VESI_ID       e.g. 00:11:11:11:44:11:11:30:02:0a
+ *   $VLAN          e.g. 4004
  */
-ps22 {
+$PS_TRANSPORT {
     anchor-point {
-        lt-0/0/0;
+        $PS_ANCHOR;
     }
     vlan-tagging;
     encapsulation flexible-ethernet-services;
-    unit $UNIT_1 {
+    unit 0 {
         encapsulation ethernet-ccc;
     }
-    unit $UNIT_2 {
+    unit $PS_SERVICE {
         encapsulation vlan-bridge;
         vlan-id $VLAN;
         esi {
-            $ESI_ID;
+            $VESI_ID;
             all-active;
         }
     }

--- a/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf
@@ -6,7 +6,7 @@
  *
  * Highlights:
  *   - Community-driven RT policy
- *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *   - Defines + adds the gold color-mapping community (color:0:4000)
  *
  * Pair with (same-device dependencies):
  *   (none derived)
@@ -33,4 +33,5 @@ policy-options {
         }
     }
     community $VPN_RT_COMM members target:$COMM_RT;
+    community CM-TC-MAP2GOLD members color:0:4000;
 }

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
@@ -27,6 +27,8 @@
  * Variables:
  *   $AC_INTF        e.g. ae10
  *   $INSTANCE_NAME  e.g. 4004-evpn-floating-pw
+ *   $PS_SERVICE     e.g. 4004
+ *   $PS_TRANSPORT   e.g. ps22
  *   $RD             e.g. 10.0.0.10:40004
  *   $UNIT           e.g. 4004
  *   $VLAN           e.g. 4004
@@ -40,7 +42,7 @@ routing-instances {
         }
         vlan-id $VLAN;
         interface $AC_INTF.$UNIT;
-        interface ps22.4004;
+        interface $PS_TRANSPORT.$PS_SERVICE;
         route-distinguisher $RD;
         vrf-target target:$VRF_TARGET;
     }

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf
@@ -26,7 +26,6 @@
  *
  * Variables:
  *   $AC_INTF        e.g. ae10
- *   $INSTANCE_NAME  e.g. 4004-evpn-floating-pw
  *   $PS_SERVICE     e.g. 4004
  *   $PS_TRANSPORT   e.g. ps22
  *   $RD             e.g. 10.0.0.10:40004
@@ -35,7 +34,7 @@
  *   $VRF_TARGET     e.g. 4004:4004
  */
 routing-instances {
-    $INSTANCE_NAME {
+    $VLAN-evpn-floating-pw {
         instance-type evpn;
         protocols {
             evpn;

--- a/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf
@@ -19,15 +19,19 @@
  *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
  *
  * Variables:
- *   $VC_ID  e.g. 10120
+ *   $PS_TRANSPORT  e.g. ps22
+ *   $PW_LABEL_IN   e.g. 1000022
+ *   $PW_LABEL_OUT  e.g. 1000022
+ *   $PW_NEIGHBOR   e.g. 10.0.0.18
+ *   $VC_ID         e.g. 10120
  */
 protocols {
     l2circuit {
-        neighbor 10.0.0.18 {
-            interface ps22.0 {
+        neighbor $PW_NEIGHBOR {
+            interface $PS_TRANSPORT.0 {
                 static {
-                    incoming-label 1000022;
-                    outgoing-label 1000022;
+                    incoming-label $PW_LABEL_IN;
+                    outgoing-label $PW_LABEL_OUT;
                 }
                 virtual-circuit-id $VC_ID;
                 encapsulation-type ethernet-vlan;


### PR DESCRIPTION
## What's New

Extends the deterministic **Config Generator** for the Metro-as-a-Service JVD with two-axis VRF export controls, a class-of-service placement fix, and a brand-new **PWHT (Pseudowire Headend Termination)** service category.

- **VRF route-export tiers (E-Line)** — choose **Uncolored** (route-target only), **Gold** (priority / low-latency) or **Bronze** (TE path). Colored services emit a self-contained `policy-options` block with both the RT community and the color-mapping community defined.
- **Class-of-Service placement fix** — classifiers, rewrite-rules and scheduler-map now render under `[edit class-of-service]` (definitions + per-interface binding), not jammed into `[edit interfaces]`. The physical interface stanza stays clean.
- **New category: PWHT** — an access L2Circuit pseudowire headed on an MX pair via a pseudowire-subscriber interface (anycast label/IP + virtual-ESI), stitched per-VLAN into EVPN-ELAN. The generator's first **asymmetric, role-based** service.

## Why

The generator's value proposition is *trustworthy, JVD-grounded config*. These changes close three gaps: colored services previously referenced an **undefined** export policy; CoS bindings landed at the wrong hierarchy level; and PWHT — a distinct architecture used across multiple JVDs — had no generator support at all.

## Details

- `src/data/generator/metro_as_a_service.json` — `routePolicySnips` + `derivedVars` (E-Line color); new `pwht` role-based family (`roles`, `transportVars`, `colorComms`, per-role `interfaceList`).
- `src/lib/generator.ts` — `stripVrfExport` / `stripCommunity` render options; `class-of-service` wrapper for CoS snips; role types + `resolveRoleSnipIds`; `bumpInt` now zero-pads (ESIs increment `…02:01 → …02:06`); `ip`/`psintf` validators.
- `src/components/ConfigGenerator.tsx` — VRF route-export selector; role-based wizard branch (Access / Headend) with per-role field columns; **PWHT asymmetric fan-out** (access renders once per transport PW with `vlan-id-list`; headend once per VLAN, transport stanzas dedupe per-PW via the merger); **Transport PWs × VLANs/PW** knobs; batch color selector.
- Snips (templatized / added): `evo,junos/services/l2circuit-floating-pw`, `junos/interfaces/pseudowire-subscriber`, `junos/services/evpn-elan-vlan-based-floating-pw`, plus new `evo/interfaces/vlan-ccc-list` and `evo/policy/communities-tc-color`. `snips.json` regenerated (0 warnings, CI `--check` passes).

## Testing

- E-Line: route-export tiers (uncolored strips `vrf-export`; gold/bronze define both communities); CoS under `class-of-service`; verified unregressed after the PWHT work.
- PWHT single-service: access `l2circuit → anycast`, headend `ps.0` transport + `ps.<vlan>` service units + EVPN-ELAN stitching `ae.<vlan>` + `ps.<vlan>`.
- PWHT fan-out (2 PWs × 3 VLANs, gold): 2 access l2circuits with `vlan-id-list` ranges + gold community per PW + community def; `ps22`/`ps23`; 6 EVPN-ELANs with unique RDs and incrementing ESIs.
- Verified via Node render tests and against the production `preview` build; `bun run build` clean.

## Notes

- **PWHT firewall tier deferred** — needs `$FILTER_NAME`-vs-hardcoded-binding reconciliation (a cross-deployment concern); with firewall off the interface filter bindings strip cleanly.
- E-Line **EVPN-FXC** remains greyed "coming soon" (multi-UNI `$UNIT_1/$UNIT_2`), planned as a follow-up.
