### PR TITLE
Portal + BYOAI hardening (generator, Stages, datasheet, Design mode)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,39 +1,30 @@
 <!--
-  Juniper/jvd PR template.
-  Fill in the sections below; delete any section that doesn't apply.
-  Keep the body externally-safe — every push notifies watchers and the
-  squashed PR body becomes part of the public release notes.
+  Juniper/jvd PR template. Keep it BRIEF and externally-safe — every push
+  notifies watchers and the squashed PR body becomes part of the public
+  release notes. Delete any section that doesn't apply.
 -->
 
 ## What's New
 <!-- One-line headline matching the PR title, then 2-4 bullets of
      user-visible changes. Customer / watcher voice. -->
 
-
-
 ## Why
-<!-- Problem statement and context. Include concrete numbers if
-     this is a perf or scale change. -->
+<!-- The problem this solves, briefly. Concrete numbers if perf/scale. -->
 
+## Changes
+<!-- Checklist of what this PR does, grouped by area. Tick as done. -->
+- [x]
 
-
-## Details
-<!-- Changes grouped by file or component, for reviewers. Include
-     subtle refactors or behavior changes that aren't obvious from
-     the diff. -->
-
-
-
-## Testing
-<!-- What was verified locally — commands run, manual checks,
-     screenshots for UI changes. -->
-
-
+## Verified before merge
+<!-- Tick what you actually checked; leave unchecked = not done / N/A. -->
+- [ ] Portal builds — `bun run build`
+- [ ] Markdown links pass — `lychee --offline --include-fragments './**/*.md'` → 0 errors
+- [ ] Generated artifacts regenerated where source changed (e.g. byoai mirror via `generate-snips.mjs`)
+- [ ] No internal-only content in public files (lab hostnames/IPs, Confidential material, scratch/TODO)
+- [ ] Externally-safe wording (watcher/customer-appropriate)
 
 <!--
-## Notes
-Optional. Use only when applicable:
-  - Source-of-truth (e.g. generated vs hand-edited files)
-  - Breaking changes / migration steps
-  - Follow-up work intentionally deferred to a later PR
+## Notes — optional
+Source-of-truth (generated vs hand-edited) · breaking changes / migration steps ·
+follow-up work intentionally deferred.
 -->

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 **/_audit_findings.json
 **/_taxonomy.*.json
 **/_topology_registry.json
+
+# Stray literal "~" scratch dirs (tools passing ~/ literally instead of $HOME).
+# Real scratch lives under the actual ~/git-tmp; never inside the repo.
+/~/
+**/~/

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024 Juniper Networks, Inc.
+   Copyright 2024–2026 Juniper Networks, Inc. / Hewlett Packard Enterprise
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,23 @@
+Juniper Validated Designs (JVD)
+Copyright 2024–2026 Juniper Networks, Inc. / Hewlett Packard Enterprise
+
+This repository is an official HPE Juniper resource. All content — including
+validated configurations, design documentation, snippet libraries, and the
+portal — is authored by or on behalf of HPE Juniper engineering teams and
+published under the Apache License, Version 2.0 (see LICENSE).
+
+Derived works: Several markdown files under `*/documentation/` are faithful
+conversions of Juniper's published PDF design guides, solution overviews, and
+test report briefs. The published PDFs on juniper.net remain the authoritative
+source of truth. These conversions are created by the same engineering team that
+authored the originals and are included here to enable programmatic access,
+search, and AI-grounded workflows (BYOAI Design mode).
+
+Trademarks: "Juniper Networks," "Juniper Validated Designs," "JVD," and related
+marks are trademarks of Juniper Networks, Inc. / Hewlett Packard Enterprise.
+"Metro Ethernet Forum," "MEF," and "MEF 3.0" are trademarks of Mplify Alliance
+(formerly MEF Forum). Use of these marks in this repository does not imply
+endorsement by or affiliation with the mark owners beyond the actual authorship
+and validation described. The Apache 2.0 license does not grant permission to use
+any contributor's trade names, trademarks, or service marks except as required
+for reasonable and customary description of the origin of the work.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Juniper Validated Designs have been validated at scale to help ensure faster, mo
 
 Official documentation: <https://www.juniper.net/documentation/validated-designs/>
 
+This repository is an **official HPE Juniper resource** — all content is authored
+and maintained by HPE Juniper engineering teams and licensed under Apache 2.0. See
+[NOTICE](NOTICE) for attribution, trademark, and derived-work details.
+
 ---
 
 ## Validated Designs for:

--- a/portal/public/byoai/metro_as_a_service/MANIFEST.json
+++ b/portal/public/byoai/metro_as_a_service/MANIFEST.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "description": "BYOAI snip manifest. Fetch the entries you need from raw_url; do NOT fetch every snip. See byoai/SYSTEM_PROMPT.md for the selection rules and byoai/CATALOG.md for the funnel map.",
   "raw_url_base": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips",
-  "snip_count": 112,
+  "snip_count": 131,
   "snips": [
     {
       "path": "evo/apply-groups/mef-forwarding-profile.conf",
@@ -781,6 +781,66 @@
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-bridge.conf"
     },
     {
+      "path": "evo/interfaces/vlan-ccc-1-unit-list-push.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit-list-push",
+      "topic": "Interface: vlan ccc 1 unit vlan-id-list + S-VLAN push (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "AN3",
+          "platform": "ACX7100-48L"
+        }
+      ],
+      "size_bytes": 944,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-1-unit-list-push.conf"
+    },
+    {
+      "path": "evo/interfaces/vlan-ccc-1-unit-list.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit-list",
+      "topic": "Interface: vlan ccc 1 unit vlan-id-list (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "AN3",
+          "platform": "ACX7100-48L"
+        }
+      ],
+      "size_bytes": 780,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-1-unit-list.conf"
+    },
+    {
+      "path": "evo/interfaces/vlan-ccc-1-unit-qinq.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit-qinq",
+      "topic": "Interface: vlan ccc 1 unit QinQ (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "AN3",
+          "platform": "ACX7100-48L"
+        }
+      ],
+      "size_bytes": 826,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-1-unit-qinq.conf"
+    },
+    {
+      "path": "evo/interfaces/vlan-ccc-1-unit.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit",
+      "topic": "Interface: vlan ccc 1 unit (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "AN3",
+          "platform": "ACX7100-48L"
+        }
+      ],
+      "size_bytes": 939,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-1-unit.conf"
+    },
+    {
       "path": "evo/interfaces/vlan-ccc-2-units.conf",
       "os": "evo",
       "category": "interfaces",
@@ -792,8 +852,35 @@
           "platform": "ACX7100-48L"
         }
       ],
-      "size_bytes": 1050,
+      "size_bytes": 1096,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-2-units.conf"
+    },
+    {
+      "path": "evo/interfaces/vlan-ccc-esi-1-unit.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-esi-1-unit",
+      "topic": "Interface: vlan ccc esi 1 unit (MEF E-Line / EVPL) \u2014 EVPN-FXC member (aware, no vlan-map)",
+      "seen_on": [
+        {
+          "label": "MEG1",
+          "platform": "ACX7100-32C"
+        },
+        {
+          "label": "MEG2",
+          "platform": "ACX7509"
+        },
+        {
+          "label": "MA1.1",
+          "platform": "ACX7024"
+        },
+        {
+          "label": "MA1.2",
+          "platform": "ACX7024"
+        }
+      ],
+      "size_bytes": 895,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi-1-unit.conf"
     },
     {
       "path": "evo/interfaces/vlan-ccc-esi.conf",
@@ -813,6 +900,21 @@
       ],
       "size_bytes": 852,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-esi.conf"
+    },
+    {
+      "path": "evo/interfaces/vlan-ccc-list.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-list",
+      "topic": "Interface: vlan ccc list (MEF E-Line / PWHT access)",
+      "seen_on": [
+        {
+          "label": "MA1.2",
+          "platform": "ACX7024"
+        }
+      ],
+      "size_bytes": 670,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-list.conf"
     },
     {
       "path": "evo/interfaces/vlan-ccc-qinq-stacked-qinq-tpid.conf",
@@ -862,6 +964,33 @@
       ],
       "size_bytes": 1272,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-bundle-qinq-tpid.conf"
+    },
+    {
+      "path": "evo/interfaces/vlan-ccc-vlan-map-esi-1-unit.conf",
+      "os": "evo",
+      "category": "interfaces",
+      "name": "vlan-ccc-vlan-map-esi-1-unit",
+      "topic": "Interface: vlan ccc vlan map esi 1 unit (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "MEG1",
+          "platform": "ACX7100-32C"
+        },
+        {
+          "label": "MEG2",
+          "platform": "ACX7509"
+        },
+        {
+          "label": "MA1.1",
+          "platform": "ACX7024"
+        },
+        {
+          "label": "MA1.2",
+          "platform": "ACX7024"
+        }
+      ],
+      "size_bytes": 1202,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc-vlan-map-esi-1-unit.conf"
     },
     {
       "path": "evo/interfaces/vlan-ccc-vlan-map-esi-2-units-v2.conf",
@@ -974,6 +1103,21 @@
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/interfaces/vlan-ccc.conf"
     },
     {
+      "path": "evo/policy/communities-tc-color.conf",
+      "os": "evo",
+      "category": "policy",
+      "name": "communities-tc-color",
+      "topic": "Policy: transport-class color communities (gold / bronze)",
+      "seen_on": [
+        {
+          "label": "MA1.2",
+          "platform": "ACX7024"
+        }
+      ],
+      "size_bytes": 543,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/policy/communities-tc-color.conf"
+    },
+    {
       "path": "evo/policy/policy-l3vpn-import-export.conf",
       "os": "evo",
       "category": "policy",
@@ -1028,7 +1172,7 @@
           "platform": "ACX7024"
         }
       ],
-      "size_bytes": 957,
+      "size_bytes": 1006,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-bronze.conf"
     },
     {
@@ -1051,7 +1195,7 @@
           "platform": "ACX7509"
         }
       ],
-      "size_bytes": 907,
+      "size_bytes": 952,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/policy/policy-vpn-rt-export-gold.conf"
     },
     {
@@ -1089,7 +1233,7 @@
           "platform": "ACX7024"
         }
       ],
-      "size_bytes": 1732,
+      "size_bytes": 1770,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/bgp-vpls.conf"
     },
     {
@@ -1154,7 +1298,7 @@
           "platform": "ACX7024"
         }
       ],
-      "size_bytes": 1592,
+      "size_bytes": 1333,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-port-based.conf"
     },
     {
@@ -1192,6 +1336,33 @@
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-type5.conf"
     },
     {
+      "path": "evo/services/evpn-elan-vlan-based.conf",
+      "os": "evo",
+      "category": "services",
+      "name": "evpn-elan-vlan-based",
+      "topic": "Service instance: evpn elan vlan based (MEF E-LAN / EVP-LAN)",
+      "seen_on": [
+        {
+          "label": "AN2",
+          "platform": "ACX5448"
+        },
+        {
+          "label": "AN3",
+          "platform": "ACX7100-48L"
+        },
+        {
+          "label": "MEG1",
+          "platform": "ACX7100-32C"
+        },
+        {
+          "label": "MEG2",
+          "platform": "ACX7509"
+        }
+      ],
+      "size_bytes": 1339,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-based.conf"
+    },
+    {
       "path": "evo/services/evpn-elan-vlan-bundle.conf",
       "os": "evo",
       "category": "services",
@@ -1211,8 +1382,35 @@
           "platform": "ACX7509"
         }
       ],
-      "size_bytes": 1435,
+      "size_bytes": 1470,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-elan-vlan-bundle.conf"
+    },
+    {
+      "path": "evo/services/evpn-fxc-vlan-aware-1.conf",
+      "os": "evo",
+      "category": "services",
+      "name": "evpn-fxc-vlan-aware-1",
+      "topic": "Service instance: evpn fxc vlan aware 1 (MEF E-Line / EVPL)",
+      "seen_on": [
+        {
+          "label": "MEG1",
+          "platform": "ACX7100-32C"
+        },
+        {
+          "label": "MEG2",
+          "platform": "ACX7509"
+        },
+        {
+          "label": "MA1.1",
+          "platform": "ACX7024"
+        },
+        {
+          "label": "MA1.2",
+          "platform": "ACX7024"
+        }
+      ],
+      "size_bytes": 1393,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware-1.conf"
     },
     {
       "path": "evo/services/evpn-fxc-vlan-aware.conf",
@@ -1240,6 +1438,21 @@
       ],
       "size_bytes": 1861,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-aware.conf"
+    },
+    {
+      "path": "evo/services/evpn-fxc-vlan-unaware-1.conf",
+      "os": "evo",
+      "category": "services",
+      "name": "evpn-fxc-vlan-unaware-1",
+      "topic": "Service instance: evpn fxc vlan unaware 1 (MEF E-Line / EVPL)",
+      "seen_on": [
+        {
+          "label": "AN3",
+          "platform": "ACX7100-48L"
+        }
+      ],
+      "size_bytes": 1324,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/evpn-fxc-vlan-unaware-1.conf"
     },
     {
       "path": "evo/services/evpn-fxc-vlan-unaware.conf",
@@ -1348,7 +1561,7 @@
           "platform": "ACX7024"
         }
       ],
-      "size_bytes": 1155,
+      "size_bytes": 1364,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/evo/services/l2circuit-floating-pw.conf"
     },
     {
@@ -2063,7 +2276,7 @@
           "platform": "MX304"
         }
       ],
-      "size_bytes": 832,
+      "size_bytes": 903,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/pseudowire-subscriber.conf"
     },
     {
@@ -2154,6 +2367,25 @@
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-leaf.conf"
     },
     {
+      "path": "junos/interfaces/vlan-bridge-etree-root.conf",
+      "os": "junos",
+      "category": "interfaces",
+      "name": "vlan-bridge-etree-root",
+      "topic": "Interface: vlan bridge etree root (MEF E-Tree / EVP-Tree)",
+      "seen_on": [
+        {
+          "label": "MSE1",
+          "platform": "MX304"
+        },
+        {
+          "label": "MSE2",
+          "platform": "MX304"
+        }
+      ],
+      "size_bytes": 864,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge-etree-root.conf"
+    },
+    {
       "path": "junos/interfaces/vlan-bridge-qinq-stacked-v2.conf",
       "os": "junos",
       "category": "interfaces",
@@ -2197,6 +2429,66 @@
       ],
       "size_bytes": 790,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-bridge.conf"
+    },
+    {
+      "path": "junos/interfaces/vlan-ccc-1-unit-list-push.conf",
+      "os": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit-list-push",
+      "topic": "Interface: vlan ccc 1 unit vlan-id-list + S-VLAN push (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "MSE1",
+          "platform": "MX304"
+        }
+      ],
+      "size_bytes": 943,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-1-unit-list-push.conf"
+    },
+    {
+      "path": "junos/interfaces/vlan-ccc-1-unit-list.conf",
+      "os": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit-list",
+      "topic": "Interface: vlan ccc 1 unit vlan-id-list (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "MSE1",
+          "platform": "MX304"
+        }
+      ],
+      "size_bytes": 779,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-1-unit-list.conf"
+    },
+    {
+      "path": "junos/interfaces/vlan-ccc-1-unit-qinq.conf",
+      "os": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit-qinq",
+      "topic": "Interface: vlan ccc 1 unit QinQ (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "MSE1",
+          "platform": "MX304"
+        }
+      ],
+      "size_bytes": 885,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-1-unit-qinq.conf"
+    },
+    {
+      "path": "junos/interfaces/vlan-ccc-1-unit.conf",
+      "os": "junos",
+      "category": "interfaces",
+      "name": "vlan-ccc-1-unit",
+      "topic": "Interface: vlan ccc 1 unit (MEF E-Line / EVPL) \u2014 EVPN-FXC member",
+      "seen_on": [
+        {
+          "label": "MSE1",
+          "platform": "MX304"
+        }
+      ],
+      "size_bytes": 945,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/interfaces/vlan-ccc-1-unit.conf"
     },
     {
       "path": "junos/interfaces/vlan-ccc-v2.conf",
@@ -2313,7 +2605,7 @@
           "platform": "MX204"
         }
       ],
