### PR TITLE
fix(byoai): redirect to portal generator instead of asking to paste 200KB

### DIFF
--- a/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
@@ -226,11 +226,21 @@ THEN — acquire the corpus for the CHOSEN mode (only after they pick):
         https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
         (~200 KB — all 112 snip bodies + reference files). Acknowledge
         "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
-      IF THE FETCH FAILS or web access is unavailable: say so and ask
-        the user to download `jvd-maas-snips.md` and paste it:
-        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-        then wait. This blocks ONLY Configuration mode — Design mode
-        still works without the bundle.
+      IF THE FETCH FAILS or web access is unavailable: DO NOT ask the
+        user to paste a 200 KB file — that is not a viable experience.
+        Instead, redirect them to the portal's **Config Generator**,
+        which renders the same validated snips with zero fetch required:
+          https://juniper.github.io/jvd/portal/#generator
+        Say something like:
+          "I can explain the architecture in Design mode, but to
+          generate the actual config I need the snip library and I
+          wasn't able to fetch it. The good news: the **JVD portal's
+          Config Generator** (Stage 4 · Build) does exactly this —
+          same validated snips, guided wizard, downloadable .conf:
+          https://juniper.github.io/jvd/portal/#generator"
+        Then offer to continue helping in Design mode (architecture,
+        comparisons, concepts) or to walk them through what to select
+        in the portal generator for their use case.
 
 Routing the user's choice:
   - Configuration mode OR a concrete generation intent → acquire the

--- a/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
+++ b/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
@@ -204,11 +204,21 @@ THEN — acquire the corpus for the CHOSEN mode (only after they pick):
         https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
         (~200 KB — all 112 snip bodies + reference files). Acknowledge
         "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
-      IF THE FETCH FAILS or web access is unavailable: say so and ask
-        the user to download `jvd-maas-snips.md` and paste it:
-        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-        then wait. This blocks ONLY Configuration mode — Design mode
-        still works without the bundle.
+      IF THE FETCH FAILS or web access is unavailable: DO NOT ask the
+        user to paste a 200 KB file — that is not a viable experience.
+        Instead, redirect them to the portal's **Config Generator**,
+        which renders the same validated snips with zero fetch required:
+          https://juniper.github.io/jvd/portal/#generator
+        Say something like:
+          "I can explain the architecture in Design mode, but to
+          generate the actual config I need the snip library and I
+          wasn't able to fetch it. The good news: the **JVD portal's
+          Config Generator** (Stage 4 · Build) does exactly this —
+          same validated snips, guided wizard, downloadable .conf:
+          https://juniper.github.io/jvd/portal/#generator"
+        Then offer to continue helping in Design mode (architecture,
+        comparisons, concepts) or to walk them through what to select
+        in the portal generator for their use case.
 
 Routing the user's choice:
   - Configuration mode OR a concrete generation intent → acquire the

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -226,11 +226,21 @@ THEN — acquire the corpus for the CHOSEN mode (only after they pick):
         https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
         (~200 KB — all 112 snip bodies + reference files). Acknowledge
         "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
-      IF THE FETCH FAILS or web access is unavailable: say so and ask
-        the user to download `jvd-maas-snips.md` and paste it:
-        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-        then wait. This blocks ONLY Configuration mode — Design mode
-        still works without the bundle.
+      IF THE FETCH FAILS or web access is unavailable: DO NOT ask the
+        user to paste a 200 KB file — that is not a viable experience.
+        Instead, redirect them to the portal's **Config Generator**,
+        which renders the same validated snips with zero fetch required:
+          https://juniper.github.io/jvd/portal/#generator
+        Say something like:
+          "I can explain the architecture in Design mode, but to
+          generate the actual config I need the snip library and I
+          wasn't able to fetch it. The good news: the **JVD portal's
+          Config Generator** (Stage 4 · Build) does exactly this —
+          same validated snips, guided wizard, downloadable .conf:
+          https://juniper.github.io/jvd/portal/#generator"
+        Then offer to continue helping in Design mode (architecture,
+        comparisons, concepts) or to walk them through what to select
+        in the portal generator for their use case.
 
 Routing the user's choice:
   - Configuration mode OR a concrete generation intent → acquire the

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
@@ -204,11 +204,21 @@ THEN — acquire the corpus for the CHOSEN mode (only after they pick):
         https://juniper.github.io/jvd/portal/byoai/metro_as_a_service/jvd-maas-snips.md
         (~200 KB — all 112 snip bodies + reference files). Acknowledge
         "Loaded JVD MaaS snip bundle (112 snips)." then go to STEP 1.
-      IF THE FETCH FAILS or web access is unavailable: say so and ask
-        the user to download `jvd-maas-snips.md` and paste it:
-        https://github.com/Juniper/jvd/tree/main/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-snips.md
-        then wait. This blocks ONLY Configuration mode — Design mode
-        still works without the bundle.
+      IF THE FETCH FAILS or web access is unavailable: DO NOT ask the
+        user to paste a 200 KB file — that is not a viable experience.
+        Instead, redirect them to the portal's **Config Generator**,
+        which renders the same validated snips with zero fetch required:
+          https://juniper.github.io/jvd/portal/#generator
+        Say something like:
+          "I can explain the architecture in Design mode, but to
+          generate the actual config I need the snip library and I
+          wasn't able to fetch it. The good news: the **JVD portal's
+          Config Generator** (Stage 4 · Build) does exactly this —
+          same validated snips, guided wizard, downloadable .conf:
+          https://juniper.github.io/jvd/portal/#generator"
+        Then offer to continue helping in Design mode (architecture,
+        comparisons, concepts) or to walk them through what to select
+        in the portal generator for their use case.
 
 Routing the user's choice:
   - Configuration mode OR a concrete generation intent → acquire the


### PR DESCRIPTION
## What's New
- BYOAI Config mode no longer dead-ends with 'paste this 200KB file'

## Why
When the snip bundle can't be fetched (free accounts, rate limits), asking the user to paste a 200KB file is not viable. The portal's Config Generator does the same thing with zero fetch.

## Changes
- [x] Config-mode fallback now redirects to the portal Config Generator (#generator)
- [x] Offers to continue in Design mode or guide them through the portal wizard
- [x] Mirror regenerated

## Verified before merge
- [x] Portal builds — bun run build
- [x] Markdown links pass — lychee --offline → 0 errors
- [x] Generated artifacts regenerated (byoai mirror)