### PR TITLE
fix(portal): honor 'break out on far PE' toggle for EVPN-FXC vlan-unaware

### DIFF
--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -404,8 +404,10 @@ export function expandVlanRange(range: string): number[] {
 /**
  * Map an EVPN-FXC entry list to the concrete UNI units for ONE PE. `mode` picks
  * the service style; `os` selects the OS-specific interface snips; on the
- * breakout side a range entry expands to per-VLAN units. For VLAN-aware, each
- * entry's ESI + vpws-service-id increment per UNI (from `base`).
+ * breakout side a range entry expands to per-VLAN units only when that entry's
+ * `breakout` flag is set (otherwise it stays a collapsed vlan-id-list, same as
+ * PE-A). For VLAN-aware, each entry's ESI + vpws-service-id increment per UNI
+ * (from `base`).
  */
 export function fxcUnitSpecs(
   mode: "unaware" | "aware",
@@ -446,7 +448,7 @@ export function fxcUnitSpecs(
     }
     const vlans = expandVlanRange(e.range);
     const start = String(vlans[0] ?? e.range);
-    if (isBreakoutSide) {
+    if (isBreakoutSide && e.breakout) {
       for (const v of vlans) {
         const rel = e.svlan
           ? `${os}/interfaces/vlan-ccc-1-unit-qinq`


### PR DESCRIPTION
## What's New
- The per-UNI **"break out on far PE"** checkbox on EVPN-FXC VLAN-unaware range entries now actually controls the far-PE (PE-B) rendering.

## Why
For EVPN-FXC VLAN-unaware, a VLAN range on PE-B was **always** expanded into one unit per VLAN, regardless of whether the entry's "break out on far PE" box was checked. The toggle was effectively dead — PE-B never rendered a collapsed `vlan-id-list`.

## Details
- `fxcUnitSpecs()` in `portal/src/lib/generator.ts` gated the per-VLAN expansion only on `isBreakoutSide` (true for PE-B), ignoring the entry's own `breakout` flag. Changed the condition to `isBreakoutSide && e.breakout`.
- Result:
  - PE-B, box **unchecked** → collapsed `vlan-id-list` (matches PE-A).
  - PE-B, box **checked** → per-VLAN units across the range.
  - PE-A and VLAN-aware paths unchanged.
- Updated the function doc comment to match.

## Testing
- Node render (`bun`) over `fxcUnitSpecs` with a `100-200` range + two singles:
  - PE-A → `vlan-ccc-1-unit-list` (VLAN_LIST `100-200`).
  - PE-B unchecked → `vlan-ccc-1-unit-list` (collapsed).
  - PE-B checked → 101 per-VLAN units (`100`…`200`) + the 2 singles = 103 units.
- `bun run build` clean.