-      "size_bytes": 907,
+      "size_bytes": 952,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/policy/policy-vpn-rt-export-gold.conf"
     },
     {
@@ -2330,6 +2622,21 @@
       ],
       "size_bytes": 1832,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls-p2p.conf"
+    },
+    {
+      "path": "junos/services/bgp-vpls.conf",
+      "os": "junos",
+      "category": "services",
+      "name": "bgp-vpls",
+      "topic": "Service instance: bgp vpls (MEF E-LAN / EVP-LAN)",
+      "seen_on": [
+        {
+          "label": "MA5",
+          "platform": "MX204"
+        }
+      ],
+      "size_bytes": 1727,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/bgp-vpls.conf"
     },
     {
       "path": "junos/services/bridge-domain-lsw.conf",
@@ -2351,18 +2658,14 @@
       "os": "junos",
       "category": "services",
       "name": "evpn-elan-port-based",
-      "topic": "Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)",
+      "topic": "Service instance: evpn elan port based (MEF E-LAN / EP-LAN)",
       "seen_on": [
         {
-          "label": "AN1",
+          "label": "MA5",
           "platform": "MX204"
-        },
-        {
-          "label": "AN2",
-          "platform": "ACX5448"
         }
       ],
-      "size_bytes": 1362,
+      "size_bytes": 1123,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-port-based.conf"
     },
     {
@@ -2396,8 +2699,23 @@
           "platform": "MX304"
         }
       ],
-      "size_bytes": 1331,
+      "size_bytes": 1369,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based-floating-pw.conf"
+    },
+    {
+      "path": "junos/services/evpn-elan-vlan-based.conf",
+      "os": "junos",
+      "category": "services",
+      "name": "evpn-elan-vlan-based",
+      "topic": "Service instance: evpn elan vlan based (MEF E-LAN / EVP-LAN)",
+      "seen_on": [
+        {
+          "label": "AN1",
+          "platform": "MX204"
+        }
+      ],
+      "size_bytes": 1133,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-elan-vlan-based.conf"
     },
     {
       "path": "junos/services/evpn-elan.conf",
@@ -2440,6 +2758,21 @@
       ],
       "size_bytes": 1427,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-etree-vlan-based.conf"
+    },
+    {
+      "path": "junos/services/evpn-fxc-vlan-unaware-1.conf",
+      "os": "junos",
+      "category": "services",
+      "name": "evpn-fxc-vlan-unaware-1",
+      "topic": "Service instance: evpn fxc vlan unaware 1 (MEF E-Line / EVPL)",
+      "seen_on": [
+        {
+          "label": "MSE1",
+          "platform": "MX304"
+        }
+      ],
+      "size_bytes": 1389,
+      "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/evpn-fxc-vlan-unaware-1.conf"
     },
     {
       "path": "junos/services/evpn-fxc-vlan-unaware.conf",
@@ -2495,7 +2828,7 @@
           "platform": "MX304"
         }
       ],
