### PR TITLE
feat(portal): Discover → Learn → Design → Build redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ Release notes for the Juniper Validated Design (JVD) configuration repository.
 
 ---
 
+## 2026-07-08
+
+The Metro-as-a-Service (MaaS) JVD gains a validated configuration snip
+library, and the JVD portal adds two ways to turn those designs into
+config: a deterministic Config Generator and an AI-assisted design
+workflow. The portal is reorganized into a four-step path — Discover,
+Learn, Design, Build.
+
+### New content
+
+- **Metro-as-a-Service snip library** — a validated library of Junos and
+  Junos EVO configuration snippets in
+  [`service_provider/metro_as_a_service/configuration/snips/`](service_provider/metro_as_a_service/configuration/snips/).
+  Covers the MEF Carrier Ethernet service families: E-Line (EVPN-VPWS,
+  L2VPN, BGP-VPLS, EVPN-FXC), E-LAN (EVPN-ELAN VLAN-based, VLAN-bundle and
+  port-based, BGP-VPLS), E-Tree (EVPN E-Tree), and Pseudowire Headend
+  Termination. Validated across ACX7024/ACX7100/ACX7509 (EVO), MX204/MX304
+  (Junos), and PTX10001-36MR. Each snip carries source provenance, a
+  variable glossary, and pair-with references.
+
+### Portal
+
+- **Config Generator** — a deterministic builder that renders
+  download-ready Junos / Junos EVO service configuration from the validated
+  snip library. Metro-as-a-Service E-Line, E-LAN, E-Tree, EVPN-FXC, and
+  PWHT are available, with per-service options for homing, VLAN handling,
+  route-target export, and class-of-service.
+- **Design & Planner (Bring Your Own AI)** — a conversation-driven workflow
+  that pairs the AI you already use with a JVD's validated snip library to
+  plan a design and build configuration.
+- **New layout** — the portal is organized as Discover (JVD Catalog), Learn
+  (Config Explorer), Design (Design & Planner), and Build (Service
+  Configuration Generator), with links between each step.
+
+### What this means for you
+
+- Pull the latest `main` to get the Metro-as-a-Service snip library and the
+  updated portal.
+- If you are building a Metro Carrier Ethernet service, start from the
+  Config Generator or the snip library instead of writing configuration
+  from scratch.
+- Use the Design & Planner when you want design and scaling guidance
+  grounded in a validated design.
+
+---
+
+### By the numbers
+
+<details>
+<summary>Per-area changes</summary>
+
+| Area | Added | Modified | Files | Lines added |
+| --- | ---: | ---: | ---: | ---: |
+| `service_provider/metro_as_a_service` (snip library) | 35 | 12 | 47 | 13,224 |
+| `portal` (Config Generator, Design & Planner, layout) | 13 | 5 | 18 | 17,842 |
+| `Documentation` | 1 | 0 | 1 | 51 |
+| **Total** | **49** | **17** | **66** | **31,117** |
+
+</details>
+
+<details>
+<summary>Net lines added/removed by area</summary>
+
+| Area | Lines added | Lines removed | Net |
+| --- | ---: | ---: | ---: |
+| service_provider/metro_as_a_service | 13,224 | 75 | +13,149 |
+| portal | 17,842 | 597 | +17,245 |
+| Documentation | 51 | 0 | +51 |
+| **Total** | **31,117** | **672** | **+30,445** |
+
+</details>
+
+---
+
 ## 2026-06-26
 
 README standardization across all 20 JVDs, plus the new AI Data Center

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,51 @@
+# JVD Documentation (markdown corpus)
+
+This folder holds the **markdown conversion of the Juniper Validated Design
+guides** — the design narrative behind each JVD: topology, platform matrix,
+scale ceilings, service catalog, design rationale, and validation results.
+
+## Why it exists
+
+The portal's **Design & Planner** (the BYOAI surface) answers design and
+planning questions — *"which JVD fits my requirements," "will it scale," "how do
+I adapt design X."* Those answers must be **grounded in the validated designs**,
+not improvised. This corpus is that ground truth: the AI is pointed at the
+markdown here (plus the per-JVD snip libraries) and cites it.
+
+Source of truth remains the published guides on
+[juniper.net](https://www.juniper.net/documentation/validated-designs/); the
+markdown here is a faithful, diffable, machine-readable mirror.
+
+## Layout
+
+Mirrors the repository's JVD paths so a JVD's docs sit next to its configs and
+snips conceptually:
+
+```
+Documentation/
+  <area>/<jvd>/
+    overview.md         # what the design is + when to use it
+    topology.md         # roles, platforms, physical/logical topology
+    services.md         # the service catalog the design validates
+    scale.md            # tested scale ceilings + caveats
+    validation.md       # what was tested and the results
+```
+
+Example: `Documentation/service_provider/metro_as_a_service/overview.md`.
+
+## Status — pilot first
+
+Converting the whole JVD library is a sustained content effort, so it is being
+proven on **one JVD before scaling**:
+
+1. **Pilot — Metro-as-a-Service (MaaS):** convert the guide, wire the Design &
+   Planner to read it, validate the design-QA value.
+2. **Scale:** Metro Ethernet Business Services (MEBS) next, then the rest.
+
+## Notes
+
+- Public repo: the source guides are already public on juniper.net, so this
+  content is not sensitive. It is simply not linked from the portal nav
+  (unlisted) to keep the site focused on the four tool surfaces.
+- Keep entries faithful to the published guide — do not invent scale numbers or
+  design claims. When unsure, link back to the source guide instead.

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -101,7 +101,8 @@ export default function ByoaiSection() {
               </span>
             </div>
             <p className="mt-3 max-w-2xl text-sm text-muted-foreground">
-              Plan and design with the AI you already use, grounded in the Juniper
+              <span className="font-medium text-foreground">Bring Your Own AI (BYOAI)</span> —
+              plan and design with the AI you already use, grounded in the Juniper
               Validated Designs. Pick a JVD, launch Claude or ChatGPT, and the
               assistant works from that JVD&apos;s validated snip library — and,
               increasingly, its full design documentation — to answer design and

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Sparkles, ExternalLink, Github, Info } from "lucide-react";
 import jvds from "@/data/jvds.json";
 import { snipBundle } from "@/lib/snips";
@@ -62,6 +62,21 @@ export default function ByoaiSection() {
 
   const [selectedId, setSelectedId] = useState<string>(pickerItems[0]?.id ?? "");
   const selected = pickerItems.find((p) => p.id === selectedId) ?? pickerItems[0];
+
+  // Deep link: "#byoai?jvd=<id>" from the Catalog pre-selects that JVD here.
+  useEffect(() => {
+    const applyHash = () => {
+      const h = window.location.hash;
+      if (!h.startsWith("#byoai")) return;
+      const qIdx = h.indexOf("?");
+      if (qIdx < 0) return;
+      const jvd = new URLSearchParams(h.slice(qIdx + 1)).get("jvd");
+      if (jvd && pickerItems.some((p) => p.id === jvd)) setSelectedId(jvd);
+    };
+    applyHash();
+    window.addEventListener("hashchange", applyHash);
+    return () => window.removeEventListener("hashchange", applyHash);
+  }, [pickerItems]);
 
   const claudeUrl = selected ? buildClaudeUrl(selected.promptUrl) : "#";
   const chatGptUrl = selected ? buildChatGptUrl(selected.promptUrl) : "#";

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -72,9 +72,12 @@ export default function ByoaiSection() {
         {/* Header */}
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <div className="flex items-center gap-2">
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
+              Step 3 · Design
+            </div>
+            <div className="mt-1 flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-primary" />
-              <h2 className="text-3xl font-semibold tracking-tight">Bring Your Own AI</h2>
+              <h2 className="text-3xl font-semibold tracking-tight">Design &amp; Planner</h2>
               <span className="ml-1 inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
                 Available now
               </span>
@@ -83,9 +86,11 @@ export default function ByoaiSection() {
               </span>
             </div>
             <p className="mt-3 max-w-2xl text-sm text-muted-foreground">
-              Generate Junos and Junos EVO configuration with the AI you already use. Pick a JVD,
-              launch Claude or ChatGPT, and the assistant will fetch that JVD&apos;s validated snip
-              library and walk you through a conversation-driven config build.
+              Plan and design with the AI you already use, grounded in the Juniper
+              Validated Designs. Pick a JVD, launch Claude or ChatGPT, and the
+              assistant works from that JVD&apos;s validated snip library — and,
+              increasingly, its full design documentation — to answer design and
+              scaling questions and walk you through a conversation-driven config build.
             </p>
           </div>
         </div>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -123,6 +123,79 @@ function MarqueeTag({ label }: { label: string }) {
   );
 }
 
+function JvdCard({ j, className = "" }: { j: Jvd; className?: string }) {
+  const families = Array.from(new Set(j.platforms.map(familyOf))).filter(Boolean);
+  const steps: StepPill[] = [];
+  if (SNIP_JVD_IDS.has(j.id))
+    steps.push({ href: `#snips?jvd=${j.id}`, label: "Learn", Icon: Layers });
+  if (BYOAI_JVD_IDS.has(j.id))
+    steps.push({ href: `#byoai?jvd=${j.id}`, label: "Design", Icon: Sparkles });
+  if (BUILD_JVD_IDS.has(j.id))
+    steps.push({ href: `#generator?jvd=${j.id}`, label: "Build", Icon: Wrench });
+  return (
+    <article
+      className={
+        "group flex flex-col rounded-lg border border-border bg-surface p-6 transition-colors hover:border-primary/50 " +
+        className
+      }
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-[11px] font-medium text-primary">
+          {j.area}
+        </span>
+        {steps.length > 0 && (
+          <div className="flex flex-wrap items-center justify-end gap-1.5">
+            {steps.map(({ href, label, Icon }) => (
+              <a
+                key={label}
+                href={href}
+                className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:text-primary"
+                title={`${label} this JVD`}
+              >
+                <Icon className="h-3 w-3" /> {label}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+      <h3 className="mt-4 text-base font-semibold leading-snug">{j.name}</h3>
+      <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">
+        {j.description || "Reference architecture and validated configuration."}
+      </p>
+      {(families.length > 0 || j.os.length > 0) && (
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {families.map((p) => (
+            <span
+              key={p}
+              className="rounded border border-transparent bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium text-foreground/80"
+            >
+              {p}
+            </span>
+          ))}
+          {j.os.map((o) => (
+            <span
+              key={o}
+              className="rounded border border-border bg-transparent px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+            >
+              {o}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-6 flex-1" />
+      <a
+        href={`${REPO_BASE}${j.repoPath}`}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center justify-between rounded-md border border-border bg-background px-4 py-2 text-sm font-medium transition-colors group-hover:border-primary/60 group-hover:text-primary"
+      >
+        View JVD
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </article>
+  );
+}
+
 export default function JvdPortal() {
   const data = jvds as Jvd[];
   const [areaF, setAreaF] = useState<string | null>(null);
@@ -327,7 +400,9 @@ export default function JvdPortal() {
               </p>
             </div>
             <div className="text-sm text-muted-foreground">
-              Showing {filtered.length} of {data.length}
+              {areaF || platformF || osF
+                ? `Showing ${filtered.length} of ${data.length}`
+                : `${data.length} designs · hover to pause, filter to expand`}
             </div>
           </div>
 
@@ -337,83 +412,26 @@ export default function JvdPortal() {
             <FilterRow label="OS" options={OS_OPTIONS} value={osF} onChange={setOsF} />
           </div>
 
-          <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {filtered.map((j) => {
-              const families = Array.from(new Set(j.platforms.map(familyOf))).filter(Boolean);
-              const hasSnips = SNIP_JVD_IDS.has(j.id);
-              const steps: StepPill[] = [];
-              if (hasSnips)
-                steps.push({ href: `#snips?jvd=${j.id}`, label: "Learn", Icon: Layers });
-              if (BYOAI_JVD_IDS.has(j.id))
-                steps.push({ href: `#byoai?jvd=${j.id}`, label: "Design", Icon: Sparkles });
-              if (BUILD_JVD_IDS.has(j.id))
-                steps.push({ href: `#generator?jvd=${j.id}`, label: "Build", Icon: Wrench });
-              return (
-                <article
-                  key={j.id}
-                  className="group flex flex-col rounded-lg border border-border bg-surface p-6 transition-colors hover:border-primary/50"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-[11px] font-medium text-primary">
-                      {j.area}
-                    </span>
-                    {steps.length > 0 && (
-                      <div className="flex flex-wrap items-center justify-end gap-1.5">
-                        {steps.map(({ href, label, Icon }) => (
-                          <a
-                            key={label}
-                            href={href}
-                            className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:text-primary"
-                            title={`${label} this JVD`}
-                          >
-                            <Icon className="h-3 w-3" /> {label}
-                          </a>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                  <h3 className="mt-4 text-base font-semibold leading-snug">{j.name}</h3>
-                  <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">
-                    {j.description || "Reference architecture and validated configuration."}
-                  </p>
-                  {(families.length > 0 || j.os.length > 0) && (
-                    <div className="mt-4 flex flex-wrap gap-1.5">
-                      {families.map((p) => (
-                        <span
-                          key={p}
-                          className="rounded border border-transparent bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium text-foreground/80"
-                        >
-                          {p}
-                        </span>
-                      ))}
-                      {j.os.map((o) => (
-                        <span
-                          key={o}
-                          className="rounded border border-border bg-transparent px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
-                        >
-                          {o}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  <div className="mt-6 flex-1" />
-                  <a
-                    href={`${REPO_BASE}${j.repoPath}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center justify-between rounded-md border border-border bg-background px-4 py-2 text-sm font-medium transition-colors group-hover:border-primary/60 group-hover:text-primary"
-                  >
-                    View JVD
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </a>
-                </article>
-              );
-            })}
-          </div>
-
-          {filtered.length === 0 && (
-            <div className="mt-12 rounded-lg border border-dashed border-border p-12 text-center text-sm text-muted-foreground">
-              No JVDs match the selected filters.
+          {areaF || platformF || osF ? (
+            <>
+              <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                {filtered.map((j) => (
+                  <JvdCard key={j.id} j={j} />
+                ))}
+              </div>
+              {filtered.length === 0 && (
+                <div className="mt-12 rounded-lg border border-dashed border-border p-12 text-center text-sm text-muted-foreground">
+                  No JVDs match the selected filters.
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="marquee-pause mt-12 overflow-hidden">
+              <div className="marquee-track marquee-cards flex w-max">
+                {[...data, ...data].map((j, i) => (
+                  <JvdCard key={`${j.id}-${i}`} j={j} className="mr-5 w-80 shrink-0" />
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -271,7 +271,7 @@ export default function JvdPortal() {
           {/* Journey ladder — Discover → Explore → Design → Build */}
           <div id="how" className="mt-24 scroll-mt-24">
             <h2 className="text-2xl font-semibold tracking-tight">
-              Discover. Learn. Design. Build.
+              Find. Learn. Plan. Build.
             </h2>
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
               Four stages, one path. Discover the right design, learn how it&apos;s

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import jvds from "@/data/jvds.json";
-import { ArrowRight, Github, ExternalLink, Network, Layers, Info } from "lucide-react";
+import { ArrowRight, Github, ExternalLink, Network, Layers, Info, Sparkles, Wrench, type LucideIcon } from "lucide-react";
 import brandLogo from "@/assets/hpe-juniper-networking.avif";
 import SnipLibrary from "@/components/SnipLibrary";
 import ByoaiSection from "@/components/ByoaiSection";
@@ -68,6 +68,10 @@ const LADDER = [
 ];
 
 const SNIP_JVD_IDS = new Set(snipBundle.jvds.map((j) => j.id));
+// Which onward steps each JVD supports, so the catalog can show live pills.
+const BYOAI_JVD_IDS = new Set((snipBundle.byoaiJvds ?? []).map((b) => b.jvd));
+const BUILD_JVD_IDS = new Set(["metro_as_a_service"]);
+type StepPill = { href: string; label: string; Icon: LucideIcon };
 
 const REPO_BASE = "https://github.com/Juniper/jvd/tree/main/";
 
@@ -124,6 +128,22 @@ export default function JvdPortal() {
   const [areaF, setAreaF] = useState<string | null>(null);
   const [platformF, setPlatformF] = useState<string | null>(null);
   const [osF, setOsF] = useState<string | null>(null);
+
+  // Deep links like "#snips?jvd=x" carry a query the browser can't anchor-scroll
+  // to (no element id matches "snips?jvd=x"), so scroll the base section into
+  // view ourselves whenever such a hash is set.
+  useEffect(() => {
+    const scrollToDeepLink = () => {
+      const h = window.location.hash;
+      const qIdx = h.indexOf("?");
+      if (qIdx < 0) return;
+      const el = document.getElementById(h.slice(1, qIdx));
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+    scrollToDeepLink();
+    window.addEventListener("hashchange", scrollToDeepLink);
+    return () => window.removeEventListener("hashchange", scrollToDeepLink);
+  }, []);
 
   const filtered = useMemo(
     () =>
@@ -247,41 +267,39 @@ export default function JvdPortal() {
               ))}
             </div>
           </div>
-        </div>
-      </section>
 
-      {/* Journey ladder — Discover → Explore → Design → Build */}
-      <section id="how" className="border-b border-border bg-surface/40">
-        <div className="mx-auto max-w-7xl px-6 py-16">
-          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-            From requirement to running config
-          </h2>
-          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-            Four stages, one path — discover the right design, explore how it&apos;s
-            built, plan it against your requirements, then generate validated config.
-          </p>
-          <div className="mt-8 grid gap-4 md:grid-cols-4">
-            {LADDER.map((s, i) => (
-              <a
-                key={s.href}
-                href={s.href}
-                className="group relative rounded-lg border border-border bg-background p-5 transition-colors hover:border-primary/60"
-              >
-                <div className="flex items-center gap-2 text-primary">
-                  <span className="flex h-6 w-6 items-center justify-center rounded-full border border-primary/40 text-xs font-semibold">
-                    {i + 1}
+          {/* Journey ladder — Discover → Explore → Design → Build */}
+          <div id="how" className="mt-24 scroll-mt-24">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              Find it. Learn it. Plan it. Build it.
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+              Four stages, one path. Discover the right design, explore how it&apos;s
+              built, plan it against your requirements, then generate validated config.
+            </p>
+            <div className="mt-8 grid gap-4 md:grid-cols-4">
+              {LADDER.map((s, i) => (
+                <a
+                  key={s.href}
+                  href={s.href}
+                  className="group relative rounded-lg border border-border bg-surface p-5 transition-colors hover:border-primary/60"
+                >
+                  <div className="flex items-center gap-2 text-primary">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-full border border-primary/40 text-xs font-semibold">
+                      {i + 1}
+                    </span>
+                    <span className="text-[11px] font-semibold uppercase tracking-wider">
+                      {s.stage}
+                    </span>
+                  </div>
+                  <div className="mt-3 font-semibold tracking-tight">{s.title}</div>
+                  <p className="mt-1 text-sm text-muted-foreground">{s.desc}</p>
+                  <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
+                    Open <ArrowRight className="h-3 w-3" />
                   </span>
-                  <span className="text-[11px] font-semibold uppercase tracking-wider">
-                    {s.stage}
-                  </span>
-                </div>
-                <div className="mt-3 font-semibold tracking-tight">{s.title}</div>
-                <p className="mt-1 text-sm text-muted-foreground">{s.desc}</p>
-                <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
-                  Open <ArrowRight className="h-3 w-3" />
-                </span>
-              </a>
-            ))}
+                </a>
+              ))}
+            </div>
           </div>
         </div>
       </section>
@@ -323,23 +341,35 @@ export default function JvdPortal() {
             {filtered.map((j) => {
               const families = Array.from(new Set(j.platforms.map(familyOf))).filter(Boolean);
               const hasSnips = SNIP_JVD_IDS.has(j.id);
+              const steps: StepPill[] = [];
+              if (hasSnips)
+                steps.push({ href: `#snips?jvd=${j.id}`, label: "Explore", Icon: Layers });
+              if (BYOAI_JVD_IDS.has(j.id))
+                steps.push({ href: `#byoai?jvd=${j.id}`, label: "Design", Icon: Sparkles });
+              if (BUILD_JVD_IDS.has(j.id))
+                steps.push({ href: `#generator?jvd=${j.id}`, label: "Build", Icon: Wrench });
               return (
                 <article
                   key={j.id}
                   className="group flex flex-col rounded-lg border border-border bg-surface p-6 transition-colors hover:border-primary/50"
                 >
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-start justify-between gap-2">
                     <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-[11px] font-medium text-primary">
                       {j.area}
                     </span>
-                    {hasSnips && (
-                      <a
-                        href={`#snips?jvd=${j.id}`}
-                        className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:text-primary"
-                        title="This JVD has a snip library — click to browse"
-                      >
-                        <Layers className="h-3 w-3" /> Snips
-                      </a>
+                    {steps.length > 0 && (
+                      <div className="flex flex-wrap items-center justify-end gap-1.5">
+                        {steps.map(({ href, label, Icon }) => (
+                          <a
+                            key={label}
+                            href={href}
+                            className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:border-primary/60 hover:text-primary"
+                            title={`${label} this JVD`}
+                          >
+                            <Icon className="h-3 w-3" /> {label}
+                          </a>
+                        ))}
+                      </div>
                     )}
                   </div>
                   <h3 className="mt-4 text-base font-semibold leading-snug">{j.name}</h3>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -48,7 +48,7 @@ const LADDER = [
     href: "#catalog",
   },
   {
-    stage: "Explore",
+    stage: "Learn",
     title: "Config Explorer",
     desc: "Drill into the reusable, provenance-tracked config building blocks.",
     href: "#snips",
@@ -271,10 +271,10 @@ export default function JvdPortal() {
           {/* Journey ladder — Discover → Explore → Design → Build */}
           <div id="how" className="mt-24 scroll-mt-24">
             <h2 className="text-2xl font-semibold tracking-tight">
-              Find it. Learn it. Plan it. Build it.
+              Discover. Learn. Design. Build.
             </h2>
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-              Four stages, one path. Discover the right design, explore how it&apos;s
+              Four stages, one path. Discover the right design, learn how it&apos;s
               built, plan it against your requirements, then generate validated config.
             </p>
             <div className="mt-8 grid gap-4 md:grid-cols-4">
@@ -343,7 +343,7 @@ export default function JvdPortal() {
               const hasSnips = SNIP_JVD_IDS.has(j.id);
               const steps: StepPill[] = [];
               if (hasSnips)
-                steps.push({ href: `#snips?jvd=${j.id}`, label: "Explore", Icon: Layers });
+                steps.push({ href: `#snips?jvd=${j.id}`, label: "Learn", Icon: Layers });
               if (BYOAI_JVD_IDS.has(j.id))
                 steps.push({ href: `#byoai?jvd=${j.id}`, label: "Design", Icon: Sparkles });
               if (BUILD_JVD_IDS.has(j.id))

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -32,10 +32,39 @@ const OS_OPTIONS = ["Junos", "Junos EVO"];
 const NAV = [
   { label: "Home", href: "#home" },
   { label: "Catalog", href: "#catalog" },
-  { label: "Snips", href: "#snips" },
-  { label: "BYOAI", href: "#byoai" },
+  { label: "Explorer", href: "#snips" },
+  { label: "Design", href: "#byoai" },
   { label: "Generator", href: "#generator" },
   { label: "About", href: "#about" },
+];
+
+// The site as a journey: Discover → Explore → Design → Build. Each rung links
+// to its section so the four tools read as stages, not competing alternatives.
+const LADDER = [
+  {
+    stage: "Discover",
+    title: "JVD Catalog",
+    desc: "Find the validated design that fits your requirements.",
+    href: "#catalog",
+  },
+  {
+    stage: "Explore",
+    title: "Config Explorer",
+    desc: "Drill into the reusable, provenance-tracked config building blocks.",
+    href: "#snips",
+  },
+  {
+    stage: "Design",
+    title: "Design & Planner",
+    desc: "Ask design and scaling questions grounded in the validated JVDs.",
+    href: "#byoai",
+  },
+  {
+    stage: "Build",
+    title: "Service Config Generator",
+    desc: "Render download-ready, JVD-validated service configuration.",
+    href: "#generator",
+  },
 ];
 
 const SNIP_JVD_IDS = new Set(snipBundle.jvds.map((j) => j.id));
@@ -221,12 +250,51 @@ export default function JvdPortal() {
         </div>
       </section>
 
+      {/* Journey ladder — Discover → Explore → Design → Build */}
+      <section id="how" className="border-b border-border bg-surface/40">
+        <div className="mx-auto max-w-7xl px-6 py-16">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+            From requirement to running config
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+            Four stages, one path — discover the right design, explore how it&apos;s
+            built, plan it against your requirements, then generate validated config.
+          </p>
+          <div className="mt-8 grid gap-4 md:grid-cols-4">
+            {LADDER.map((s, i) => (
+              <a
+                key={s.href}
+                href={s.href}
+                className="group relative rounded-lg border border-border bg-background p-5 transition-colors hover:border-primary/60"
+              >
+                <div className="flex items-center gap-2 text-primary">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-full border border-primary/40 text-xs font-semibold">
+                    {i + 1}
+                  </span>
+                  <span className="text-[11px] font-semibold uppercase tracking-wider">
+                    {s.stage}
+                  </span>
+                </div>
+                <div className="mt-3 font-semibold tracking-tight">{s.title}</div>
+                <p className="mt-1 text-sm text-muted-foreground">{s.desc}</p>
+                <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
+                  Open <ArrowRight className="h-3 w-3" />
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {/* Catalog */}
       <section id="catalog" className="border-b border-border">
         <div className="mx-auto max-w-7xl px-6 py-24">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight">Catalog</h2>
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
+                Step 1 · Discover
+              </div>
+              <h2 className="mt-1 text-3xl font-semibold tracking-tight">JVD Catalog</h2>
               <p className="mt-2 text-sm text-muted-foreground">
                 Browse the {data.length} validated designs in this GitHub catalog. Visit{" "}
                 <a
@@ -330,8 +398,11 @@ export default function JvdPortal() {
       {/* Generator */}
       <section id="generator" className="border-b border-border">
         <div className="mx-auto max-w-7xl px-6 py-24">
-          <div className="flex items-center gap-2">
-            <h2 className="text-3xl font-semibold tracking-tight">JVD Config Generator</h2>
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
+            Step 4 · Build
+          </div>
+          <div className="mt-1 flex items-center gap-2">
+            <h2 className="text-3xl font-semibold tracking-tight">Service Configuration Generator</h2>
             <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400">
               Beta
             </span>
@@ -340,8 +411,9 @@ export default function JvdPortal() {
             A deterministic config builder: pick a service, choose your
             options, fill in the parameters, and download validated Junos /
             Junos EVO configuration rendered straight from the JVD snip library.
-            Metro-as-a-Service E-Line is available first — more services and
-            JVDs coming.
+            Metro-as-a-Service E-Line, E-LAN and E-Tree are live — more services
+            and JVDs are being added. Scoped to validated <em>services</em>; for
+            broader design and platform questions, use the Design &amp; Planner.
           </p>
 
           <div className="mt-5 flex max-w-2xl items-start gap-2 rounded-md border border-border bg-surface p-3 text-xs text-muted-foreground">

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -229,6 +229,17 @@ export default function JvdPortal() {
     [data, areaF, platformF, osF],
   );
 
+  // Shuffle once per load so the idle marquee interleaves areas/platforms
+  // instead of scrolling through them in source (grouped) order.
+  const shuffledData = useMemo(() => {
+    const a = [...data];
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  }, [data]);
+
   const stats = [
     { label: "Validated Designs", value: "60+" },
     { label: "Reusable Config Templates", value: `${Math.floor(snipBundle.counts.total / 50) * 50}+` },
@@ -428,7 +439,7 @@ export default function JvdPortal() {
           ) : (
             <div className="marquee-pause mt-12 overflow-hidden">
               <div className="marquee-track marquee-cards flex w-max">
-                {[...data, ...data].map((j, i) => (
+                {[...shuffledData, ...shuffledData].map((j, i) => (
                   <JvdCard key={`${j.id}-${i}`} j={j} className="mr-5 w-80 shrink-0" />
                 ))}
               </div>

--- a/portal/src/components/SnipLibrary.tsx
+++ b/portal/src/components/SnipLibrary.tsx
@@ -610,7 +610,7 @@ export default function SnipLibrary() {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-              Step 2 · Explore
+              Step 2 · Learn
             </div>
             <div className="mt-1 flex items-center gap-2">
               <Layers className="h-5 w-5 text-primary" />

--- a/portal/src/components/SnipLibrary.tsx
+++ b/portal/src/components/SnipLibrary.tsx
@@ -609,13 +609,16 @@ export default function SnipLibrary() {
         {/* Header */}
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <div className="flex items-center gap-2">
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
+              Step 2 · Explore
+            </div>
+            <div className="mt-1 flex items-center gap-2">
               <Layers className="h-5 w-5 text-primary" />
-              <h2 className="text-3xl font-semibold tracking-tight">Snip Library</h2>
+              <h2 className="text-3xl font-semibold tracking-tight">Config Explorer</h2>
             </div>
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-              Browse {snipBundle.counts.total} reusable configuration snips extracted from{" "}
-              {snipBundle.counts.jvds} JVD libraries — Junos and Junos EVO. Each snip carries its
+              Explore {snipBundle.counts.total} reusable configuration building blocks extracted from{" "}
+              {snipBundle.counts.jvds} JVD libraries — Junos and Junos EVO. Each carries its
               source provenance, variable glossary, and pair-with references back to GitHub.
             </p>
           </div>

--- a/portal/src/styles.css
+++ b/portal/src/styles.css
@@ -85,6 +85,10 @@
 .marquee-track {
   animation: marquee 60s linear infinite;
 }
+/* Slower cadence for the larger JVD cards in the Catalog marquee. */
+.marquee-cards {
+  animation-duration: 120s;
+}
 .marquee-pause:hover .marquee-track {
   animation-play-state: paused;
 }


### PR DESCRIPTION
## What's New
The portal now reads as a **guided journey** instead of four peer tools. A new
**Discover → Learn → Design → Build** ladder in the hero frames the four surfaces
as stages of one workflow, and the Catalog links directly into each next step.

- **Journey ladder** in the hero — *Find. Learn. Plan. Build.* — four stage cards
  that link to each section.
- **Relabelled surfaces** to match the stages: Snip Library → **Config Explorer**
  (Learn), Bring Your Own AI → **Design & Planner** (Design, with the BYOAI phrase
  kept), JVD Config Generator → **Service Configuration Generator** (Build).
- **Catalog step pills** — each JVD card shows live **Learn / Design / Build** pills
  for the steps that JVD supports; clicking one jumps to that section **and
  pre-selects the JVD**.
- **Catalog marquee** — the Catalog idles as a hover-pausing, shuffled card carousel
  (areas interleaved) and expands to the full grid the moment you apply a filter.
- **Deep-link scroll fix** — `#section?jvd=…` links now scroll to the section
  (previously they selected the JVD but didn't move the page).

## Why
Two of the four surfaces (BYOAI and the Generator) both "produce config," which made
the site feel like several overlapping ways to do the same thing. Reframing them as
sequential stages — and giving BYOAI a distinct **design & planning** identity —
removes the overlap and makes the next step obvious from anywhere.

## Details
- `JvdPortal.tsx`: `LADDER` model + hero ladder; `JvdCard` extracted for reuse in
  both marquee and grid; per-JVD availability sets (`BYOAI_JVD_IDS`, `BUILD_JVD_IDS`);
  Fisher–Yates shuffle (once per load) for the idle marquee; a deep-link scroll
  effect for `#section?query` hashes; stage eyebrows + retitles.
- `SnipLibrary.tsx` / `ByoaiSection.tsx`: retitles, `Step N ·` eyebrows, and BYOAI
  pre-selects its JVD from `#byoai?jvd=…`.
- `styles.css`: slower `.marquee-cards` cadence for the larger cards.
- `Documentation/`: new **unlisted markdown corpus** scaffold (README + per-JVD
  layout) that will ground the Design & Planner. Pilot-first — MaaS, then MEBS.

## Testing
- `bun run build` clean; no type/lint errors across the edited components.
- Redesign is presentation-only — no change to the Config Generator engine or snips.

## Notes
- The `Documentation/` corpus is scaffolded, not yet populated; converting the MaaS
  guide → markdown and wiring the Design & Planner to read it is the intended
  follow-up (piloted on one JVD before scaling).
- Nav keeps tool-name shortcuts (Catalog / Explorer / Design / Generator) while the
  ladder uses stage verbs; easy to unify later if desired.
