### PR TITLE
feat(portal): E-Tree in the Config Generator

### DIFF
--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -21,6 +21,7 @@ import {
   resolveOsBlock,
   resolveSnipIds,
   resolveRoleSnipIds,
+  resolveEtreeSnipIds,
   attributeOptions,
   vlanModes,
   collectVariables,
@@ -370,6 +371,10 @@ export default function ConfigGenerator() {
   const [count, setCount] = useState(1);
   const [siteCount, setSiteCount] = useState(2);
   const [pwCount, setPwCount] = useState(1);
+  // E-Tree: the root is single-homed (1 root PE) or multihomed (a 2-node
+  // all-active ESI pair); `leafCount` fans out single-homed leaf PEs.
+  const [rootMultihomed, setRootMultihomed] = useState(true);
+  const [leafCount, setLeafCount] = useState(2);
   // EVPN-FXC per-UNI VLAN entry list (+ a stable id for React keys) and the
   // VLAN-aware map toggle (matching vlan-id vs input/output vlan-map).
   const [fxcEntries, setFxcEntries] = useState<(FxcEntry & { id: number })[]>([]);
@@ -388,13 +393,18 @@ export default function ConfigGenerator() {
   const multiSite = !!deployment?.multiSite;
   // BGP-VPLS: site-range + label-block-size must scale to the number of sites.
   const isVpls = !!deployment?.id?.includes("vpls");
+  // E-Tree (rooted-multipoint): one EVI split into a Root PE + N Leaf PEs.
+  const isEtree = !!deployment?.etree;
 
   // Role-based families (PWHT) render one config per fixed role (Access /
   // Headend) instead of the symmetric PE-A / PE-B model.
   const roleBased = !!family?.roleBased;
   const roles = family?.roles ?? [];
+  // Asymmetric two-pane deployments (PWHT roles, E-Tree root/leaf): each pane's
+  // fields + defaults come from its OWN snips, not a symmetric bump/mirror.
+  const asym = roleBased || isEtree;
 
-  const twoPe = sel.osB && sel.osB !== "none";
+  const twoPe = isEtree || (!!sel.osB && sel.osB !== "none");
 
   const osBlockA =
     sel.familyId && sel.muxId && sel.deploymentId && sel.osA
@@ -411,7 +421,7 @@ export default function ConfigGenerator() {
           familyId: sel.familyId,
           muxId: sel.muxId,
           deploymentId: sel.deploymentId,
-          os: sel.osB as GenOsKey,
+          os: (isEtree ? sel.osA : sel.osB) as GenOsKey,
         })
       : null;
 
@@ -483,7 +493,7 @@ export default function ConfigGenerator() {
   const attrsComplete = roleBased
     ? true
     : Boolean(
-        sel.homing && (modeOpts.length === 0 || vlanMode) && (!sel.firewall || sel.color),
+        (sel.homing || isEtree) && (modeOpts.length === 0 || vlanMode) && (!sel.firewall || sel.color),
       );
   const steps = roleBased ? STEPS_ROLE : STEPS;
   const currentStep = steps[Math.min(step, steps.length - 1)];
@@ -494,7 +504,7 @@ export default function ConfigGenerator() {
           sel.muxId &&
           sel.deploymentId &&
           sel.osA &&
-          sel.homing &&
+          (sel.homing || isEtree) &&
           (modeOpts.length === 0 || vlanMode) &&
           (!sel.firewall || sel.color),
       );
@@ -545,16 +555,36 @@ export default function ConfigGenerator() {
           ...(sel.cos ? r.cosSnips ?? [] : []),
         ]);
       }
+      if (isEtree)
+        return complete && sel.osA && osBlockA
+          ? resolveEtreeSnipIds(CATALOG, osBlockA, sel.osA as GenOsKey, "root", {
+              rootMultihomed,
+              rtPolicy,
+              firewall: sel.firewall,
+              color: sel.color ?? "",
+              cos: sel.cos,
+            })
+          : [];
       return complete && sel.osA ? resolveSnipIds(CATALOG, selFor(sel.osA)) : [];
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [complete, sel, roleBased, count, pwColorComm],
+    [complete, sel, roleBased, count, pwColorComm, rootMultihomed],
   );
   const idsB = useMemo(
     () => {
       if (roleBased)
         return roles[1]
           ? resolveRoleSnipIds(CATALOG, roles[1], { cos: sel.cos, firewall: false })
+          : [];
+      if (isEtree)
+        return complete && sel.osA && osBlockB
+          ? resolveEtreeSnipIds(CATALOG, osBlockB, sel.osA as GenOsKey, "leaf", {
+              rootMultihomed,
+              rtPolicy,
+              firewall: sel.firewall,
+              color: sel.color ?? "",
+              cos: sel.cos,
+            })
           : [];
       return complete && twoPe ? resolveSnipIds(CATALOG, selFor(sel.osB as GenOsKey)) : [];
     },
@@ -602,10 +632,10 @@ export default function ConfigGenerator() {
     () => new Set(collectVariables(idsB, byId).map((v) => v.name.replace(/^\$/, ""))),
     [idsB, byId],
   );
-  const perFieldsA = roleBased
+  const perFieldsA = asym
     ? perFields.filter((v) => varsInA.has(v.name.replace(/^\$/, "")))
     : perFields;
-  const perFieldsB = roleBased
+  const perFieldsB = asym
     ? perFields.filter((v) => varsInB.has(v.name.replace(/^\$/, "")))
     : perFields;
 
@@ -619,6 +649,7 @@ export default function ConfigGenerator() {
     vlanMode,
     rtPolicy,
     sel.pwColor,
+    rootMultihomed,
     count > 1,
     sel.color,
     sel.cos,
@@ -628,9 +659,10 @@ export default function ConfigGenerator() {
     const sh: Record<string, string> = {};
     const a: Record<string, string> = {};
     const b: Record<string, string> = {};
-    if (roleBased) {
-      // Asymmetric roles: each side's default comes from ITS OWN snips (access
-      // AC_INTF = et-0/0/12, headend AC_INTF = ae10; no distinct-bump/mirror).
+    if (asym) {
+      // Asymmetric panes: each side's default comes from ITS OWN snips (access
+      // AC_INTF = et-0/0/12, headend ae10; E-Tree root ae10, leaf xe-0/1/5;
+      // no distinct-bump/mirror).
       const exA = new Map(
         collectVariables(idsA, byId).map((v) => [v.name.replace(/^\$/, ""), v.example]),
       );
@@ -865,6 +897,8 @@ export default function ConfigGenerator() {
     setCount(1);
     setSiteCount(2);
     setPwCount(1);
+    setRootMultihomed(true);
+    setLeafCount(2);
     setFxcEntries([]);
     setStep(0);
   };
@@ -881,6 +915,50 @@ export default function ConfigGenerator() {
 
   const download = () => {
     if (!fullText) return;
+    // E-Tree (rooted-multipoint): ONE EVI = root PE(s) + N leaf PEs. A multihomed
+    // root is an all-active ESI PAIR (2 root PEs that SHARE one ESI — so the ESI
+    // is constant, only the route-distinguisher differs). Leaves are single-homed;
+    // `leafCount` fans them out. Every node is a separate device, merged on its
+    // own; the RD bumps per node (roots from the root pane's RD, leaves from the
+    // leaf pane's).
+    if (isEtree) {
+      const os = sel.osA as GenOsKey;
+      const roots = rootMultihomed ? 2 : 1;
+      const leaves = Math.max(1, Math.min(leafCount, 64));
+      const rootBase = endpointValues(names, ROLES, shared, perA, perB);
+      const leafBase = endpointValues(names, ROLES, shared, perB, perA);
+      const sects: string[] = [];
+      const opts = {
+        stripUniFilter: !sel.firewall,
+        stripVrfExport: rtPolicy === "rt-only",
+        derived: CATALOG.derivedVars,
+      };
+      for (let r = 0; r < roots; r++) {
+        if (!idsA.length) break;
+        // Roots share the ESI (all-active pair) — bump only the RD.
+        const vals = { ...rootBase, RD: bumpInt(rootBase.RD ?? "", r) };
+        const body = renderConfig(idsA, vals, byId, opts).text;
+        const label = roots > 1 ? `Root ${r + 1}` : "Root";
+        sects.push(`/* ===== ${label} \u00b7 ${OS_LABELS[os]} ===== */\n${mergeJunosConfig(body)}`);
+      }
+      for (let l = 0; l < leaves; l++) {
+        if (!idsB.length) break;
+        const vals = { ...leafBase, RD: bumpInt(leafBase.RD ?? "", l) };
+        const body = renderConfig(idsB, vals, byId, opts).text;
+        const label = leaves > 1 ? `Leaf ${l + 1}` : "Leaf";
+        sects.push(`/* ===== ${label} \u00b7 ${OS_LABELS[os]} ===== */\n${mergeJunosConfig(body)}`);
+      }
+      const text = sects.join("\n\n") + "\n";
+      const fname = `maas-e-tree-evpn-etree-${roots}root-${leaves}leaf.conf`;
+      const blob = new Blob([text], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fname;
+      a.click();
+      URL.revokeObjectURL(url);
+      return;
+    }
     // Multipoint EVI (EVPN-ELAN / BGP-VPLS): a 2-D fan-out — `count` independent
     // instances (EVIs / VPLS domains) × `siteCount` self-contained PE sites per
     // instance. Each site is a DIFFERENT device, merged on its own (never across
@@ -1038,8 +1116,8 @@ export default function ConfigGenerator() {
     os ? `${tag} · ${OS_LABELS[os]}` : tag;
   // Endpoint column / section tags — role names for PWHT, per-site labels for
   // multipoint EVIs, PE-A/PE-B otherwise.
-  const tagA = roleBased ? roles[0]?.label ?? "Access" : multiSite ? "Site A" : "PE-A";
-  const tagB = roleBased ? roles[1]?.label ?? "Headend" : multiSite ? "Site B" : "PE-B";
+  const tagA = roleBased ? roles[0]?.label ?? "Access" : isEtree ? "Root" : multiSite ? "Site A" : "PE-A";
+  const tagB = roleBased ? roles[1]?.label ?? "Headend" : isEtree ? "Leaf" : multiSite ? "Site B" : "PE-B";
 
   return (
     <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_minmax(22rem,34rem)]">
@@ -1311,13 +1389,9 @@ export default function ConfigGenerator() {
 
           {currentStep === "attributes" && !roleBased && osBlockA && (
             <div className="space-y-4">
-              {!multiUni && (
+              {!multiUni && !isEtree && (
                 <div>
-                  <div className="mb-2 text-xs font-medium text-foreground">
-                    {homingOpts.includes("root") || homingOpts.includes("leaf")
-                      ? "AC role"
-                      : "Homing"}
-                  </div>
+                  <div className="mb-2 text-xs font-medium text-foreground">Homing</div>
                   <div className="space-y-2">
                     {homingOpts.map((h) => (
                       <Chip
@@ -1327,6 +1401,25 @@ export default function ConfigGenerator() {
                         onClick={() => setSel((p) => ({ ...p, homing: h }))}
                       />
                     ))}
+                  </div>
+                </div>
+              )}
+              {isEtree && (
+                <div>
+                  <div className="mb-2 text-xs font-medium text-foreground">Root redundancy</div>
+                  <div className="space-y-2">
+                    <Chip
+                      label="Multihomed root"
+                      sub="Two root PEs sharing one all-active ESI"
+                      active={rootMultihomed}
+                      onClick={() => setRootMultihomed(true)}
+                    />
+                    <Chip
+                      label="Single-homed root"
+                      sub="One root PE (no ESI)"
+                      active={!rootMultihomed}
+                      onClick={() => setRootMultihomed(false)}
+                    />
                   </div>
                 </div>
               )}
@@ -1617,6 +1710,34 @@ export default function ConfigGenerator() {
                         : "Each VLAN is a multihomed AC matched end-to-end (no vlan-map); ESI + vpws-service-id increment per UNI."}
                   </span>
                 </div>
+              ) : isEtree ? (
+                <div className="space-y-2 rounded-md border border-border bg-background p-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <label className="text-xs font-medium text-foreground">
+                      Number of leaves
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={64}
+                      value={leafCount}
+                      onChange={(e) =>
+                        setLeafCount(Math.max(1, Math.min(64, Number(e.target.value) || 1)))
+                      }
+                      className="h-8 w-20 rounded-md border border-border bg-surface px-2 font-mono text-sm text-foreground focus:border-primary/60 focus:outline-none"
+                    />
+                    <span className="text-[11px] font-medium text-primary">
+                      {rootMultihomed ? 2 : 1} root{rootMultihomed ? "s" : ""} + {leafCount} lea
+                      {leafCount === 1 ? "f" : "ves"}
+                    </span>
+                  </div>
+                  <span className="block text-[11px] text-muted-foreground">
+                    One EVPN E-Tree EVI. The preview shows a Root PE + a Leaf PE;
+                    the download emits {rootMultihomed ? "both roots (all-active ESI pair)" : "the root"}{" "}
+                    plus every leaf, each its own PE section with a unique
+                    route-distinguisher.
+                  </span>
+                </div>
               ) : multiSite ? (
                 <div className="space-y-2 rounded-md border border-border bg-background p-3">
                   <div className="flex flex-wrap items-center gap-4">
@@ -1742,7 +1863,7 @@ export default function ConfigGenerator() {
                 {twoPe && (
                   <div>
                     <div className="mb-2 text-xs font-medium text-foreground">
-                      {peLabel(sel.osB as GenOsKey, tagB)}
+                      {peLabel((isEtree ? sel.osA : sel.osB) as GenOsKey, tagB)}
                     </div>
                     <div className="space-y-3">
                       {perFieldsB.map((v) => {
@@ -1821,7 +1942,7 @@ export default function ConfigGenerator() {
               {renderB && (
                 <div className="mt-4">
                   <div className="mb-1 text-[11px] font-semibold text-primary">
-                    # {peLabel(sel.osB as GenOsKey, tagB)}
+                    # {peLabel((isEtree ? sel.osA : sel.osB) as GenOsKey, tagB)}
                   </div>
                   <pre className="max-h-[24rem] overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-relaxed text-foreground">
                     {mergedB}

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -139,6 +139,8 @@ const JVDS = [
 const HOMING_LABELS: Record<string, string> = {
   "single-homed": "Single-homed",
   multihomed: "Multihomed (all-active ESI)",
+  root: "Root (multihomed)",
+  leaf: "Leaf (single-homed)",
 };
 const COLOR_LABELS: Record<string, string> = {
   "color-blind": "Color-blind",
@@ -1311,7 +1313,11 @@ export default function ConfigGenerator() {
             <div className="space-y-4">
               {!multiUni && (
                 <div>
-                  <div className="mb-2 text-xs font-medium text-foreground">Homing</div>
+                  <div className="mb-2 text-xs font-medium text-foreground">
+                    {homingOpts.includes("root") || homingOpts.includes("leaf")
+                      ? "AC role"
+                      : "Homing"}
+                  </div>
                   <div className="space-y-2">
                     {homingOpts.map((h) => (
                       <Chip

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -466,10 +466,39 @@
     {
       "id": "e-tree",
       "label": "E-Tree",
-      "tagline": "Rooted-multipoint",
+      "tagline": "Rooted-Multipoint",
       "description": "Leaf sites talk only to root sites, never to each other (MEF EP-Tree / EVP-Tree).",
-      "available": false,
-      "multiplexing": []
+      "available": true,
+      "multiplexing": [
+        {
+          "id": "evp-tree",
+          "label": "EVP-Tree (VLAN-based)",
+          "description": "Specific customer VLAN(s) form the rooted-multipoint tree; leaves reach only roots, never each other.",
+          "deployments": [
+            {
+              "id": "evpn-etree",
+              "label": "EVPN E-Tree (VLAN-based)",
+              "description": "EVPN rooted-multipoint; each AC is a root or a leaf (evpn-etree + etree-ac-role). MX / Junos.",
+              "multiSite": true,
+              "siteVars": ["RD", "ESI_ID"],
+              "os": {
+                "junos": {
+                  "service": ["junos/services/evpn-etree-vlan-based"],
+                  "interface": {
+                    "root": "junos/interfaces/vlan-bridge-esi-etree-root",
+                    "leaf": "junos/interfaces/vlan-bridge-etree-leaf"
+                  },
+                  "interfaceExtras": [],
+                  "filter": {
+                    "color-blind": "junos/firewall/filter-bridge-color-blind",
+                    "color-aware": "junos/firewall/filter-bridge-color-aware"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "id": "e-access",

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -479,15 +479,16 @@
               "id": "evpn-etree",
               "label": "EVPN E-Tree (VLAN-based)",
               "description": "EVPN rooted-multipoint; each AC is a root or a leaf (evpn-etree + etree-ac-role). MX / Junos.",
-              "multiSite": true,
-              "siteVars": ["RD", "ESI_ID"],
+              "etree": true,
               "os": {
                 "junos": {
                   "service": ["junos/services/evpn-etree-vlan-based"],
-                  "interface": {
-                    "root": "junos/interfaces/vlan-bridge-esi-etree-root",
-                    "leaf": "junos/interfaces/vlan-bridge-etree-leaf"
+                  "interface": { "leaf": "junos/interfaces/vlan-bridge-etree-leaf" },
+                  "rootInterface": {
+                    "single-homed": "junos/interfaces/vlan-bridge-etree-root",
+                    "multihomed": "junos/interfaces/vlan-bridge-esi-etree-root"
                   },
+                  "leafInterface": "junos/interfaces/vlan-bridge-etree-leaf",
                   "interfaceExtras": [],
                   "filter": {
                     "color-blind": "junos/firewall/filter-bridge-color-blind",

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-07-08T02:44:10.755Z",
+  "generatedAt": "2026-07-08T03:35:02.758Z",
   "counts": {
-    "total": 533,
-    "junos": 255,
+    "total": 534,
+    "junos": 256,
     "evo": 278,
     "jvds": 9
   },
@@ -123,9 +123,9 @@
       "area": "Service Provider",
       "repoPath": "service_provider/metro_as_a_service",
       "counts": {
-        "junos": 57,
+        "junos": 58,
         "evo": 73,
-        "total": 130
+        "total": 131
       }
     },
     {
@@ -27805,6 +27805,83 @@
       "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    flexible-vlan-tagging;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    mtu $MTU;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    encapsulation flexible-ethernet-services;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        etree-ac-role leaf;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
       "bytes": 324,
       "lineCount": 15,
+      "techFamily": "Interfaces",
+      "subfamily": "Interfaces",
+      "usecases": [
+        "Service Provider",
+        "Metro",
+        "Business Services",
+        "MEF"
+      ],
+      "parseWarnings": []
+    },
+    {
+      "id": "metro_as_a_service/junos/interfaces/vlan-bridge-etree-root",
+      "jvd": "metro_as_a_service",
+      "jvdLabel": "Metro as a Service",
+      "area": "Service Provider",
+      "os": "Junos",
+      "osKey": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-etree-root",
+      "path": "service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-root.conf",
+      "topic": "Interface: vlan bridge etree root (MEF E-Tree / EVP-Tree)",
+      "seenOn": {
+        "junos": [
+          "MSE1"
+        ],
+        "evo": []
+      },
+      "highlights": [
+        "encapsulation vlan-bridge",
+        "etree-ac-role root (single-homed — no ESI)"
+      ],
+      "pairWith": [
+        {
+          "raw": "junos/cos/classifiers.conf",
+          "id": "metro_as_a_service/junos/cos/classifiers",
+          "note": null
+        },
+        {
+          "raw": "junos/cos/cos-binding-ieee8021p.conf",
+          "id": "metro_as_a_service/junos/cos/cos-binding-ieee8021p",
+          "note": null
+        },
+        {
+          "raw": "junos/cos/rewrite-rules.conf",
+          "id": "metro_as_a_service/junos/cos/rewrite-rules",
+          "note": null
+        },
+        {
+          "raw": "junos/firewall/filter-bridge-color-blind.conf",
+          "id": "metro_as_a_service/junos/firewall/filter-bridge-color-blind",
+          "note": null
+        },
+        {
+          "raw": "junos/services/evpn-etree-vlan-based.conf",
+          "id": "metro_as_a_service/junos/services/evpn-etree-vlan-based",
+          "note": null
+        }
+      ],
+      "variables": [
+        {
+          "name": "$AC_INTF",
+          "example": "ae10"
+        },
+        {
+          "name": "$UNIT",
+          "example": "4080"
+        },
+        {
+          "name": "$VLAN",
+          "example": "4080"
+        }
+      ],
+      "jvdServiceMapping": [],
+      "body": "$AC_INTF {\n    unit $UNIT {\n        encapsulation vlan-bridge;\n        vlan-id $VLAN;\n        family bridge {\n            filter {\n                input f_vlan_based_fam_bridge;\n            }\n        }\n        etree-ac-role root;\n    }\n}",
+      "bodyHtml": "<pre class=\"shiki github-dark-default\" style=\"background-color:#0d1117;color:#e6edf3\" tabindex=\"0\"><code><span class=\"line\"><span style=\"color:#E6EDF3\">$AC_INTF {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    unit $UNIT {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        encapsulation vlan-bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        vlan-id $VLAN;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        family bridge {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            filter {</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">                input f_vlan_based_fam_bridge;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">            }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">        etree-ac-role root;</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">    }</span></span>\n<span class=\"line\"><span style=\"color:#E6EDF3\">}</span></span></code></pre>",
+      "bytes": 237,
+      "lineCount": 12,
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-08T01:56:40.190Z",
+  "generatedAt": "2026-07-08T02:44:10.755Z",
   "counts": {
     "total": 533,
     "junos": 255,

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -35,6 +35,11 @@ export type GenOsBlock = {
    *  uses this so single-homed = VLAN-unaware and multihomed = VLAN-aware. */
   serviceByHoming?: Record<string, string[]>;
   interface: Record<string, string>; // homing key -> snip id (relative to jvd)
+  /** E-Tree root AC interface, keyed by homing (single-homed root = 1 root PE,
+   *  multihomed root = an all-active ESI pair of 2 root PEs). */
+  rootInterface?: Record<string, string>;
+  /** E-Tree leaf AC interface (leaves are single-homed; there can be many). */
+  leafInterface?: string;
   interfaceExtras: string[];
   filter: Record<string, string>; // color key -> snip id (relative to jvd)
   uni?: { modes: UniMode[] };
@@ -66,6 +71,11 @@ export type GenDeployment = {
   /** Variables that increment per site (route-distinguisher — must be unique
    *  per PE — plus the local ESI). Everything else is constant across sites. */
   siteVars?: string[];
+  /** E-Tree (rooted-multipoint): one EVI split into root vs leaf ACs. The
+   *  wizard shows a Root PE + a Leaf PE; a "multihomed root" toggle makes the
+   *  root a 2-node all-active ESI pair; a "leaves" count fans out leaf PEs.
+   *  Roots share one ESI; only the route-distinguisher is unique per node. */
+  etree?: boolean;
   os: Partial<Record<GenOsKey, GenOsBlock>>;
 };
 
@@ -601,6 +611,51 @@ export function resolveSnipIds(catalog: GenCatalog, sel: GenSelection): string[]
     rel.push(...(osb.cosSnips ?? catalog.cosSnips[sel.os] ?? []));
   }
   // De-dupe while preserving order, then qualify with the jvd prefix.
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rel) {
+    const qualified = `${catalog.jvd}/${r}`;
+    if (!seen.has(qualified)) {
+      seen.add(qualified);
+      out.push(qualified);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the ordered jvd-qualified snip ids for one E-Tree AC role. The
+ * service snip is shared by roots and leaves (`evpn-etree`); only the interface
+ * differs — a root uses `rootInterface[single-homed|multihomed]` (multihomed =
+ * the 2-node ESI pair), a leaf uses the single `leafInterface`. Order matches
+ * `resolveSnipIds`: service → (colored) route-policy → interface → extras →
+ * (firewall) filter → (cos) cos.
+ */
+export function resolveEtreeSnipIds(
+  catalog: GenCatalog,
+  osb: GenOsBlock,
+  os: GenOsKey,
+  role: "root" | "leaf",
+  opts: { rootMultihomed: boolean; rtPolicy?: string; firewall: boolean; color: string; cos: boolean },
+): string[] {
+  const rel: string[] = [...osb.service];
+  if (opts.rtPolicy && opts.rtPolicy !== "rt-only") {
+    const pol = catalog.routePolicySnips?.[os]?.[opts.rtPolicy];
+    if (pol) rel.push(pol);
+  }
+  const iface =
+    role === "root"
+      ? osb.rootInterface?.[opts.rootMultihomed ? "multihomed" : "single-homed"]
+      : osb.leafInterface;
+  if (iface) rel.push(iface);
+  rel.push(...osb.interfaceExtras);
+  if (opts.firewall) {
+    const filter = osb.filter[opts.color];
+    if (filter) rel.push(filter);
+  }
+  if (opts.cos) {
+    rel.push(...(osb.cosSnips ?? catalog.cosSnips[os] ?? []));
+  }
   const seen = new Set<string>();
   const out: string[] = [];
   for (const r of rel) {

--- a/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-root.conf
+++ b/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-root.conf
@@ -1,0 +1,34 @@
+/*
+ * Topic:   Interface: vlan bridge etree root (MEF E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)   [single-homed variant of the MH root]
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - etree-ac-role root (single-homed — no ESI)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-blind.conf
+ *   - junos/services/evpn-etree-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae10
+ *   $UNIT     e.g. 4080
+ *   $VLAN     e.g. 4080
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        family bridge {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+        etree-ac-role root;
+    }
+}


### PR DESCRIPTION
## What's New
E-Tree (rooted-multipoint) joins the Config Generator — the MEF E-Tree family is now clickable end-to-end.

- **EVPN E-Tree (VLAN-based)** on MX / Junos — one EVI split into **root** and **leaf** ACs (`evpn-etree` + `etree-ac-role`)
- **Root redundancy** toggle — a *multihomed root* is a two-node all-active ESI pair; a *single-homed root* is one root PE
- **Number of leaves** — fan out N single-homed leaf PEs
- The preview shows a **Root PE + a Leaf PE** together; the download emits the whole tree (root(s) + every leaf), each PE its own section with a unique route-distinguisher

## Why
Root vs leaf is an AC-level role that's **independent of homing** — a setup has roots *and* leaves, a multihomed setup means the *root* is a 2-node ESI pair, and either setup can have many leaves. Modelling it as one root+leaf view (rather than tying role to homing) matches how the service is actually deployed.

## Details
- **Catalog** (`metro_as_a_service.json`): E-Tree family set `available`, mux `evp-tree`, deployment `evpn-etree` with a new `etree` flag + `rootInterface` (single-homed / multihomed) and `leafInterface`.
- **Generator** (`generator.ts`): `resolveEtreeSnipIds()` (shared service snip, role-specific interface, colored route-policy tier) + `GenOsBlock.rootInterface`/`leafInterface` + `GenDeployment.etree`.
- **Wizard** (`ConfigGenerator.tsx`): reuses the two-pane engine as Root + Leaf via an asymmetric-panes path (each pane's fields/defaults come from its own snips, like PWHT). A "Root redundancy" toggle replaces the homing selector; a "Number of leaves" control drives the fan-out. The download emits roots (sharing one ESI, RD bumped per node) plus leaves (RD bumped per node).
- **Snip**: added `junos/interfaces/vlan-bridge-etree-root` (single-homed root) — a clean ESI-less variant of the captured multihomed root, since the JVD source only captured multihomed roots. The service, multihomed-root and leaf snips already existed.

## Testing
- Root (multihomed + single-homed) and leaf rendered through the full `resolveEtreeSnipIds → renderConfig → mergeJunosConfig` path (Node) — all `missing: []`, output matches the source `etree_evp-tree_evpn-etree.conf` per device (MSE1 root, MA4 leaf).
- `bun run build` clean; no type/lint errors.

## Notes
- `snips.json` is build-generated (`node portal/scripts/generate-snips.mjs`), not hand-edited.
- The gold export tier emits the snip-defined `CM-TC-MAP2GOLD` community rather than the source's `map2gold` (which the JSON base config defines elsewhere) — functionally the same gold color, and self-contained.