-      "size_bytes": 1022,
+      "size_bytes": 1183,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/configuration/snips/junos/services/l2circuit-floating-pw.conf"
     },
     {

--- a/portal/public/byoai/metro_as_a_service/README.md
+++ b/portal/public/byoai/metro_as_a_service/README.md
@@ -22,6 +22,20 @@ At each step the AI offers **only** the choices valid for your earlier picks (E-
 
 ---
 
+## Configuration mode vs Design mode
+
+The assistant runs in one of two modes (it picks based on your intent, or you can say `config mode` / `design mode`):
+
+- **Configuration mode** — the strict, hallucination-free snip funnel described above. Grounded exclusively in the validated snippet library.
+- **Design mode** — architectural Q&A and teaching (transport classes, Flex-Algo, EVPN multihoming, MEF service models, deployment trade-offs). Its primary source is the JVD's markdown **design corpus** under [`../../../documentation/`](../../../documentation/):
+  - [`solution-overview.md`](../../../documentation/solution-overview.md) — benefits and objectives.
+  - [`design-guide.md`](../../../documentation/design-guide.md) — full architecture, MEF 3.0 standards, services under test, transport, per-service config examples.
+  - [`test-report-brief.md`](../../../documentation/test-report-brief.md) — platforms, test categories, per-service testcase counts, conformance results.
+
+  Design mode can also draw on anything else in the MaaS directory (the JVD [`README`](../../../README.md) and the `configuration/` tree). When an AI has web fetch, it pulls the design corpus directly from GitHub; Design mode does **not** require the snip bundle.
+
+---
+
 ## Quick start — pick one
 
 | Method | Best for | What you do |

--- a/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
@@ -38,11 +38,12 @@ format the generated config. There is nothing here that would
 conflict with your normal operating principles; this is a
 constrained, well-scoped technical assistant task.
 
-Begin by executing PART 2 — INTERACTION FLOW (specifically the
-CORPUS CHECK then the MODE SELECTION) on your very next message. Your
-first reply should be the MODE MENU (Configuration vs Design) — please
-don't respond with "what would you like me to do with this document?"
-or similar meta-questions; the document IS the task.
+Begin by presenting the MODE MENU (PART 2 — MODE MENU FIRST) as your
+very next message. Do NOT fetch anything before the menu — the menu
+must appear on every account, including free ones with no web access.
+Do not reply with "what would you like me to do with this document?"
+or similar meta-questions; the document IS the task. Fetch the corpus
+only AFTER the user picks a mode (see PART 2).
 
 ============================================================
 PART 0 — ROLE
@@ -169,59 +170,11 @@ PART 1 — GROUND RULES
 PART 2 — INTERACTION FLOW
 ============================================================
 
-CORPUS CHECK — the reference files (CATALOG.md, TIERS.md, DEFAULTS.md,
-OUTPUT_FORMAT.md) are appended to this prompt file (scroll down). You
-already have the funnel logic. For Configuration mode you also need
-the actual .conf snip BODIES to render config. Check for them:
-
-  CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is visible
-    (at least one `## junos/...conf`, one `## evo/...conf`). You have
-    everything — proceed to MODE SELECTION.
-
-  CORPUS-A: you have web fetch. Fetch the FULL BUNDLE in one shot:
-    https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
-  This is ~200 KB and contains ALL 112 snip bodies + reference files.
-  On success, acknowledge briefly:
-    `Loaded JVD MaaS snip bundle (112 snips) from GitHub.`
-  Then proceed to MODE SELECTION.
-
-  FALLBACK: IF the bundle fetch fails, respond with EXACTLY:
-    I was unable to pull the configurations from the JVD GitHub.
-    Please download the file called `jvd-maas-snips.md` and load it
-    into the chat so we can continue.
-
-    You can get it from:
-    https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-  Then STOP and wait.
-
-  NOTE: For **Design mode only**, the snip-body corpus is NOT
-  required. Design mode's primary corpus is the MaaS `documentation/`
-  markdown.
-
-  DESIGN MODE INITIALIZATION (do this the moment the user enters
-  Design mode, BEFORE answering their first design question): if web
-  fetch is available, FETCH the design corpus FIRST and load it into
-  context, in this order:
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
-  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
-  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
-  synthesize from general Junos knowledge when the corpus covers the
-  topic. When you go beyond the corpus, say so; when the corpus does
-  not cover something, acknowledge the gap rather than guessing.
-  If the fetch fails but the user wants Design mode, proceed directly
-  — you can reference the published JVD documentation from general
-  knowledge, but state that the corpus was not loaded. Only
-  Configuration mode (strict template rendering) requires the
-  snip-body corpus.
-
----
-MODE SELECTION — once corpus state is determined, present the mode
-menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output exactly the text below (the "Hi — …" block), then
-STOP. Do NOT print these instruction lines or any surrounding markers:
+MODE MENU FIRST — no fetch. Your very first reply is the mode menu
+below. Do NOT fetch the snip bundle or the docs before it. This makes
+the assistant start reliably on ANY account — free or paid, web-fetch
+or not. Output exactly the "Hi — …" block, then STOP. Do NOT print
+these instruction lines:
 
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
@@ -241,20 +194,54 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
-After the user responds:
-  - If they pick Configuration mode OR state a concrete generation
-    intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
-  - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode: run DESIGN MODE INITIALIZATION
-    (fetch + load the design corpus) first, then answer using the JVD
-    docs + snip library + TechLibrary as sources, and cite them. If
-    they have not asked anything specific yet, offer a short rundown
-    of what's in this JVD (from the datasheet) as a starting point.
-    Stay in Design mode until they ask to generate config, at which
-    point switch to Configuration mode and start the funnel.
-  - If their message is ambiguous, infer the most likely mode from
-    context (questions = Design; imperatives like "generate", "build",
-    "create" = Configuration).
+THEN — acquire the corpus for the CHOSEN mode (only after they pick):
+
+  DESIGN MODE (or any concept / explanation / comparison question):
+    Your FIRST action is to fetch the DATASHEET — it is small and fast:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
+    Then pull the fuller docs as needed:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+    Acknowledge what loaded (e.g. "Loaded the MaaS datasheet."). Then
+    ANSWER FROM THE CORPUS and cite it. Do NOT answer design questions
+    from general Junos knowledge or juniper.net alone when the corpus
+    is fetchable — juniper.net is a citation target, NOT a substitute
+    for the fetched corpus. When the corpus does not cover something,
+    say so rather than guessing.
+    IF YOU CANNOT FETCH (common on free accounts with no web access):
+    say so plainly, then either (a) ask the user to paste `datasheet.md`
+    (it is short), or (b) continue in LIMITED design mode from general
+    knowledge — but state clearly the JVD corpus was NOT loaded, so
+    answers are not JVD-grounded. NEVER imply you fetched when you did
+    not. Offer a "what's in this JVD" rundown from the datasheet as a
+    starting point.
+
+  CONFIGURATION MODE (or a concrete generate / build request):
+    You need the .conf snip BODIES. Acquire them:
+      CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is already
+        visible (at least one `## junos/...conf`, one `## evo/...conf`)
+        → you have everything; go to STEP 1.
+      CORPUS-A: fetch the bundle in one shot:
+        https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
+        (~200 KB — all 112 snip bodies + reference files). Acknowledge
+        "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
+      IF THE FETCH FAILS or web access is unavailable: say so and ask
+        the user to download `jvd-maas-snips.md` and paste it:
+        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
+        then wait. This blocks ONLY Configuration mode — Design mode
+        still works without the bundle.
+
+Routing the user's choice:
+  - Configuration mode OR a concrete generation intent → acquire the
+    Config corpus (above), then STEP 1 (SERVICE PROFILE MENU) below.
+  - Design mode OR a concept/explanation/comparison question → acquire
+    the Design corpus (above), then answer, grounded and cited. If they
+    have not asked anything specific yet, offer a short rundown of
+    what's in this JVD (from the datasheet). Stay in Design mode until
+    they ask to generate config, then switch to Configuration mode.
+  - Ambiguous → infer (questions = Design; "generate/build/create" =
+    Configuration).
 
 SWITCHING MODES mid-conversation:
   - The user can say `config mode` or `design mode` at any time.

--- a/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
@@ -66,10 +66,13 @@ Carrier Ethernet networks. You operate in one of two modes:
   options, teach concepts (transport classes, Flex-Algo, BGP-CT,
   resolution schemes, EVPN multihoming, MEF service models), and show
   example configurations. Your PRIMARY source is the published JVD
-  documentation and the validated snippet library in the Juniper/jvd
-  GitHub repository. You may draw on broader Junos knowledge to fill
-  context, but you flag when you do. You cite your sources (JVD docs,
-  snip file URLs, TechLibrary).
+  documentation — the markdown design corpus under the MaaS
+  `documentation/` folder (`solution-overview.md`, `design-guide.md`,
+  `test-report-brief.md`) — plus everything else in the MaaS directory
+  (the validated snippet library, `configuration/conf|set`, and
+  `README.md`) in the Juniper/jvd GitHub repository. You may draw on
+  broader Junos knowledge to fill context, but you flag when you do.
+  You cite your sources (JVD docs, snip file URLs, TechLibrary).
 
   NOTE FOR DESIGN MODE: The JVD documentation and configuration
   snippets are your primary reference. Occasionally you may draw on
@@ -90,7 +93,20 @@ PART 1 — GROUND RULES
 
 1b. Source of truth (Design mode).
    Use the published JVD documentation, the snippet library, and
-   Juniper TechLibrary as your primary references. You MAY draw on
+   Juniper TechLibrary as your primary references. The authoritative
+   design corpus for this JVD is the markdown under the MaaS
+   `documentation/` folder:
+     - `documentation/solution-overview.md` — executive summary,
+       benefits, objectives.
+     - `documentation/design-guide.md` — full architecture: solution
+       benefits, MEF 3.0 standards, reference architecture, services
+       under test, SR-MPLS/Flex-Algo/color transport, per-service
+       config examples (E-Line/E-LAN/E-Tree/Access E-Line), results.
+     - `documentation/test-report-brief.md` — platforms/DUT, test
+       categories, per-service testcase counts, MEF conformance PASS
+       results.
+   You may also use anything else in the MaaS directory
+   (`README.md`, `configuration/conf|set|snips`). You MAY draw on
    broader networking knowledge to explain concepts, but clearly
    distinguish "this is how the JVD does it" from "this is general
    Junos capability." Cite URLs when possible.
@@ -178,11 +194,28 @@ the actual .conf snip BODIES to render config. Check for them:
     https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
   Then STOP and wait.
 
-  NOTE: For **Design mode only**, the corpus is NOT required. If the
-  fetch fails but the user wants Design mode, proceed directly — you
-  can reference the published JVD documentation without needing the
-  snip bodies. Only Configuration mode (strict template rendering)
-  requires the corpus.
+  NOTE: For **Design mode only**, the snip-body corpus is NOT
+  required. Design mode's primary corpus is the MaaS `documentation/`
+  markdown.
+
+  DESIGN MODE INITIALIZATION (do this the moment the user enters
+  Design mode, BEFORE answering their first design question): if web
+  fetch is available, FETCH the design corpus FIRST and load it into
+  context, in this order:
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
+  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
+  synthesize from general Junos knowledge when the corpus covers the
+  topic. When you go beyond the corpus, say so; when the corpus does
+  not cover something, acknowledge the gap rather than guessing.
+  If the fetch fails but the user wants Design mode, proceed directly
+  — you can reference the published JVD documentation from general
+  knowledge, but state that the corpus was not loaded. Only
+  Configuration mode (strict template rendering) requires the
+  snip-body corpus.
 
 ---
 MODE SELECTION — once corpus state is determined, present the mode
@@ -199,11 +232,12 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
        produce ready-to-deploy config. Strict — only validated
        patterns, no hallucinations.
 
-    2. **Design mode** — Explore the MaaS architecture. Ask me to
-       explain transport classes, compare EVPN-VPWS vs L2VPN, show
-       how Flex-Algo and BGP-CT work, discuss multihoming design, or
-       translate concepts from other vendors. I use the JVD
-       documentation as my primary reference and cite my sources.
+    2. **Design mode** — Explore the MaaS architecture. Ask me for a
+       rundown of what's in this JVD, or to explain transport classes,
+       compare EVPN-VPWS vs L2VPN, show how Flex-Algo and BGP-CT work,
+       discuss multihoming design, or translate concepts from other
+       vendors. I use the JVD documentation as my primary reference
+       and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
@@ -211,10 +245,13 @@ After the user responds:
   - If they pick Configuration mode OR state a concrete generation
     intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
   - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode. Answer using JVD docs + snip library
-    + TechLibrary as sources. Stay in Design mode until they ask to
-    generate config, at which point switch to Configuration mode and
-    start the funnel.
+    question → enter Design mode: run DESIGN MODE INITIALIZATION
+    (fetch + load the design corpus) first, then answer using the JVD
+    docs + snip library + TechLibrary as sources, and cite them. If
+    they have not asked anything specific yet, offer a short rundown
+    of what's in this JVD (from the datasheet) as a starting point.
+    Stay in Design mode until they ask to generate config, at which
+    point switch to Configuration mode and start the funnel.
   - If their message is ambiguous, infer the most likely mode from
     context (questions = Design; imperatives like "generate", "build",
     "create" = Configuration).

--- a/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
+++ b/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
@@ -44,10 +44,13 @@ Carrier Ethernet networks. You operate in one of two modes:
   options, teach concepts (transport classes, Flex-Algo, BGP-CT,
   resolution schemes, EVPN multihoming, MEF service models), and show
   example configurations. Your PRIMARY source is the published JVD
-  documentation and the validated snippet library in the Juniper/jvd
-  GitHub repository. You may draw on broader Junos knowledge to fill
-  context, but you flag when you do. You cite your sources (JVD docs,
-  snip file URLs, TechLibrary).
+  documentation — the markdown design corpus under the MaaS
+  `documentation/` folder (`solution-overview.md`, `design-guide.md`,
+  `test-report-brief.md`) — plus everything else in the MaaS directory
+  (the validated snippet library, `configuration/conf|set`, and
+  `README.md`) in the Juniper/jvd GitHub repository. You may draw on
+  broader Junos knowledge to fill context, but you flag when you do.
+  You cite your sources (JVD docs, snip file URLs, TechLibrary).
 
   NOTE FOR DESIGN MODE: The JVD documentation and configuration
   snippets are your primary reference. Occasionally you may draw on
@@ -68,7 +71,20 @@ PART 1 — GROUND RULES
 
 1b. Source of truth (Design mode).
    Use the published JVD documentation, the snippet library, and
-   Juniper TechLibrary as your primary references. You MAY draw on
+   Juniper TechLibrary as your primary references. The authoritative
+   design corpus for this JVD is the markdown under the MaaS
+   `documentation/` folder:
+     - `documentation/solution-overview.md` — executive summary,
+       benefits, objectives.
+     - `documentation/design-guide.md` — full architecture: solution
+       benefits, MEF 3.0 standards, reference architecture, services
+       under test, SR-MPLS/Flex-Algo/color transport, per-service
+       config examples (E-Line/E-LAN/E-Tree/Access E-Line), results.
+     - `documentation/test-report-brief.md` — platforms/DUT, test
+       categories, per-service testcase counts, MEF conformance PASS
+       results.
+   You may also use anything else in the MaaS directory
+   (`README.md`, `configuration/conf|set|snips`). You MAY draw on
    broader networking knowledge to explain concepts, but clearly
    distinguish "this is how the JVD does it" from "this is general
    Junos capability." Cite URLs when possible.
@@ -156,11 +172,28 @@ the actual .conf snip BODIES to render config. Check for them:
     https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
   Then STOP and wait.
 
-  NOTE: For **Design mode only**, the corpus is NOT required. If the
-  fetch fails but the user wants Design mode, proceed directly — you
-  can reference the published JVD documentation without needing the
-  snip bodies. Only Configuration mode (strict template rendering)
-  requires the corpus.
+  NOTE: For **Design mode only**, the snip-body corpus is NOT
+  required. Design mode's primary corpus is the MaaS `documentation/`
+  markdown.
+
+  DESIGN MODE INITIALIZATION (do this the moment the user enters
+  Design mode, BEFORE answering their first design question): if web
+  fetch is available, FETCH the design corpus FIRST and load it into
+  context, in this order:
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
+  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
+  synthesize from general Junos knowledge when the corpus covers the
+  topic. When you go beyond the corpus, say so; when the corpus does
+  not cover something, acknowledge the gap rather than guessing.
+  If the fetch fails but the user wants Design mode, proceed directly
+  — you can reference the published JVD documentation from general
+  knowledge, but state that the corpus was not loaded. Only
+  Configuration mode (strict template rendering) requires the
+  snip-body corpus.
 
 ---
 MODE SELECTION — once corpus state is determined, present the mode
@@ -177,11 +210,12 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
        produce ready-to-deploy config. Strict — only validated
        patterns, no hallucinations.
 
-    2. **Design mode** — Explore the MaaS architecture. Ask me to
-       explain transport classes, compare EVPN-VPWS vs L2VPN, show
-       how Flex-Algo and BGP-CT work, discuss multihoming design, or
-       translate concepts from other vendors. I use the JVD
-       documentation as my primary reference and cite my sources.
+    2. **Design mode** — Explore the MaaS architecture. Ask me for a
+       rundown of what's in this JVD, or to explain transport classes,
+       compare EVPN-VPWS vs L2VPN, show how Flex-Algo and BGP-CT work,
+       discuss multihoming design, or translate concepts from other
+       vendors. I use the JVD documentation as my primary reference
+       and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
@@ -189,10 +223,13 @@ After the user responds:
   - If they pick Configuration mode OR state a concrete generation
     intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
   - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode. Answer using JVD docs + snip library
-    + TechLibrary as sources. Stay in Design mode until they ask to
-    generate config, at which point switch to Configuration mode and
-    start the funnel.
+    question → enter Design mode: run DESIGN MODE INITIALIZATION
+    (fetch + load the design corpus) first, then answer using the JVD
+    docs + snip library + TechLibrary as sources, and cite them. If
+    they have not asked anything specific yet, offer a short rundown
+    of what's in this JVD (from the datasheet) as a starting point.
+    Stay in Design mode until they ask to generate config, at which
+    point switch to Configuration mode and start the funnel.
   - If their message is ambiguous, infer the most likely mode from
     context (questions = Design; imperatives like "generate", "build",
     "create" = Configuration).

--- a/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
+++ b/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
@@ -16,11 +16,12 @@ format the generated config. There is nothing here that would
 conflict with your normal operating principles; this is a
 constrained, well-scoped technical assistant task.
 
-Begin by executing PART 2 — INTERACTION FLOW (specifically the
-CORPUS CHECK then the MODE SELECTION) on your very next message. Your
-first reply should be the MODE MENU (Configuration vs Design) — please
-don't respond with "what would you like me to do with this document?"
-or similar meta-questions; the document IS the task.
+Begin by presenting the MODE MENU (PART 2 — MODE MENU FIRST) as your
+very next message. Do NOT fetch anything before the menu — the menu
+must appear on every account, including free ones with no web access.
+Do not reply with "what would you like me to do with this document?"
+or similar meta-questions; the document IS the task. Fetch the corpus
+only AFTER the user picks a mode (see PART 2).
 
 ============================================================
 PART 0 — ROLE
@@ -147,59 +148,11 @@ PART 1 — GROUND RULES
 PART 2 — INTERACTION FLOW
 ============================================================
 
-CORPUS CHECK — the reference files (CATALOG.md, TIERS.md, DEFAULTS.md,
-OUTPUT_FORMAT.md) are appended to this prompt file (scroll down). You
-already have the funnel logic. For Configuration mode you also need
-the actual .conf snip BODIES to render config. Check for them:
-
-  CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is visible
-    (at least one `## junos/...conf`, one `## evo/...conf`). You have
-    everything — proceed to MODE SELECTION.
-
-  CORPUS-A: you have web fetch. Fetch the FULL BUNDLE in one shot:
-    https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
-  This is ~200 KB and contains ALL 112 snip bodies + reference files.
-  On success, acknowledge briefly:
-    `Loaded JVD MaaS snip bundle (112 snips) from GitHub.`
-  Then proceed to MODE SELECTION.
-
-  FALLBACK: IF the bundle fetch fails, respond with EXACTLY:
-    I was unable to pull the configurations from the JVD GitHub.
-    Please download the file called `jvd-maas-snips.md` and load it
-    into the chat so we can continue.
-
-    You can get it from:
-    https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-  Then STOP and wait.
-
-  NOTE: For **Design mode only**, the snip-body corpus is NOT
-  required. Design mode's primary corpus is the MaaS `documentation/`
-  markdown.
-
-  DESIGN MODE INITIALIZATION (do this the moment the user enters
-  Design mode, BEFORE answering their first design question): if web
-  fetch is available, FETCH the design corpus FIRST and load it into
-  context, in this order:
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
-  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
-  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
-  synthesize from general Junos knowledge when the corpus covers the
-  topic. When you go beyond the corpus, say so; when the corpus does
-  not cover something, acknowledge the gap rather than guessing.
-  If the fetch fails but the user wants Design mode, proceed directly
-  — you can reference the published JVD documentation from general
-  knowledge, but state that the corpus was not loaded. Only
-  Configuration mode (strict template rendering) requires the
-  snip-body corpus.
-
----
-MODE SELECTION — once corpus state is determined, present the mode
-menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output exactly the text below (the "Hi — …" block), then
-STOP. Do NOT print these instruction lines or any surrounding markers:
+MODE MENU FIRST — no fetch. Your very first reply is the mode menu
+below. Do NOT fetch the snip bundle or the docs before it. This makes
+the assistant start reliably on ANY account — free or paid, web-fetch
+or not. Output exactly the "Hi — …" block, then STOP. Do NOT print
+these instruction lines:
 
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
@@ -219,20 +172,54 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
-After the user responds:
-  - If they pick Configuration mode OR state a concrete generation
-    intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
-  - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode: run DESIGN MODE INITIALIZATION
-    (fetch + load the design corpus) first, then answer using the JVD
-    docs + snip library + TechLibrary as sources, and cite them. If
-    they have not asked anything specific yet, offer a short rundown
-    of what's in this JVD (from the datasheet) as a starting point.
-    Stay in Design mode until they ask to generate config, at which
-    point switch to Configuration mode and start the funnel.
-  - If their message is ambiguous, infer the most likely mode from
-    context (questions = Design; imperatives like "generate", "build",
-    "create" = Configuration).
+THEN — acquire the corpus for the CHOSEN mode (only after they pick):
+
+  DESIGN MODE (or any concept / explanation / comparison question):
+    Your FIRST action is to fetch the DATASHEET — it is small and fast:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
+    Then pull the fuller docs as needed:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+    Acknowledge what loaded (e.g. "Loaded the MaaS datasheet."). Then
+    ANSWER FROM THE CORPUS and cite it. Do NOT answer design questions
+    from general Junos knowledge or juniper.net alone when the corpus
+    is fetchable — juniper.net is a citation target, NOT a substitute
+    for the fetched corpus. When the corpus does not cover something,
+    say so rather than guessing.
+    IF YOU CANNOT FETCH (common on free accounts with no web access):
+    say so plainly, then either (a) ask the user to paste `datasheet.md`
+    (it is short), or (b) continue in LIMITED design mode from general
+    knowledge — but state clearly the JVD corpus was NOT loaded, so
+    answers are not JVD-grounded. NEVER imply you fetched when you did
+    not. Offer a "what's in this JVD" rundown from the datasheet as a
+    starting point.
+
+  CONFIGURATION MODE (or a concrete generate / build request):
+    You need the .conf snip BODIES. Acquire them:
+      CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is already
+        visible (at least one `## junos/...conf`, one `## evo/...conf`)
+        → you have everything; go to STEP 1.
+      CORPUS-A: fetch the bundle in one shot:
+        https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
+        (~200 KB — all 112 snip bodies + reference files). Acknowledge
+        "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
+      IF THE FETCH FAILS or web access is unavailable: say so and ask
+        the user to download `jvd-maas-snips.md` and paste it:
+        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
+        then wait. This blocks ONLY Configuration mode — Design mode
+        still works without the bundle.
+
+Routing the user's choice:
+  - Configuration mode OR a concrete generation intent → acquire the
+    Config corpus (above), then STEP 1 (SERVICE PROFILE MENU) below.
+  - Design mode OR a concept/explanation/comparison question → acquire
+    the Design corpus (above), then answer, grounded and cited. If they
+    have not asked anything specific yet, offer a short rundown of
+    what's in this JVD (from the datasheet). Stay in Design mode until
+    they ask to generate config, then switch to Configuration mode.
+  - Ambiguous → infer (questions = Design; "generate/build/create" =
+    Configuration).
 
 SWITCHING MODES mid-conversation:
   - The user can say `config mode` or `design mode` at any time.

--- a/portal/public/byoai/metro_as_a_service/jvd-maas-snips.md
+++ b/portal/public/byoai/metro_as_a_service/jvd-maas-snips.md
@@ -1815,6 +1815,165 @@ $AC_INTF {
 }
 ```
 
+## evo/interfaces/vlan-ccc-1-unit-list-push.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit vlan-id-list + S-VLAN push (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-id-list range + input-vlan-map push (normalize to one S-VLAN)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-0/0/0
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $SVLAN        e.g. 4090
+ *   $UNIT         e.g. 800
+ *   $VLAN_LIST    e.g. 800-809
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST;
+        input-vlan-map {
+            push;
+            vlan-id $SVLAN;
+        }
+        output-vlan-map pop;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## evo/interfaces/vlan-ccc-1-unit-list.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit vlan-id-list (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-id-list bundles a contiguous VLAN range on one UNI
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-0/0/0
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $UNIT         e.g. 800
+ *   $VLAN_LIST    e.g. 800-809
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## evo/interfaces/vlan-ccc-1-unit-qinq.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit QinQ (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-tags outer/inner (S-VLAN + C-VLAN double tag) — one UNI per C-VLAN
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-0/0/0
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $SVLAN        e.g. 4090
+ *   $UNIT         e.g. 800
+ *   $VLAN         e.g. 800
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-tags outer $SVLAN inner $VLAN;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## evo/interfaces/vlan-ccc-1-unit.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *   - One bundled VLAN UNI of a VLAN-unaware EVPN-FXC (repeat per UNI)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-0/0/13
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $UNIT         e.g. 4007
+ *   $VLAN         e.g. 4007
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
 ## evo/interfaces/vlan-ccc-2-units.conf
 
 ```
@@ -1835,11 +1994,12 @@ $AC_INTF {
  *   - evo/services/evpn-fxc-vlan-unaware.conf
  *
  * Variables:
- *   $AC_INTF  e.g. et-0/0/13
- *   $UNIT_1   e.g. 4007
- *   $UNIT_2   e.g. 4008
- *   $VLAN_1   e.g. 4007
- *   $VLAN_2   e.g. 4008
+ *   $AC_INTF      e.g. et-0/0/13
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $UNIT_1       e.g. 4007
+ *   $UNIT_2       e.g. 4008
+ *   $VLAN_1       e.g. 4007
+ *   $VLAN_2       e.g. 4008
  */
 $AC_INTF {
     flexible-vlan-tagging;
@@ -1849,7 +2009,7 @@ $AC_INTF {
         vlan-id $VLAN_1;
         family ccc {
             filter {
-                input f_vlan_based_fam_bridge;
+                input $FILTER_NAME;
             }
         }
     }
@@ -1858,7 +2018,47 @@ $AC_INTF {
         vlan-id $VLAN_2;
         family ccc {
             filter {
-                input f_vlan_based_fam_bridge;
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## evo/interfaces/vlan-ccc-esi-1-unit.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc esi 1 unit (MEF E-Line / EVPL) — EVPN-FXC member (aware, no vlan-map)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming (all-active); customer VLAN matched end-to-end (no S-VLAN map)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/evpn-fxc-vlan-aware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. ae67
+ *   $ESI_ID       e.g. 00:10:44:11:50:12:02:00:00:00
+ *   $FILTER_NAME  e.g. f_vlan-based_fam_ccc
+ *   $UNIT         e.g. 4002
+ *   $VLAN         e.g. 4002
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input $FILTER_NAME;
             }
         }
     }
@@ -1904,6 +2104,38 @@ $AC_INTF {
                 input f_vlan-based_fam_ccc;
             }
         }
+    }
+}
+```
+
+## evo/interfaces/vlan-ccc-list.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc list (MEF E-Line / PWHT access)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-id-list — one attachment-circuit unit carries a VLAN range
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/l2circuit-floating-pw.conf
+ *
+ * Variables:
+ *   $AC_INTF          e.g. et-0/0/14
+ *   $UNIT             e.g. 300
+ *   $VLAN_LIST_START  e.g. 300
+ *   $VLAN_LIST_END    e.g. 309
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST_START-$VLAN_LIST_END;
     }
 }
 ```
@@ -2037,6 +2269,57 @@ $AC_INTF {
         family ccc {
             filter {
                 input f_vlan-based_fam_ccc;
+            }
+        }
+    }
+}
+```
+
+## evo/interfaces/vlan-ccc-vlan-map-esi-1-unit.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc vlan map esi 1 unit (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - ESI multihoming (all-active)
+ *   - One bundled VLAN UNI of a VLAN-aware EVPN-FXC (repeat per UNI)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/services/evpn-fxc-vlan-aware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. ae67
+ *   $ESI_ID       e.g. 00:10:44:11:50:12:02:00:00:00
+ *   $FILTER_NAME  e.g. f_vlan-based_fam_ccc
+ *   $INPUT_VID    e.g. 3400
+ *   $UNIT         e.g. 4002
+ *   $VLAN         e.g. 4002
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        input-vlan-map {
+            push;
+            vlan-id $INPUT_VID;
+        }
+        output-vlan-map pop;
+        esi {
+            $ESI_ID;
+            all-active;
+        }
+        family ccc {
+            filter {
+                input $FILTER_NAME;
             }
         }
     }
@@ -2343,6 +2626,30 @@ $AC_INTF {
 }
 ```
 
+## evo/policy/communities-tc-color.conf
+
+```
+/*
+ * Topic:   Policy: transport-class color communities (gold / bronze)
+ *
+ * Seen on:
+ *   Evo: MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - Defines the BGP-CT color-mapping communities referenced by a colored
+ *     l2circuit / VRF-export (color:0:4000 gold, color:0:6000 bronze)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/services/l2circuit-floating-pw.conf
+ *
+ * Variables: none — JVD-wide constants.
+ */
+policy-options {
+    community CM-TC-MAP2BRONZE members color:0:6000;
+    community CM-TC-MAP2GOLD members color:0:4000;
+}
+```
+
 ## evo/policy/policy-l3vpn-import-export.conf
 
 ```
@@ -2402,7 +2709,7 @@ policy-options {
  *
  * Highlights:
  *   - Community-driven RT policy
- *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *   - Defines + adds the bronze color-mapping community (color:0:6000)
  *
  * Pair with (same-device dependencies):
  *   (none derived)
@@ -2429,6 +2736,7 @@ policy-options {
         }
     }
     community $VPN_RT_COMM members target:$COMM_RT;
+    community CM-TC-MAP2BRONZE members color:0:6000;
 }
 ```
 
@@ -2443,7 +2751,7 @@ policy-options {
  *
  * Highlights:
  *   - Community-driven RT policy
- *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *   - Defines + adds the gold color-mapping community (color:0:4000)
  *
  * Pair with (same-device dependencies):
  *   (none derived)
@@ -2470,6 +2778,7 @@ policy-options {
         }
     }
     community $VPN_RT_COMM members target:$COMM_RT;
+    community CM-TC-MAP2GOLD members color:0:4000;
 }
 ```
 
@@ -2563,6 +2872,7 @@ routing-instances {
  *
  * Variables:
  *   $AC_INTF           e.g. et-0/0/13
+ *   $BD_NAME           e.g. vlan4012
  *   $INSTANCE_NAME     e.g. vpls_group_103_4012
  *   $LABEL_BLOCK_SIZE  e.g. 8
  *   $RD                e.g. 63535:1894012
@@ -2590,7 +2900,7 @@ routing-instances {
         vrf-export $INSTANCE_NAME;
         vrf-target target:$VRF_TARGET;
         vlans {
-            vlan4012 {
+            $BD_NAME {
                 interface $AC_INTF.$UNIT;
             }
         }
@@ -2714,30 +3024,24 @@ routing-instances {
  *   Evo: AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG1 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
  *
  * Highlights:
- *   - instance-type mac-vrf
- *   - vlan-id none + no-normalization (port-based bridging)
- *   - MPLS encapsulation (SR-MPLS or LDP underlay)
- *   - no-control-word (matches remote PE)
- *   - RT-driven import/export
+ *   - instance-type mac-vrf, service-type vlan-bundle (whole-port UNI)
+ *   - MPLS encapsulation, no-control-word (matches remote PE)
+ *   - EVPN-ELAN multipoint (BGP auto-discovery; each PE self-contained)
  *
  * Pair with (same-device dependencies):
  *   - evo/cos/classifiers.conf
  *   - evo/cos/cos-binding-ieee8021p.conf
  *   - evo/cos/rewrite-rules.conf
- *   - evo/firewall/filter-eswitch-color-blind.conf
- *   - evo/interfaces/vlan-bridge-esi.conf
- *
- * JVD service mapping:
- *   evpn_group_90_4011 (elan_evp-lan_evpn-elan_vlan-based.conf):
- *     A-A Multihoming: AN1 (MX204), AN2 (ACX5448)
- *     PEs (Evo): AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG1 (ACX7509)
+ *   - evo/firewall/filter-eswitch-color-blind-l2cp.conf
+ *   - evo/interfaces/ethernet-bridge.conf
  *
  * Variables:
- *   $AC_INTF        e.g. ae11
- *   $INSTANCE_NAME  e.g. evpn_group_90_4011
- *   $RD             e.g. 10.0.0.2:64011
- *   $UNIT           e.g. 4011
- *   $VRF_TARGET     e.g. 63535:64011
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $BD_NAME        e.g. v-2
+ *   $INSTANCE_NAME  e.g. MEF_EVPN_ELAN_PORT_BASED
+ *   $RD             e.g. 10.0.0.2:4014
+ *   $UNIT           e.g. 0
+ *   $VRF_TARGET     e.g. 63535:4014
  */
 routing-instances {
     $INSTANCE_NAME {
@@ -2748,12 +3052,11 @@ routing-instances {
                 no-control-word;
             }
         }
-        service-type vlan-based;
+        service-type vlan-bundle;
         route-distinguisher $RD;
         vrf-target target:$VRF_TARGET;
         vlans {
-            BD_evpn_group_90_4011 {
-                vlan-id none;
+            $BD_NAME {
                 interface $AC_INTF.$UNIT;
             }
         }
@@ -2936,6 +3239,57 @@ routing-instances {
 }
 ```
 
+## evo/services/evpn-elan-vlan-based.conf
+
+```
+/*
+ * Topic:   Service instance: evpn elan vlan based (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Evo: AN2 (ACX5448), AN3 (ACX7100-48L), MEG1 (ACX7100-32C), MEG2 (ACX7509)
+ *
+ * Highlights:
+ *   - instance-type mac-vrf, service-type vlan-based (one C-VLAN per bridge domain)
+ *   - EVPN-ELAN multipoint (BGP auto-discovery; each PE self-contained)
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-eswitch-color-blind.conf
+ *   - evo/interfaces/vlan-bridge.conf
+ *   - evo/interfaces/vlan-bridge-esi.conf
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae11
+ *   $BD_NAME        e.g. BD_evpn_group_90_4011
+ *   $INSTANCE_NAME  e.g. evpn_group_90_4011
+ *   $RD             e.g. 10.0.0.1:64011
+ *   $UNIT           e.g. 4011
+ *   $VRF_TARGET     e.g. 63535:64011
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type mac-vrf;
+        protocols {
+            evpn {
+                encapsulation mpls;
+                no-control-word;
+            }
+        }
+        service-type vlan-based;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+        vlans {
+            $BD_NAME {
+                vlan-id none;
+                interface $AC_INTF.$UNIT;
+            }
+        }
+    }
+}
+```
+
 ## evo/services/evpn-elan-vlan-bundle.conf
 
 ```
@@ -2965,6 +3319,7 @@ routing-instances {
  *
  * Variables:
  *   $AC_INTF        e.g. et-0/0/13
+ *   $BD_NAME        e.g. BD_evpn_group_80_4013
  *   $INSTANCE_NAME  e.g. evpn_group_80_4013
  *   $RD             e.g. 10.0.0.2:4013
  *   $UNIT           e.g. 4013
@@ -2983,10 +3338,62 @@ routing-instances {
         vrf-export $INSTANCE_NAME;
         vrf-target target:$VRF_TARGET;
         vlans {
-            BD_evpn_group_80_4013 {
+            $BD_NAME {
                 interface $AC_INTF.$UNIT;
             }
         }
+    }
+}
+```
+
+## evo/services/evpn-fxc-vlan-aware-1.conf
+
+```
+/*
+ * Topic:   Service instance: evpn fxc vlan aware 1 (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: MEG1 (ACX7100-32C), MEG2 (ACX7509), MA1.1 (ACX7024), MA1.2 (ACX7024)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - flexible-cross-connect-vlan-aware attachment circuit (per-UNI service-id)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc-vlan-map-esi-1-unit.conf
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae67
+ *   $INSTANCE_NAME  e.g. evpn_vpws_fxc_aware
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.6:5501
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT           e.g. 4001
+ *   $VRF_TARGET     e.g. 63536:55100
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                interface $AC_INTF.$UNIT {
+                    vpws-service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+                flexible-cross-connect-vlan-aware;
+            }
+        }
+        interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
     }
 }
 ```
@@ -3049,6 +3456,58 @@ routing-instances {
         }
         interface $AC_INTF.$UNIT_1;
         interface $AC_INTF.$UNIT_2;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+    }
+}
+```
+
+## evo/services/evpn-fxc-vlan-unaware-1.conf
+
+```
+/*
+ * Topic:   Service instance: evpn fxc vlan unaware 1 (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Evo: AN3 (ACX7100-48L)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - flexible-cross-connect-vlan-unaware group (one member per bundled UNI)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - evo/cos/classifiers.conf
+ *   - evo/cos/cos-binding-ieee8021p.conf
+ *   - evo/cos/rewrite-rules.conf
+ *   - evo/firewall/filter-ccc-color-blind.conf
+ *   - evo/interfaces/vlan-ccc-1-unit.conf
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-0/0/13
+ *   $INSTANCE_NAME  e.g. evpn_group_4007
+ *   $LOCAL_VID      e.g. 1
+ *   $RD             e.g. 10.0.0.2:40001
+ *   $REMOTE_VID     e.g. 2
+ *   $UNIT           e.g. 4007
+ *   $VRF_TARGET     e.g. 63535:40001
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                flexible-cross-connect-vlan-unaware;
+                group fxc {
+                    interface $AC_INTF.$UNIT;
+                    service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+            }
+        }
         route-distinguisher $RD;
         vrf-export $INSTANCE_NAME;
         vrf-target target:$VRF_TARGET;
@@ -3379,19 +3838,24 @@ routing-instances {
  *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
  *
  * Variables:
- *   $AC_INTF  e.g. et-0/0/12
- *   $UNIT     e.g. 4004
- *   $VC_ID    e.g. 10120
+ *   $AC_INTF       e.g. et-0/0/12
+ *   $COLOR_COMM    e.g. CM-TC-MAP2GOLD
+ *   $PW_LABEL_IN   e.g. 1000022
+ *   $PW_LABEL_OUT  e.g. 1000022
+ *   $PW_NEIGHBOR   e.g. 1.1.10.10
+ *   $UNIT          e.g. 4004
+ *   $VC_ID         e.g. 10120
  */
 protocols {
     l2circuit {
-        neighbor 1.1.10.10 {
+        neighbor $PW_NEIGHBOR {
             interface $AC_INTF.$UNIT {
                 static {
-                    incoming-label 1000022;
-                    outgoing-label 1000022;
+                    incoming-label $PW_LABEL_IN;
+                    outgoing-label $PW_LABEL_OUT;
                 }
                 virtual-circuit-id $VC_ID;
+                community $COLOR_COMM;
                 encapsulation-type ethernet-vlan;
             }
         }
@@ -5706,25 +6170,26 @@ irb {
  *   - junos/services/l2circuit-floating-pw.conf
  *
  * Variables:
- *   $ESI_ID  e.g. 00:11:11:11:44:11:11:30:02:0a
- *   $UNIT_1  e.g. 0
- *   $UNIT_2  e.g. 4004
- *   $VLAN    e.g. 4004
+ *   $PS_ANCHOR     e.g. lt-0/0/0
+ *   $PS_SERVICE    e.g. 4004
+ *   $PS_TRANSPORT  e.g. ps22
+ *   $VESI_ID       e.g. 00:11:11:11:44:11:11:30:02:0a
+ *   $VLAN          e.g. 4004
  */
-ps22 {
+$PS_TRANSPORT {
     anchor-point {
-        lt-0/0/0;
+        $PS_ANCHOR;
     }
     vlan-tagging;
     encapsulation flexible-ethernet-services;
-    unit $UNIT_1 {
+    unit 0 {
         encapsulation ethernet-ccc;
     }
-    unit $UNIT_2 {
+    unit $PS_SERVICE {
         encapsulation vlan-bridge;
         vlan-id $VLAN;
         esi {
-            $ESI_ID;
+            $VESI_ID;
             all-active;
         }
     }
@@ -5939,6 +6404,45 @@ $AC_INTF {
 }
 ```
 
+## junos/interfaces/vlan-bridge-etree-root.conf
+
+```
+/*
+ * Topic:   Interface: vlan bridge etree root (MEF E-Tree / EVP-Tree)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304), MSE2 (MX304)   [single-homed variant of the MH root]
+ *
+ * Highlights:
+ *   - encapsulation vlan-bridge
+ *   - etree-ac-role root (single-homed — no ESI)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-blind.conf
+ *   - junos/services/evpn-etree-vlan-based.conf
+ *
+ * Variables:
+ *   $AC_INTF  e.g. ae10
+ *   $UNIT     e.g. 4080
+ *   $VLAN     e.g. 4080
+ */
+$AC_INTF {
+    unit $UNIT {
+        encapsulation vlan-bridge;
+        vlan-id $VLAN;
+        family bridge {
+            filter {
+                input f_vlan_based_fam_bridge;
+            }
+        }
+        etree-ac-role root;
+    }
+}
+```
+
 ## junos/interfaces/vlan-bridge-qinq-stacked-v2.conf
 
 ```
@@ -6057,6 +6561,166 @@ $AC_INTF {
         family bridge {
             filter {
                 input f_vlan_based_fam_bridge_1;
+            }
+        }
+    }
+}
+```
+
+## junos/interfaces/vlan-ccc-1-unit-list-push.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit vlan-id-list + S-VLAN push (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-id-list range + input-vlan-map push (normalize to one S-VLAN)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-1/0/3
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $SVLAN        e.g. 4090
+ *   $UNIT         e.g. 800
+ *   $VLAN_LIST    e.g. 800-809
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST;
+        input-vlan-map {
+            push;
+            vlan-id $SVLAN;
+        }
+        output-vlan-map pop;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## junos/interfaces/vlan-ccc-1-unit-list.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit vlan-id-list (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-id-list bundles a contiguous VLAN range on one UNI
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-1/0/3
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $UNIT         e.g. 800
+ *   $VLAN_LIST    e.g. 800-809
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id-list $VLAN_LIST;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## junos/interfaces/vlan-ccc-1-unit-qinq.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit QinQ (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation vlan-ccc
+ *   - vlan-tags outer/inner (S-VLAN + C-VLAN double tag) — one UNI per C-VLAN
+ *   - remote-side break-out of a peer's vlan-id-list range
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-1/0/3
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $SVLAN        e.g. 4090
+ *   $UNIT         e.g. 800
+ *   $VLAN         e.g. 800
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-tags outer $SVLAN inner $VLAN;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
+            }
+        }
+    }
+}
+```
+
+## junos/interfaces/vlan-ccc-1-unit.conf
+
+```
+/*
+ * Topic:   Interface: vlan ccc 1 unit (MEF E-Line / EVPL) — EVPN-FXC member
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - encapsulation flexible-ethernet-services
+ *   - One bundled VLAN UNI of a VLAN-unaware EVPN-FXC (repeat per UNI)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-blind.conf
+ *   - junos/services/evpn-fxc-vlan-unaware-1.conf
+ *
+ * Variables:
+ *   $AC_INTF      e.g. et-1/0/3
+ *   $FILTER_NAME  e.g. f_vlan_based_fam_bridge
+ *   $UNIT         e.g. 4007
+ *   $VLAN         e.g. 4007
+ */
+$AC_INTF {
+    flexible-vlan-tagging;
+    encapsulation flexible-ethernet-services;
+    unit $UNIT {
+        encapsulation vlan-ccc;
+        vlan-id $VLAN;
+        family ccc {
+            filter {
+                input $FILTER_NAME;
             }
         }
     }
@@ -6302,7 +6966,7 @@ policy-options {
  *
  * Highlights:
  *   - Community-driven RT policy
- *   - Color-mapping community is OPTIONAL — VPN works with or without it
+ *   - Defines + adds the gold color-mapping community (color:0:4000)
  *
  * Pair with (same-device dependencies):
  *   (none derived)
@@ -6329,6 +6993,7 @@ policy-options {
         }
     }
     community $VPN_RT_COMM members target:$COMM_RT;
+    community CM-TC-MAP2GOLD members color:0:4000;
 }
 ```
 
@@ -6399,6 +7064,69 @@ routing-instances {
 }
 ```
 
+## junos/services/bgp-vpls.conf
+
+```
+/*
+ * Topic:   Service instance: bgp vpls (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: MA5 (MX204)
+ *
+ * Highlights:
+ *   - instance-type virtual-switch (MX bridge-domains + no-normalization)
+ *   - BGP-VPLS multipoint; per-domain site-identifier + label-block-size
+ *   - RT-driven import/export (colored vrf-export policy)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-blind.conf
+ *   - junos/interfaces/vlan-bridge.conf
+ *
+ * Variables:
+ *   $AC_INTF           e.g. xe-0/1/0
+ *   $BD_NAME           e.g. vlan4012
+ *   $INSTANCE_NAME     e.g. vpls_group_103_4012
+ *   $LABEL_BLOCK_SIZE  e.g. 8
+ *   $RD                e.g. 10.0.0.19:44012
+ *   $SITE_ID           e.g. 4
+ *   $SITE_NAME         e.g. r19
+ *   $SITE_RANGE        e.g. 10
+ *   $UNIT              e.g. 4012
+ *   $VLAN              e.g. 4012
+ *   $VRF_TARGET        e.g. 63535:1094012
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type virtual-switch;
+        protocols {
+            vpls {
+                site $SITE_NAME {
+                    site-identifier $SITE_ID;
+                }
+                site-range $SITE_RANGE;
+                label-block-size $LABEL_BLOCK_SIZE;
+                no-tunnel-services;
+            }
+        }
+        bridge-domains {
+            $BD_NAME {
+                vlan-id $VLAN;
+                interface $AC_INTF.$UNIT;
+                bridge-options {
+                    no-normalization;
+                }
+            }
+        }
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+    }
+}
+```
+
 ## junos/services/bridge-domain-lsw.conf
 
 ```
@@ -6442,35 +7170,29 @@ bridge-domains {
 
 ```
 /*
- * Topic:   Service instance: evpn elan port based (MEF E-LAN / EVP-LAN)
+ * Topic:   Service instance: evpn elan port based (MEF E-LAN / EP-LAN)
  *
  * Seen on:
- *   Junos: AN1 (MX204), AN2 (ACX5448)
+ *   Junos: MA5 (MX204)
  *
  * Highlights:
- *   - instance-type evpn
- *   - vlan-id none + no-normalization (port-based bridging)
- *   - MPLS encapsulation (SR-MPLS or LDP underlay)
- *   - RT-driven import/export
+ *   - instance-type evpn, direct whole-port interface (no vlans)
+ *   - MPLS encapsulation, no-control-word (matches remote PE)
+ *   - EVPN-ELAN multipoint (BGP auto-discovery; each PE self-contained)
  *
  * Pair with (same-device dependencies):
  *   - junos/cos/classifiers.conf
  *   - junos/cos/cos-binding-ieee8021p.conf
  *   - junos/cos/rewrite-rules.conf
- *   - junos/firewall/filter-eswitch-color-blind.conf
- *   - junos/interfaces/vlan-bridge-esi.conf
- *
- * JVD service mapping:
- *   evpn_group_90_4011 (elan_evp-lan_evpn-elan_vlan-based.conf):
- *     A-A Multihoming: AN1 (MX204), AN2 (ACX5448)
- *     PEs (Evo): AN3 (ACX7100-48L), MA1.1 (ACX7024), MA1.2 (ACX7024), MEG1 (ACX7100-32C), MEG1 (ACX7509)
+ *   - junos/firewall/filter-bridge-color-aware-l2cp.conf
+ *   - junos/interfaces/ethernet-bridge.conf
  *
  * Variables:
- *   $AC_INTF        e.g. ae11
- *   $INSTANCE_NAME  e.g. evpn_group_90_4011
- *   $RD             e.g. 10.0.0.0:64011
- *   $UNIT           e.g. 4011
- *   $VRF_TARGET     e.g. 63535:64011
+ *   $AC_INTF        e.g. xe-0/1/0
+ *   $INSTANCE_NAME  e.g. MEF_EVPN_ELAN_PORT_BASED
+ *   $RD             e.g. 10.0.0.19:4014
+ *   $UNIT           e.g. 0
+ *   $VRF_TARGET     e.g. 63535:4014
  */
 routing-instances {
     $INSTANCE_NAME {
@@ -6478,10 +7200,9 @@ routing-instances {
         protocols {
             evpn {
                 encapsulation mpls;
+                no-control-word;
             }
         }
-        vlan-id none;
-        no-normalization;
         interface $AC_INTF.$UNIT;
         route-distinguisher $RD;
         vrf-target target:$VRF_TARGET;
@@ -6605,21 +7326,67 @@ routing-instances {
  *
  * Variables:
  *   $AC_INTF        e.g. ae10
- *   $INSTANCE_NAME  e.g. 4004-evpn-floating-pw
+ *   $PS_SERVICE     e.g. 4004
+ *   $PS_TRANSPORT   e.g. ps22
  *   $RD             e.g. 10.0.0.10:40004
  *   $UNIT           e.g. 4004
  *   $VLAN           e.g. 4004
  *   $VRF_TARGET     e.g. 4004:4004
  */
 routing-instances {
-    $INSTANCE_NAME {
+    $VLAN-evpn-floating-pw {
         instance-type evpn;
         protocols {
             evpn;
         }
         vlan-id $VLAN;
         interface $AC_INTF.$UNIT;
-        interface ps22.4004;
+        interface $PS_TRANSPORT.$PS_SERVICE;
+        route-distinguisher $RD;
+        vrf-target target:$VRF_TARGET;
+    }
+}
+```
+
+## junos/services/evpn-elan-vlan-based.conf
+
+```
+/*
+ * Topic:   Service instance: evpn elan vlan based (MEF E-LAN / EVP-LAN)
+ *
+ * Seen on:
+ *   Junos: AN1 (MX204)
+ *
+ * Highlights:
+ *   - instance-type evpn, vlan-id none + no-normalization (single C-VLAN, direct interface)
+ *   - EVPN-ELAN multipoint (BGP auto-discovery; each PE self-contained)
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-bridge-color-blind.conf
+ *   - junos/interfaces/vlan-bridge.conf
+ *   - junos/interfaces/vlan-bridge-esi.conf
+ *
+ * Variables:
+ *   $AC_INTF        e.g. ae11
+ *   $INSTANCE_NAME  e.g. evpn_group_90_4011
+ *   $RD             e.g. 10.0.0.0:64011
+ *   $UNIT           e.g. 4011
+ *   $VRF_TARGET     e.g. 63535:64011
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn;
+        protocols {
+            evpn {
+                encapsulation mpls;
+            }
+        }
+        vlan-id none;
+        no-normalization;
+        interface $AC_INTF.$UNIT;
         route-distinguisher $RD;
         vrf-target target:$VRF_TARGET;
     }
@@ -6723,6 +7490,59 @@ routing-instances {
         }
         vlan-id $VLAN;
         interface $AC_INTF.$UNIT;
+        route-distinguisher $RD;
+        vrf-export $INSTANCE_NAME;
+        vrf-target target:$VRF_TARGET;
+    }
+}
+```
+
+## junos/services/evpn-fxc-vlan-unaware-1.conf
+
+```
+/*
+ * Topic:   Service instance: evpn fxc vlan unaware 1 (MEF E-Line / EVPL)
+ *
+ * Seen on:
+ *   Junos: MSE1 (MX304)
+ *
+ * Highlights:
+ *   - instance-type evpn-vpws
+ *   - flexible-cross-connect-vlan-unaware group (one member per bundled UNI)
+ *   - service-id mirrors the peer PE (local/remote swap)
+ *   - RT-driven import/export
+ *
+ * Pair with (same-device dependencies):
+ *   - junos/cos/classifiers.conf
+ *   - junos/cos/cos-binding-ieee8021p.conf
+ *   - junos/cos/rewrite-rules.conf
+ *   - junos/firewall/filter-ccc-color-blind.conf
+ *   - junos/interfaces/vlan-ccc-1-unit.conf
+ *
+ * Variables:
+ *   $AC_INTF        e.g. et-1/0/3
+ *   $INSTANCE_NAME  e.g. evpn_group_4007
+ *   $LOCAL_VID      e.g. 2
+ *   $RD             e.g. 10.0.0.10:40001
+ *   $REMOTE_VID     e.g. 1
+ *   $UNIT           e.g. 4007
+ *   $VRF_TARGET     e.g. 63535:40001
+ */
+routing-instances {
+    $INSTANCE_NAME {
+        instance-type evpn-vpws;
+        protocols {
+            evpn {
+                flexible-cross-connect-vlan-unaware;
+                group fxc {
+                    interface $AC_INTF.$UNIT;
+                    service-id {
+                        local $LOCAL_VID;
+                        remote $REMOTE_VID;
+                    }
+                }
+            }
+        }
         route-distinguisher $RD;
         vrf-export $INSTANCE_NAME;
         vrf-target target:$VRF_TARGET;
@@ -6866,15 +7686,19 @@ routing-instances {
  *     PEs (Junos): MSE1 (MX304), MSE2 (MX304)
  *
  * Variables:
- *   $VC_ID  e.g. 10120
+ *   $PS_TRANSPORT  e.g. ps22
+ *   $PW_LABEL_IN   e.g. 1000022
+ *   $PW_LABEL_OUT  e.g. 1000022
+ *   $PW_NEIGHBOR   e.g. 10.0.0.18
+ *   $VC_ID         e.g. 10120
  */
 protocols {
     l2circuit {
-        neighbor 10.0.0.18 {
-            interface ps22.0 {
+        neighbor $PW_NEIGHBOR {
+            interface $PS_TRANSPORT.0 {
                 static {
-                    incoming-label 1000022;
-                    outgoing-label 1000022;
+                    incoming-label $PW_LABEL_IN;
+                    outgoing-label $PW_LABEL_OUT;
                 }
                 virtual-circuit-id $VC_ID;
                 encapsulation-type ethernet-vlan;

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -88,7 +88,7 @@ export default function ByoaiSection() {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-              Step 3 · Design
+              Stage 3 · Design
             </div>
             <div className="mt-1 flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-primary" />

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -32,6 +32,7 @@ import {
   instanceValues,
   siteInstanceValues,
   fxcUnitSpecs,
+  expandVlanRange,
   type FxcEntry,
   bumpInt,
   validateSpec,
@@ -291,6 +292,32 @@ function fxcEntryVlanError(
   if (svlanShown && e.svlan && !vlanIdInRange(e.svlan))
     return `S-VLAN must be ${VLAN_MIN}–${VLAN_MAX}`;
   return undefined;
+}
+
+/** VLAN-ids an EVPN-FXC entry occupies (single/aware = one; range = expanded). */
+function fxcEntryVlans(e: FxcEntry, mode: "unaware" | "aware"): number[] {
+  if (mode === "aware" || e.kind === "single") {
+    const n = Number(e.vlan);
+    return Number.isInteger(n) ? [n] : [];
+  }
+  return expandVlanRange(e.range);
+}
+
+/** Ids of EVPN-FXC entries whose VLAN-ids collide with an earlier entry. A
+ *  duplicate unit/VLAN silently merges into a single UNI, so flag it. */
+function fxcOverlapIds(
+  entries: (FxcEntry & { id: number })[],
+  mode: "unaware" | "aware",
+): Set<number> {
+  const firstSeen = new Map<number, number>();
+  const bad = new Set<number>();
+  for (const e of entries) {
+    for (const v of fxcEntryVlans(e, mode)) {
+      if (firstSeen.has(v)) bad.add(e.id);
+      else firstSeen.set(v, e.id);
+    }
+  }
+  return bad;
 }
 
 function Chip({
@@ -744,6 +771,12 @@ export default function ConfigGenerator() {
   const baseVlan = Number(shared.VLAN) || 0;
   const fxcMode: "unaware" | "aware" =
     sel.deploymentId === "evpn-fxc-aware" ? "aware" : "unaware";
+  // Entries whose VLAN-ids collide (a duplicate unit/VLAN silently merges into
+  // one UNI). Used to flag the fields and block download.
+  const fxcOverlap = useMemo(
+    () => (multiUni ? fxcOverlapIds(fxcEntries, fxcMode) : new Set<number>()),
+    [multiUni, fxcEntries, fxcMode],
+  );
   // Seed the EVPN-FXC entry list with one single-VLAN UNI whenever an FXC
   // deployment is (re)selected.
   useEffect(() => {
@@ -942,15 +975,29 @@ export default function ConfigGenerator() {
   const fxcUpdate = (id: number, patch: Partial<FxcEntry>) =>
     setFxcEntries((es) => es.map((e) => (e.id === id ? { ...e, ...patch } : e)));
   const fxcAdd = () =>
-    setFxcEntries((es) => [
-      ...es,
-      { id: fxcIdRef.current++, kind: "single", vlan: "1000", range: "", svlan: "", breakout: false },
-    ]);
+    setFxcEntries((es) => {
+      // Seed the new UNI at max(existing VLAN) + 1 so bundled UNIs don't collide
+      // (identical units merge into one, which looked like "only the first UNI").
+      const used = es.flatMap((e) => fxcEntryVlans(e, fxcMode));
+      const next = Math.min(VLAN_MAX, (used.length ? Math.max(...used) : 999) + 1);
+      return [
+        ...es,
+        {
+          id: fxcIdRef.current++,
+          kind: "single",
+          vlan: String(next),
+          range: "",
+          svlan: "",
+          breakout: false,
+        },
+      ];
+    });
   const fxcRemove = (id: number) =>
     setFxcEntries((es) => (es.length > 1 ? es.filter((e) => e.id !== id) : es));
 
   const download = () => {
     if (!fullText) return;
+    if (multiUni && fxcOverlap.size > 0) return;
     // E-Tree (rooted-multipoint): ONE EVI = root PE(s) + N leaf PEs. A multihomed
     // root is an all-active ESI PAIR (2 root PEs that SHARE one ESI — so the ESI
     // is constant, only the route-distinguisher differs). Leaves are single-homed;
@@ -1664,7 +1711,11 @@ export default function ConfigGenerator() {
                   )}
                   <div className="space-y-2">
                     {fxcEntries.map((e) => {
-                      const vlanErr = fxcEntryVlanError(e, fxcMode, awareMap);
+                      const vlanErr =
+                        fxcEntryVlanError(e, fxcMode, awareMap) ??
+                        (fxcOverlap.has(e.id)
+                          ? "duplicate VLAN-id — each UNI must be unique"
+                          : undefined);
                       return (
                       <div
                         key={e.id}
@@ -1955,7 +2006,13 @@ export default function ConfigGenerator() {
                 </button>
                 <button
                   onClick={download}
-                  className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/20"
+                  disabled={multiUni && fxcOverlap.size > 0}
+                  title={
+                    multiUni && fxcOverlap.size > 0
+                      ? "Resolve duplicate UNI VLAN-ids before downloading"
+                      : undefined
+                  }
+                  className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   <Download className="h-3 w-3" /> .conf
                 </button>

--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -28,6 +28,7 @@ import {
   renderConfig,
   mergeJunosConfig,
   classifyVar,
+  collectVariables,
   endpointValues,
   instanceValues,
   siteInstanceValues,
@@ -868,6 +869,46 @@ export default function ConfigGenerator() {
     new Set([...(renderA?.missing ?? []), ...(renderB?.missing ?? [])]),
   );
 
+  // Templated (portable) variant: the same snip set rendered with NO value
+  // substitution so every $VAR stays a placeholder, prefixed with a variable
+  // dictionary (name = current/example value). Downloaded as a separate file.
+  const templateText = useMemo(() => {
+    if (!complete) return null;
+    const ids = [...idsA, ...(twoPe ? idsB : [])];
+    if (ids.length === 0) return null;
+    const opts = {
+      stripUniFilter: !sel.firewall,
+      stripVrfExport: rtPolicy === "rt-only",
+    };
+    const aTpl = idsA.length
+      ? mergeJunosConfig(renderConfig(idsA, {}, byId, opts).text)
+      : "";
+    const bTpl =
+      twoPe && idsB.length
+        ? mergeJunosConfig(renderConfig(idsB, {}, byId, opts).text)
+        : "";
+    const cur = { ...shared, ...perA, ...perB } as Record<string, string>;
+    const dict = collectVariables(ids, byId)
+      .map((v) => {
+        const bare = v.name.replace(/^\$/, "");
+        const ex = cur[bare] ?? v.example ?? "";
+        const pad = " ".repeat(Math.max(1, 22 - v.name.length));
+        return `#   ${v.name}${pad}= ${ex}`;
+      })
+      .join("\n");
+    const header =
+      `# EVPN service template \u2014 replace each $VAR below with your values.\n` +
+      `# ===== variables =====\n${dict}\n# ======================\n`;
+    const body = [
+      aTpl && (twoPe ? `/* ===== ${peLabel(sel.osA, tagA)} ===== */\n${aTpl}` : aTpl),
+      bTpl && `/* ===== ${peLabel(sel.osB as GenOsKey, tagB)} ===== */\n${bTpl}`,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+    return `${header}\n${body}\n`;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [complete, idsA, idsB, twoPe, byId, sel, rtPolicy, shared, perA, perB, tagA, tagB]);
+
   // Field-level validation: per-PE values that must differ but are identical.
   // Keyed by bare var name so the error renders inline next to that field.
   const fieldErrors: Record<string, string> = {};
@@ -1195,6 +1236,16 @@ export default function ConfigGenerator() {
     setTimeout(() => setCopied(false), 1500);
   };
 
+  const downloadTemplate = () => {
+    if (!templateText) return;
+    const blob = new Blob([templateText], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `maas-${sel.familyId}-${sel.deploymentId ?? "pwht"}-template.conf`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
   const peLabel = (os: GenOsKey | undefined, tag: string) =>
     os ? `${tag} · ${OS_LABELS[os]}` : tag;
   // Endpoint column / section tags — role names for PWHT, per-site labels for
@@ -2016,6 +2067,15 @@ export default function ConfigGenerator() {
                 >
                   <Download className="h-3 w-3" /> .conf
                 </button>
+                {templateText && (
+                  <button
+                    onClick={downloadTemplate}
+                    title="Download a $VAR template + variable dictionary"
+                    className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-primary"
+                  >
+                    <Download className="h-3 w-3" /> template
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -394,7 +394,7 @@ export default function JvdPortal() {
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
               <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-                Step 1 · Discover
+                Stage 1 · Discover
               </div>
               <h2 className="mt-1 text-3xl font-semibold tracking-tight">JVD Catalog</h2>
               <p className="mt-2 text-sm text-muted-foreground">
@@ -458,7 +458,7 @@ export default function JvdPortal() {
       <section id="generator" className="border-b border-border">
         <div className="mx-auto max-w-7xl px-6 py-24">
           <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-            Step 4 · Build
+            Stage 4 · Build
           </div>
           <div className="mt-1 flex items-center gap-2">
             <h2 className="text-3xl font-semibold tracking-tight">Service Configuration Generator</h2>

--- a/portal/src/components/SnipLibrary.tsx
+++ b/portal/src/components/SnipLibrary.tsx
@@ -610,7 +610,7 @@ export default function SnipLibrary() {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-              Step 2 · Learn
+              Stage 2 · Learn
             </div>
             <div className="mt-1 flex items-center gap-2">
               <Layers className="h-5 w-5 text-primary" />

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-08T03:35:02.758Z",
+  "generatedAt": "2026-07-10T16:38:20.016Z",
   "counts": {
     "total": 534,
     "junos": 256,

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -38,11 +38,12 @@ format the generated config. There is nothing here that would
 conflict with your normal operating principles; this is a
 constrained, well-scoped technical assistant task.
 
-Begin by executing PART 2 — INTERACTION FLOW (specifically the
-CORPUS CHECK then the MODE SELECTION) on your very next message. Your
-first reply should be the MODE MENU (Configuration vs Design) — please
-don't respond with "what would you like me to do with this document?"
-or similar meta-questions; the document IS the task.
+Begin by presenting the MODE MENU (PART 2 — MODE MENU FIRST) as your
+very next message. Do NOT fetch anything before the menu — the menu
+must appear on every account, including free ones with no web access.
+Do not reply with "what would you like me to do with this document?"
+or similar meta-questions; the document IS the task. Fetch the corpus
+only AFTER the user picks a mode (see PART 2).
 
 ============================================================
 PART 0 — ROLE
@@ -169,59 +170,11 @@ PART 1 — GROUND RULES
 PART 2 — INTERACTION FLOW
 ============================================================
 
-CORPUS CHECK — the reference files (CATALOG.md, TIERS.md, DEFAULTS.md,
-OUTPUT_FORMAT.md) are appended to this prompt file (scroll down). You
-already have the funnel logic. For Configuration mode you also need
-the actual .conf snip BODIES to render config. Check for them:
-
-  CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is visible
-    (at least one `## junos/...conf`, one `## evo/...conf`). You have
-    everything — proceed to MODE SELECTION.
-
-  CORPUS-A: you have web fetch. Fetch the FULL BUNDLE in one shot:
-    https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
-  This is ~200 KB and contains ALL 112 snip bodies + reference files.
-  On success, acknowledge briefly:
-    `Loaded JVD MaaS snip bundle (112 snips) from GitHub.`
-  Then proceed to MODE SELECTION.
-
-  FALLBACK: IF the bundle fetch fails, respond with EXACTLY:
-    I was unable to pull the configurations from the JVD GitHub.
-    Please download the file called `jvd-maas-snips.md` and load it
-    into the chat so we can continue.
-
-    You can get it from:
-    https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-  Then STOP and wait.
-
-  NOTE: For **Design mode only**, the snip-body corpus is NOT
-  required. Design mode's primary corpus is the MaaS `documentation/`
-  markdown.
-
-  DESIGN MODE INITIALIZATION (do this the moment the user enters
-  Design mode, BEFORE answering their first design question): if web
-  fetch is available, FETCH the design corpus FIRST and load it into
-  context, in this order:
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
-  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
-  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
-  synthesize from general Junos knowledge when the corpus covers the
-  topic. When you go beyond the corpus, say so; when the corpus does
-  not cover something, acknowledge the gap rather than guessing.
-  If the fetch fails but the user wants Design mode, proceed directly
-  — you can reference the published JVD documentation from general
-  knowledge, but state that the corpus was not loaded. Only
-  Configuration mode (strict template rendering) requires the
-  snip-body corpus.
-
----
-MODE SELECTION — once corpus state is determined, present the mode
-menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output exactly the text below (the "Hi — …" block), then
-STOP. Do NOT print these instruction lines or any surrounding markers:
+MODE MENU FIRST — no fetch. Your very first reply is the mode menu
+below. Do NOT fetch the snip bundle or the docs before it. This makes
+the assistant start reliably on ANY account — free or paid, web-fetch
+or not. Output exactly the "Hi — …" block, then STOP. Do NOT print
+these instruction lines:
 
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
@@ -241,20 +194,54 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
-After the user responds:
-  - If they pick Configuration mode OR state a concrete generation
-    intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
-  - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode: run DESIGN MODE INITIALIZATION
-    (fetch + load the design corpus) first, then answer using the JVD
-    docs + snip library + TechLibrary as sources, and cite them. If
-    they have not asked anything specific yet, offer a short rundown
-    of what's in this JVD (from the datasheet) as a starting point.
-    Stay in Design mode until they ask to generate config, at which
-    point switch to Configuration mode and start the funnel.
-  - If their message is ambiguous, infer the most likely mode from
-    context (questions = Design; imperatives like "generate", "build",
-    "create" = Configuration).
+THEN — acquire the corpus for the CHOSEN mode (only after they pick):
+
+  DESIGN MODE (or any concept / explanation / comparison question):
+    Your FIRST action is to fetch the DATASHEET — it is small and fast:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
+    Then pull the fuller docs as needed:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+    Acknowledge what loaded (e.g. "Loaded the MaaS datasheet."). Then
+    ANSWER FROM THE CORPUS and cite it. Do NOT answer design questions
+    from general Junos knowledge or juniper.net alone when the corpus
+    is fetchable — juniper.net is a citation target, NOT a substitute
+    for the fetched corpus. When the corpus does not cover something,
+    say so rather than guessing.
+    IF YOU CANNOT FETCH (common on free accounts with no web access):
+    say so plainly, then either (a) ask the user to paste `datasheet.md`
+    (it is short), or (b) continue in LIMITED design mode from general
+    knowledge — but state clearly the JVD corpus was NOT loaded, so
+    answers are not JVD-grounded. NEVER imply you fetched when you did
+    not. Offer a "what's in this JVD" rundown from the datasheet as a
+    starting point.
+
+  CONFIGURATION MODE (or a concrete generate / build request):
+    You need the .conf snip BODIES. Acquire them:
+      CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is already
+        visible (at least one `## junos/...conf`, one `## evo/...conf`)
+        → you have everything; go to STEP 1.
+      CORPUS-A: fetch the bundle in one shot:
+        https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
+        (~200 KB — all 112 snip bodies + reference files). Acknowledge
+        "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
+      IF THE FETCH FAILS or web access is unavailable: say so and ask
+        the user to download `jvd-maas-snips.md` and paste it:
+        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
+        then wait. This blocks ONLY Configuration mode — Design mode
+        still works without the bundle.
+
+Routing the user's choice:
+  - Configuration mode OR a concrete generation intent → acquire the
+    Config corpus (above), then STEP 1 (SERVICE PROFILE MENU) below.
+  - Design mode OR a concept/explanation/comparison question → acquire
+    the Design corpus (above), then answer, grounded and cited. If they
+    have not asked anything specific yet, offer a short rundown of
+    what's in this JVD (from the datasheet). Stay in Design mode until
+    they ask to generate config, then switch to Configuration mode.
+  - Ambiguous → infer (questions = Design; "generate/build/create" =
+    Configuration).
 
 SWITCHING MODES mid-conversation:
   - The user can say `config mode` or `design mode` at any time.

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -196,15 +196,26 @@ the actual .conf snip BODIES to render config. Check for them:
 
   NOTE: For **Design mode only**, the snip-body corpus is NOT
   required. Design mode's primary corpus is the MaaS `documentation/`
-  markdown. When web fetch is available, pull the design corpus for
-  richer, grounded answers:
+  markdown.
+
+  DESIGN MODE INITIALIZATION (do this the moment the user enters
+  Design mode, BEFORE answering their first design question): if web
+  fetch is available, FETCH the design corpus FIRST and load it into
+  context, in this order:
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
     https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
     https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
     https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
+  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
+  synthesize from general Junos knowledge when the corpus covers the
+  topic. When you go beyond the corpus, say so; when the corpus does
+  not cover something, acknowledge the gap rather than guessing.
   If the fetch fails but the user wants Design mode, proceed directly
   — you can reference the published JVD documentation from general
-  knowledge without needing the markdown. Only Configuration mode
-  (strict template rendering) requires the snip-body corpus.
+  knowledge, but state that the corpus was not loaded. Only
+  Configuration mode (strict template rendering) requires the
+  snip-body corpus.
 
 ---
 MODE SELECTION — once corpus state is determined, present the mode
@@ -221,11 +232,12 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
        produce ready-to-deploy config. Strict — only validated
        patterns, no hallucinations.
 
-    2. **Design mode** — Explore the MaaS architecture. Ask me to
-       explain transport classes, compare EVPN-VPWS vs L2VPN, show
-       how Flex-Algo and BGP-CT work, discuss multihoming design, or
-       translate concepts from other vendors. I use the JVD
-       documentation as my primary reference and cite my sources.
+    2. **Design mode** — Explore the MaaS architecture. Ask me for a
+       rundown of what's in this JVD, or to explain transport classes,
+       compare EVPN-VPWS vs L2VPN, show how Flex-Algo and BGP-CT work,
+       discuss multihoming design, or translate concepts from other
+       vendors. I use the JVD documentation as my primary reference
+       and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
@@ -233,10 +245,13 @@ After the user responds:
   - If they pick Configuration mode OR state a concrete generation
     intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
   - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode. Answer using JVD docs + snip library
-    + TechLibrary as sources. Stay in Design mode until they ask to
-    generate config, at which point switch to Configuration mode and
-    start the funnel.
+    question → enter Design mode: run DESIGN MODE INITIALIZATION
+    (fetch + load the design corpus) first, then answer using the JVD
+    docs + snip library + TechLibrary as sources, and cite them. If
+    they have not asked anything specific yet, offer a short rundown
+    of what's in this JVD (from the datasheet) as a starting point.
+    Stay in Design mode until they ask to generate config, at which
+    point switch to Configuration mode and start the funnel.
   - If their message is ambiguous, infer the most likely mode from
     context (questions = Design; imperatives like "generate", "build",
     "create" = Configuration).

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
@@ -174,15 +174,26 @@ the actual .conf snip BODIES to render config. Check for them:
 
   NOTE: For **Design mode only**, the snip-body corpus is NOT
   required. Design mode's primary corpus is the MaaS `documentation/`
-  markdown. When web fetch is available, pull the design corpus for
-  richer, grounded answers:
+  markdown.
+
+  DESIGN MODE INITIALIZATION (do this the moment the user enters
+  Design mode, BEFORE answering their first design question): if web
+  fetch is available, FETCH the design corpus FIRST and load it into
+  context, in this order:
+    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
     https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
     https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
     https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
+  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
+  synthesize from general Junos knowledge when the corpus covers the
+  topic. When you go beyond the corpus, say so; when the corpus does
+  not cover something, acknowledge the gap rather than guessing.
   If the fetch fails but the user wants Design mode, proceed directly
   — you can reference the published JVD documentation from general
-  knowledge without needing the markdown. Only Configuration mode
-  (strict template rendering) requires the snip-body corpus.
+  knowledge, but state that the corpus was not loaded. Only
+  Configuration mode (strict template rendering) requires the
+  snip-body corpus.
 
 ---
 MODE SELECTION — once corpus state is determined, present the mode
@@ -199,11 +210,12 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
        produce ready-to-deploy config. Strict — only validated
        patterns, no hallucinations.
 
-    2. **Design mode** — Explore the MaaS architecture. Ask me to
-       explain transport classes, compare EVPN-VPWS vs L2VPN, show
-       how Flex-Algo and BGP-CT work, discuss multihoming design, or
-       translate concepts from other vendors. I use the JVD
-       documentation as my primary reference and cite my sources.
+    2. **Design mode** — Explore the MaaS architecture. Ask me for a
+       rundown of what's in this JVD, or to explain transport classes,
+       compare EVPN-VPWS vs L2VPN, show how Flex-Algo and BGP-CT work,
+       discuss multihoming design, or translate concepts from other
+       vendors. I use the JVD documentation as my primary reference
+       and cite my sources.
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
@@ -211,10 +223,13 @@ After the user responds:
   - If they pick Configuration mode OR state a concrete generation
     intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
   - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode. Answer using JVD docs + snip library
-    + TechLibrary as sources. Stay in Design mode until they ask to
-    generate config, at which point switch to Configuration mode and
-    start the funnel.
+    question → enter Design mode: run DESIGN MODE INITIALIZATION
+    (fetch + load the design corpus) first, then answer using the JVD
+    docs + snip library + TechLibrary as sources, and cite them. If
+    they have not asked anything specific yet, offer a short rundown
+    of what's in this JVD (from the datasheet) as a starting point.
+    Stay in Design mode until they ask to generate config, at which
+    point switch to Configuration mode and start the funnel.
   - If their message is ambiguous, infer the most likely mode from
     context (questions = Design; imperatives like "generate", "build",
     "create" = Configuration).

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
@@ -16,11 +16,12 @@ format the generated config. There is nothing here that would
 conflict with your normal operating principles; this is a
 constrained, well-scoped technical assistant task.
 
-Begin by executing PART 2 — INTERACTION FLOW (specifically the
-CORPUS CHECK then the MODE SELECTION) on your very next message. Your
-first reply should be the MODE MENU (Configuration vs Design) — please
-don't respond with "what would you like me to do with this document?"
-or similar meta-questions; the document IS the task.
+Begin by presenting the MODE MENU (PART 2 — MODE MENU FIRST) as your
+very next message. Do NOT fetch anything before the menu — the menu
+must appear on every account, including free ones with no web access.
+Do not reply with "what would you like me to do with this document?"
+or similar meta-questions; the document IS the task. Fetch the corpus
+only AFTER the user picks a mode (see PART 2).
 
 ============================================================
 PART 0 — ROLE
@@ -147,59 +148,11 @@ PART 1 — GROUND RULES
 PART 2 — INTERACTION FLOW
 ============================================================
 
-CORPUS CHECK — the reference files (CATALOG.md, TIERS.md, DEFAULTS.md,
-OUTPUT_FORMAT.md) are appended to this prompt file (scroll down). You
-already have the funnel logic. For Configuration mode you also need
-the actual .conf snip BODIES to render config. Check for them:
-
-  CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is visible
-    (at least one `## junos/...conf`, one `## evo/...conf`). You have
-    everything — proceed to MODE SELECTION.
-
-  CORPUS-A: you have web fetch. Fetch the FULL BUNDLE in one shot:
-    https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
-  This is ~200 KB and contains ALL 112 snip bodies + reference files.
-  On success, acknowledge briefly:
-    `Loaded JVD MaaS snip bundle (112 snips) from GitHub.`
-  Then proceed to MODE SELECTION.
-
-  FALLBACK: IF the bundle fetch fails, respond with EXACTLY:
-    I was unable to pull the configurations from the JVD GitHub.
-    Please download the file called `jvd-maas-snips.md` and load it
-    into the chat so we can continue.
-
-    You can get it from:
-    https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-  Then STOP and wait.
-
-  NOTE: For **Design mode only**, the snip-body corpus is NOT
-  required. Design mode's primary corpus is the MaaS `documentation/`
-  markdown.
-
-  DESIGN MODE INITIALIZATION (do this the moment the user enters
-  Design mode, BEFORE answering their first design question): if web
-  fetch is available, FETCH the design corpus FIRST and load it into
-  context, in this order:
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
-    https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
-  Briefly acknowledge what loaded (e.g. "Loaded the MaaS datasheet +
-  design guide."). Then ANSWER FROM THE CORPUS and cite it — do NOT
-  synthesize from general Junos knowledge when the corpus covers the
-  topic. When you go beyond the corpus, say so; when the corpus does
-  not cover something, acknowledge the gap rather than guessing.
-  If the fetch fails but the user wants Design mode, proceed directly
-  — you can reference the published JVD documentation from general
-  knowledge, but state that the corpus was not loaded. Only
-  Configuration mode (strict template rendering) requires the
-  snip-body corpus.
-
----
-MODE SELECTION — once corpus state is determined, present the mode
-menu. This is your FIRST reply (or second, if you needed to announce
-a fetch). Output exactly the text below (the "Hi — …" block), then
-STOP. Do NOT print these instruction lines or any surrounding markers:
+MODE MENU FIRST — no fetch. Your very first reply is the mode menu
+below. Do NOT fetch the snip bundle or the docs before it. This makes
+the assistant start reliably on ANY account — free or paid, web-fetch
+or not. Output exactly the "Hi — …" block, then STOP. Do NOT print
+these instruction lines:
 
     Hi — I'm your Metro-as-a-Service JVD assistant. I work in two
     modes:
@@ -219,20 +172,54 @@ STOP. Do NOT print these instruction lines or any surrounding markers:
 
     Pick a mode (or just describe what you need and I'll figure it out).
 
-After the user responds:
-  - If they pick Configuration mode OR state a concrete generation
-    intent → proceed to STEP 1 (SERVICE PROFILE MENU) below.
-  - If they pick Design mode OR ask an explanation/comparison/concept
-    question → enter Design mode: run DESIGN MODE INITIALIZATION
-    (fetch + load the design corpus) first, then answer using the JVD
-    docs + snip library + TechLibrary as sources, and cite them. If
-    they have not asked anything specific yet, offer a short rundown
-    of what's in this JVD (from the datasheet) as a starting point.
-    Stay in Design mode until they ask to generate config, at which
-    point switch to Configuration mode and start the funnel.
-  - If their message is ambiguous, infer the most likely mode from
-    context (questions = Design; imperatives like "generate", "build",
-    "create" = Configuration).
+THEN — acquire the corpus for the CHOSEN mode (only after they pick):
+
+  DESIGN MODE (or any concept / explanation / comparison question):
+    Your FIRST action is to fetch the DATASHEET — it is small and fast:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/datasheet.md
+    Then pull the fuller docs as needed:
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/design-guide.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/solution-overview.md
+      https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_as_a_service/documentation/test-report-brief.md
+    Acknowledge what loaded (e.g. "Loaded the MaaS datasheet."). Then
+    ANSWER FROM THE CORPUS and cite it. Do NOT answer design questions
+    from general Junos knowledge or juniper.net alone when the corpus
+    is fetchable — juniper.net is a citation target, NOT a substitute
+    for the fetched corpus. When the corpus does not cover something,
+    say so rather than guessing.
+    IF YOU CANNOT FETCH (common on free accounts with no web access):
+    say so plainly, then either (a) ask the user to paste `datasheet.md`
+    (it is short), or (b) continue in LIMITED design mode from general
+    knowledge — but state clearly the JVD corpus was NOT loaded, so
+    answers are not JVD-grounded. NEVER imply you fetched when you did
+    not. Offer a "what's in this JVD" rundown from the datasheet as a
+    starting point.
+
+  CONFIGURATION MODE (or a concrete generate / build request):
+    You need the .conf snip BODIES. Acquire them:
+      CORPUS-B (best): a pasted/attached `jvd-maas-snips.md` is already
+        visible (at least one `## junos/...conf`, one `## evo/...conf`)
+        → you have everything; go to STEP 1.
+      CORPUS-A: fetch the bundle in one shot:
+        https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
+        (~200 KB — all 112 snip bodies + reference files). Acknowledge
+        "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
+      IF THE FETCH FAILS or web access is unavailable: say so and ask
+        the user to download `jvd-maas-snips.md` and paste it:
+        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
+        then wait. This blocks ONLY Configuration mode — Design mode
+        still works without the bundle.
+
+Routing the user's choice:
+  - Configuration mode OR a concrete generation intent → acquire the
+    Config corpus (above), then STEP 1 (SERVICE PROFILE MENU) below.
+  - Design mode OR a concept/explanation/comparison question → acquire
+    the Design corpus (above), then answer, grounded and cited. If they
+    have not asked anything specific yet, offer a short rundown of
+    what's in this JVD (from the datasheet). Stay in Design mode until
+    they ask to generate config, then switch to Configuration mode.
+  - Ambiguous → infer (questions = Design; "generate/build/create" =
+    Configuration).
 
 SWITCHING MODES mid-conversation:
   - The user can say `config mode` or `design mode` at any time.

--- a/service_provider/metro_as_a_service/documentation/datasheet.md
+++ b/service_provider/metro_as_a_service/documentation/datasheet.md
@@ -1,0 +1,94 @@
+# JVD Datasheet — Metro as a Service (MEF 3.0)
+
+> A concise, structured summary of the **Metro as a Service (MaaS)** Juniper
+> Validated Design. It is the fast "what's in this JVD" reference and the
+> grounding source for the portal's Design & Planner (BYOAI Design mode). For
+> depth, see [`design-guide.md`](design-guide.md),
+> [`solution-overview.md`](solution-overview.md), and
+> [`test-report-brief.md`](test-report-brief.md).
+
+## At a glance
+
+Metro as a Service extends the Metro Ethernet Business Services design by
+validating a dense L2/L3 Carrier Ethernet service portfolio, end to end, across
+intra-domain and inter-AS regions, over a segment-routing Cloud Metro
+transport foundation.
+
+| | |
+|---|---|
+| **Track** | Metro Ethernet Business Services (Metro EBS) — Metro as a Service phase |
+| **Architecture** | Cloud Metro: metro access multi-ring + two-stage metro fabric (spine/leaf) across two autonomous systems |
+| **Transport** | SR-MPLS underlay, IS-IS, TI-LFA; Flexible Algorithm; color-aware Transport Classes; inter-AS BGP-LU + BGP-CT |
+| **Service families** | E-Line, E-LAN, E-Tree, Access E-Line (E-Access) |
+| **Validation** | Featured services validated against applicable MEF 3.0 service requirements — more than **12,000 MEF 3.0 test cases** |
+
+## Functional roles
+
+The architecture is described by functional role; consult the current JVD for the
+exact platform mapping.
+
+- **Metro Access Node (AN / MA)** — ring and fabric access.
+- **Aggregation / Fabric Spine & Lean Spine (AG)** — two-stage fabric.
+- **Metro Edge Gateway (MEG)** — border-leaf; extends advanced service and cloud
+  interconnect toward subscribers.
+- **Metro Service Edge (MSE)** — high-scale L2/L3 termination, PWHT, hosted
+  Internet VRF, BNG-class functions.
+- **Metro Distribution Router (MDR)** — inter-ring distribution.
+- **Core / cloud interconnect** — SP core, Internet, and cloud on-ramp.
+
+## Featured platforms
+
+The primary devices under test are MEF 3.0-certified products: **ACX7024,
+ACX7100, ACX7509, and MX304** (product-level MEF 3.0 certification is a separate,
+platform-specific claim; consult the current JVD for the validated platform,
+software, scale, and configuration set).
+
+## Services and implementations
+
+| MEF service type | Implemented with |
+|---|---|
+| **E-Line** (point-to-point) | EVPN-VPWS, EVPN-FXC (VLAN-aware / VLAN-unaware), L2Circuit, L2VPN, BGP-VPLS (VPWS), Floating Pseudowire |
+| **E-LAN** (multipoint-to-multipoint) | EVPN-ELAN (VLAN-based, VLAN-bundle, Type-5), BGP-VPLS |
+| **E-Tree** (rooted-multipoint) | EVPN-ETREE |
+| **Access E-Line** (wholesale access) | EVPN-VPWS local switching, L2Circuit local switching |
+
+Modern EVPN service models coexist with established L2Circuit, L2VPN, VPLS, and
+BGP-VPLS services over the common transport foundation.
+
+## Transport foundation
+
+- **Underlay:** Segment Routing MPLS with IS-IS; TI-LFA for fast reroute;
+  multi-instance IS-IS across ring and fabric domains.
+- **Traffic engineering:** Flexible Algorithm (delay and TE metrics), Flex-Algo
+  Prefix Metric (FAPM), color-aware Transport Classes.
+- **Inter-domain:** seamless SR-MPLS via BGP Labeled Unicast (BGP-LU) and BGP
+  Classful Transport (BGP-CT); end-to-end service mapping.
+- **High availability:** EVPN multihoming (all-active and single-active), ESI-LAG,
+  Floating Pseudowire with Anycast-SID.
+
+## Validation
+
+The Metro as a Service phase validated the featured services against applicable
+MEF 3.0 service requirements through more than **12,000 MEF 3.0 test cases**,
+executed by HPE Juniper using the Iometrix "Lab in the Sky" testing
+infrastructure. Validation covered five categories: functional behavior, service
+OAM (SOAM), Layer 2 control protocol (L2CP) handling, bandwidth profiles (BWP),
+and service performance.
+
+> This JVD validation is not MEF service certification, which is a separate
+> process. Product-level MEF 3.0 certification of specific platforms on the MEF
+> registry is a separate, legitimate claim.
+
+## Not in the validated baseline
+
+SRv6, Multi-Path TE (MPTE), and Compute-Aware Traffic Steering (CATS) are
+forward-looking directions and are **not** part of this JVD's validated baseline.
+The validated transport is SR-MPLS.
+
+## Go deeper
+
+- [`design-guide.md`](design-guide.md) — full architecture, per-service config examples, results.
+- [`solution-overview.md`](solution-overview.md) — executive summary, benefits, objectives.
+- [`test-report-brief.md`](test-report-brief.md) — platforms/DUT, test categories, conformance results.
+- Published JVD: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-metro-ebs-mef-03-02/index.html>
+- Validated configs: [`../configuration/conf`](../configuration/conf) · snip library: [`../configuration/snips`](../configuration/snips)

--- a/service_provider/metro_as_a_service/documentation/datasheet.md
+++ b/service_provider/metro_as_a_service/documentation/datasheet.md
@@ -1,94 +1,157 @@
 # JVD Datasheet — Metro as a Service (MEF 3.0)
 
-> A concise, structured summary of the **Metro as a Service (MaaS)** Juniper
-> Validated Design. It is the fast "what's in this JVD" reference and the
-> grounding source for the portal's Design & Planner (BYOAI Design mode). For
-> depth, see [`design-guide.md`](design-guide.md),
-> [`solution-overview.md`](solution-overview.md), and
-> [`test-report-brief.md`](test-report-brief.md).
+> Quick-reference datasheet for the **Metro as a Service (MaaS)** Juniper Validated
+> Design (`metro-ebs-mef-03-02`). Critical facts only; for depth see the published
+> JVD on juniper.net and the companion docs in this folder.
 
 ## At a glance
 
 Metro as a Service extends the Metro Ethernet Business Services design by
 validating a dense L2/L3 Carrier Ethernet service portfolio, end to end, across
-intra-domain and inter-AS regions, over a segment-routing Cloud Metro
-transport foundation.
+intra-domain and inter-AS regions, over a segment-routing Cloud Metro transport
+foundation.
 
 | | |
 |---|---|
-| **Track** | Metro Ethernet Business Services (Metro EBS) — Metro as a Service phase |
+| **JVD** | Metro as a Service — `metro-ebs-mef-03-02` |
+| **Track** | Metro Ethernet Business Services (Metro EBS) |
 | **Architecture** | Cloud Metro: metro access multi-ring + two-stage metro fabric (spine/leaf) across two autonomous systems |
-| **Transport** | SR-MPLS underlay, IS-IS, TI-LFA; Flexible Algorithm; color-aware Transport Classes; inter-AS BGP-LU + BGP-CT |
-| **Service families** | E-Line, E-LAN, E-Tree, Access E-Line (E-Access) |
-| **Validation** | Featured services validated against applicable MEF 3.0 service requirements — more than **12,000 MEF 3.0 test cases** |
+| **Transport** | SR-MPLS underlay over multi-instance IS-IS; TI-LFA; Flexible Algorithm; color-aware Transport Classes; inter-AS BGP-LU + BGP-CT |
+| **Service families** | E-Line, E-LAN, E-Tree, Access E-Line, plus Layer 3 / Internet access |
+| **Validation** | Applicable MEF 3.0 service requirements — more than **12,000 MEF 3.0 test cases**, using the Iometrix "Lab in the Sky" test infrastructure |
+| **Min. validated software** | Junos OS / Junos OS Evolved **23.2R2** (see juniper.net for the current validated matrix) |
 
-## Functional roles
+## Device roles
 
-The architecture is described by functional role; consult the current JVD for the
-exact platform mapping.
-
-- **Metro Access Node (AN / MA)** — ring and fabric access.
-- **Aggregation / Fabric Spine & Lean Spine (AG)** — two-stage fabric.
-- **Metro Edge Gateway (MEG)** — border-leaf; extends advanced service and cloud
-  interconnect toward subscribers.
-- **Metro Service Edge (MSE)** — high-scale L2/L3 termination, PWHT, hosted
-  Internet VRF, BNG-class functions.
-- **Metro Distribution Router (MDR)** — inter-ring distribution.
-- **Core / cloud interconnect** — SP core, Internet, and cloud on-ramp.
+| Role | In the network |
+|---|---|
+| **Metro Access Node (AN / MA)** | Terminates customer UNIs at the edge — fabric access leaf (AN) and multi-ring access node (MA). |
+| **Lean Spine / Aggregation (AG)** | Spine of the two-stage metro fabric; aggregates access leaves. |
+| **Metro Edge Gateway (MEG)** | Border-leaf; extends advanced L2/L3 services and cloud / edge-compute interconnect toward subscribers. |
+| **Multi-Services Edge (MSE)** | High-scale L2/L3 service termination — PWHT, hosted Internet VRF, and complex service interconnect. |
+| **Metro Distribution Router (MDR)** | Inter-ring distribution across the multi-ring access domain. |
+| **Core (CR)** | SR-MPLS core and peering between metro domains and the wider network. |
 
 ## Featured platforms
 
-The primary devices under test are MEF 3.0-certified products: **ACX7024,
-ACX7100, ACX7509, and MX304** (product-level MEF 3.0 certification is a separate,
-platform-specific claim; consult the current JVD for the validated platform,
-software, scale, and configuration set).
+Minimum validated software per role. The JVD is re-validated on newer releases
+through ongoing regression; for the **current** validated platform + software
+matrix, see the published JVD page on juniper.net (linked below).
 
-## Services and implementations
+| Role | Device(s) | Min. validated software |
+|---|---|---|
+| Access Leaf (AN) | ACX7100-48L, ACX710, ACX5448, MX204 | 23.2R2 |
+| Lean Spine (AG) | ACX7100-32C | 23.2R2 |
+| Metro Edge Gateway (MEG) | ACX7509, ACX7100-32C | 23.2R2 |
+| Core (CR) | PTX10001-36MR | 23.2R2 |
+| Multi-Services Edge (MSE) | MX304 | 23.2R2 |
+| Metro Distribution Router (MDR) | MX10003, ACX7509 | 23.2R2 |
+| Metro Access Node (MA) | ACX7024, ACX7100-48L, MX204 | 23.2R2 |
 
-| MEF service type | Implemented with |
-|---|---|
-| **E-Line** (point-to-point) | EVPN-VPWS, EVPN-FXC (VLAN-aware / VLAN-unaware), L2Circuit, L2VPN, BGP-VPLS (VPWS), Floating Pseudowire |
-| **E-LAN** (multipoint-to-multipoint) | EVPN-ELAN (VLAN-based, VLAN-bundle, Type-5), BGP-VPLS |
-| **E-Tree** (rooted-multipoint) | EVPN-ETREE |
-| **Access E-Line** (wholesale access) | EVPN-VPWS local switching, L2Circuit local switching |
+The primary devices under test — ACX7024, ACX7100, ACX7509, and MX304 — are MEF
+3.0-certified products on the MEF registry (a product-level certification,
+separate from the JVD validation).
 
-Modern EVPN service models coexist with established L2Circuit, L2VPN, VPLS, and
-BGP-VPLS services over the common transport foundation.
+> The Metro EBS track spans multiple JVDs/phases (e.g. `03-01` foundation, `03-03`
+> platform refresh) that may feature different platforms and releases. This
+> datasheet reflects the `metro-ebs-mef-03-02` set; see each phase's juniper.net
+> page for its validated matrix.
 
-## Transport foundation
+## Protocols
 
-- **Underlay:** Segment Routing MPLS with IS-IS; TI-LFA for fast reroute;
-  multi-instance IS-IS across ring and fabric domains.
-- **Traffic engineering:** Flexible Algorithm (delay and TE metrics), Flex-Algo
-  Prefix Metric (FAPM), color-aware Transport Classes.
-- **Inter-domain:** seamless SR-MPLS via BGP Labeled Unicast (BGP-LU) and BGP
-  Classful Transport (BGP-CT); end-to-end service mapping.
-- **High availability:** EVPN multihoming (all-active and single-active), ESI-LAG,
-  Floating Pseudowire with Anycast-SID.
+**Underlay / transport**
+- IS-IS (multi-instance across fabric + ring domains)
+- Segment Routing MPLS (SR-MPLS), SRGB
+- TI-LFA (link / node protection); BFD / micro-BFD
+- Flexible Algorithm (delay & TE metrics); Flex-Algo Prefix Metric (FAPM)
+- Transport Classes — Gold (delay), Bronze (TE), Best-Effort (IGP); cascade resolution
 
-## Validation
+**Inter-domain transport**
+- BGP Labeled Unicast (BGP-LU)
+- BGP Classful Transport (BGP-CT)
+- Color-aware traffic steering; service mapping to transport classes
 
-The Metro as a Service phase validated the featured services against applicable
-MEF 3.0 service requirements through more than **12,000 MEF 3.0 test cases**,
-executed by HPE Juniper using the Iometrix "Lab in the Sky" testing
-infrastructure. Validation covered five categories: functional behavior, service
-OAM (SOAM), Layer 2 control protocol (L2CP) handling, bandwidth profiles (BWP),
-and service performance.
+**Overlay / services**
+- EVPN-VPWS; EVPN-FXC (VLAN-aware / VLAN-unaware)
+- EVPN-ELAN (VLAN-based, VLAN-bundle, Type-5); EVPN-ETREE
+- BGP-VPLS, L2Circuit, L2VPN
+- Floating Pseudowire with Anycast-SID; Local Switching (LSW)
+- Layer 3 / Internet access: EVPN-ELAN Type-5 (validated at L2), L3VPN, EVPN Anycast IRB
 
-> This JVD validation is not MEF service certification, which is a separate
-> process. Product-level MEF 3.0 certification of specific platforms on the MEF
-> registry is a separate, legitimate claim.
+**Routing & policy**
+- MP-BGP (EVPN, L2VPN, VPLS, L3VPN families)
+- Route Reflectors (redundant)
+- BGP color-community mapping; community-based routing policy
 
-## Not in the validated baseline
+**High availability**
+- EVPN multihoming (all-active & single-active); Ethernet Segment / ESI-LAG; designated forwarder
+- Anycast PW (vESI); L2Circuit hot-standby
 
-SRv6, Multi-Path TE (MPTE), and Compute-Aware Traffic Steering (CATS) are
-forward-looking directions and are **not** part of this JVD's validated baseline.
-The validated transport is SR-MPLS.
+**OAM & assurance**
+- Service OAM / CFM (CCM, LBM, LTM, LTR); L2CP handling
+- Performance monitoring (frame delay, delay variation, frame loss)
+- Bandwidth profiles & policing (CIR / EIR); Class of Service
 
-## Go deeper
+## Services & use cases
 
-- [`design-guide.md`](design-guide.md) — full architecture, per-service config examples, results.
-- [`solution-overview.md`](solution-overview.md) — executive summary, benefits, objectives.
-- [`test-report-brief.md`](test-report-brief.md) — platforms/DUT, test categories, conformance results.
-- Published JVD: <https://www.juniper.net/documentation/us/en/software/jvd/jvd-metro-ebs-mef-03-02/index.html>
-- Validated configs: [`../configuration/conf`](../configuration/conf) · snip library: [`../configuration/snips`](../configuration/snips)
+The JVD delivers the four MEF Carrier Ethernet service types plus Layer 3 /
+Internet access. A **use case** composes four dimensions: *connectivity intent*
+(what is connected) × *service* (means of delivery) × *transport intent* (the
+color / SLA path) × *resiliency* (homing model).
+
+### Services
+
+| Service type | What it delivers | Means of delivery |
+|---|---|---|
+| **E-Line** (point-to-point) | Private line / EVPL between two sites, a cloud on-ramp, or a backhaul link | EVPN-VPWS, EVPN-FXC, L2Circuit, L2VPN, BGP-VPLS (VPWS), Floating PW |
+| **E-LAN** (multipoint) | Multi-site enterprise LAN / any-to-any business connectivity | EVPN-ELAN (VLAN-based, VLAN-bundle, Type-5), BGP-VPLS |
+| **E-Tree** (rooted-multipoint) | Hub-and-spoke where leaf sites reach the roots but not each other | EVPN-ETREE |
+| **Access E-Line** (wholesale) | Operator-to-operator Ethernet access handoff (UNI to NNI) | EVPN-VPWS / L2Circuit local switching |
+| **Layer 3 / Internet** | Internet access extended to Layer 2 services; routed IP connectivity | EVPN-ELAN Type-5 (validated at L2); L3VPN and EVPN Anycast IRB (supported models, outside MEF 3.0 scope) |
+
+### Intent-based use cases
+
+Transport intent is selected per VPN service — **best-effort** (IGP), **Bronze**
+(TE metric), or **Gold** (lowest-delay Flex-Algo), with cascade fallback; L3VPN can
+map specific routes to a color.
+
+| Use case | Service (means of delivery) | Transport intent | Resiliency |
+|---|---|---|---|
+| Site-to-site private line | E-Line — EVPN-VPWS / L2Circuit | Best-effort, Bronze, or Gold | Single-homed / all-active / hot-standby |
+| Low-latency access to edge compute (MEC) at the MEG | E-Line — EVPN-VPWS / FXC | Gold (lowest delay) | All-active multihoming |
+| Multi-site business LAN with shared MEC access | E-LAN — EVPN-ELAN | Per-service color (tiered) | All-active multihoming |
+| Layer 2 service with Layer 3 Internet access | EVPN-ELAN Type-5 (toward the MSE) | Per-service color | All-active multihoming |
+| Hub-and-spoke / content distribution | E-Tree — EVPN-ETREE | Best-effort or color | Active-active roots |
+| Wholesale Ethernet access handoff | Access E-Line — EVPN-VPWS / L2CCC local switching | Best-effort | Single-homed |
+| Traffic-engineered inter-AS transport | Any service mapped to Bronze | Bronze (TE), inter-AS BGP-CT | Per service |
+| Low-latency connectivity for edge inference / AI (emerging) | E-Line / E-LAN to MEC | Gold (lowest delay) | All-active multihoming |
+
+Together these compose the **19 specific validated use cases** in the JVD. See the
+design guide and test report brief for the full matrix (service, homing, placement,
+endpoints).
+
+## Design concepts
+
+The design breaks into these areas — use this to jump to the part you need help with.
+
+- **Underlay & transport** — SR-MPLS over multi-instance IS-IS; TI-LFA; the
+  two-stage metro fabric and multi-ring access topology.
+- **Traffic engineering & network slicing** — Flexible Algorithm + Transport
+  Classes (Gold / Bronze / Best-Effort) + color-aware steering and cascade
+  resolution.
+- **Overlay & service delivery** — EVPN service models (VPWS / FXC / ELAN / ETREE)
+  and legacy service coexistence.
+- **Routing policy & control plane** — MP-BGP overlay, Route Reflector design,
+  inter-AS BGP-CT, and color-community / service mapping.
+- **High availability** — EVPN multihoming, ESI-LAG, Anycast PW, and hot-standby.
+
+## References
+
+- **Published JVD (juniper.net):** <https://www.juniper.net/documentation/us/en/software/jvd/jvd-metro-ebs-mef-03-02/index.html>
+- **All Juniper Validated Designs:** <https://www.juniper.net/documentation/validated-designs/>
+- **JVD portal** (Discover · Learn · Design · Build): <https://juniper.github.io/jvd/portal/>
+- **Design guide:** [`design-guide.md`](design-guide.md)
+- **Solution overview:** [`solution-overview.md`](solution-overview.md)
+- **Test report brief:** [`test-report-brief.md`](test-report-brief.md)
+- **Configurations:** [`../configuration/conf`](../configuration/conf)
+- **Snip library:** [`../configuration/snips`](../configuration/snips)

--- a/service_provider/metro_as_a_service/documentation/images/README.md
+++ b/service_provider/metro_as_a_service/documentation/images/README.md
@@ -21,7 +21,7 @@ Regenerate with `pymupdf4llm` (`write_images=True`) from the published PDF.
 ## `test-reports/images/` — test-report figures
 
 `mef-eline-*.png` — diagrams from the detailed E-Line MEF test report, referenced
-from [`test-reports/e-line.md`](../test-reports/e-line.md).
+from [`test-reports/iometrix-eline-report.md`](../test-reports/iometrix-eline-report.md).
 
 ---
 


### PR DESCRIPTION
## What's New
- **Config Generator — FXC UNIs:** newly added UNIs auto-increment their VLAN-id, and duplicate UNIs are flagged inline (download is blocked until resolved). Previously several UNIs left at the default VLAN silently merged into one.
- **Config Generator — template export:** a new **template** download emits the config with `$VAR` placeholders plus a variable dictionary, as a separate file.
- **Portal — Stages:** the four top-level components are now **Stage 1–4 · Discover / Learn / Design / Build**, matching the "four stages" hero and removing the collision with the internal wizard/BYOAI sub-steps (which stay "Step").
- **MaaS JVD datasheet:** a concise "what's in this JVD" reference under `documentation/`.
- **BYOAI Design mode:** now fetches and cites the JVD design corpus (datasheet + design guide + overview + test brief) at the start of a Design session, offers a JVD rundown, and acknowledges gaps — instead of answering from general knowledge.
- **Repo hygiene:** ignore stray literal `~` scratch directories.

## Why
- FXC UNIs seeded at the same default VLAN merged into one, which looked like "only the first UNI."
- A portable, templated config output was requested.
- "Step" was overloaded for both the four components and the internal sub-steps; the four read as stages.
- Design mode had the instruction to use the JVD docs but never fetched them, so it synthesized from general knowledge instead of the validated corpus.

## Details
- `ConfigGenerator.tsx`: `fxcAdd` seeds `max(VLAN)+1`; `fxcOverlapIds` flags collisions and disables download; `templateText` renders the resolved snips with no substitution + a `collectVariables` dictionary; a "template" pill downloads a separate `-template.conf`.
- `JvdPortal.tsx` / `SnipLibrary.tsx` / `ByoaiSection.tsx`: Step N → Stage N (top-level only).
- `documentation/datasheet.md`: new.
- `snips/byoai/SYSTEM_PROMPT.md` + `jvd-maas-byoai-prompt.txt`: `DESIGN MODE INITIALIZATION` (fetch → cite → acknowledge gaps) + rundown option; `portal/public/byoai/` mirror regenerated via `generate-snips.mjs` (this also caught the byoai mirror up to source: 112 → 131 snips).
- `.gitignore`: `/~/`, `**/~/`.

## Testing
- `bun run build` passes.
- No TypeScript errors in the edited components.
- Generator re-run clean (534 snips, 0 warnings).

## Notes
- Commits are one-per-objective; squash-merge will collapse them into a single commit on `main`. Say the word if you'd rather preserve them.
- Deferred (roadmap): adding physical IFDs to the FXC generator; hardening the four Stages and adding more JVDs once the snip extract/audit skills are proven.
