### PR TITLE
feat(portal): add GoatCounter analytics + daily repo traffic collector

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,0 +1,76 @@
+name: Repo Traffic Stats
+
+on:
+  schedule:
+    - cron: '15 6 * * *'   # daily at 06:15 UTC (before GitHub's 14-day rolloff)
+  workflow_dispatch:        # manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Fetch traffic data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p .github/traffic
+
+          # Views (14-day rolling)
+          gh api repos/${{ github.repository }}/traffic/views \
+            > .github/traffic/views-latest.json
+
+          # Clones (14-day rolling)
+          gh api repos/${{ github.repository }}/traffic/clones \
+            > .github/traffic/clones-latest.json
+
+          # Top referrers (snapshot)
+          gh api repos/${{ github.repository }}/traffic/popular/referrers \
+            > .github/traffic/referrers-latest.json
+
+          # Top paths (snapshot)
+          gh api repos/${{ github.repository }}/traffic/popular/paths \
+            > .github/traffic/paths-latest.json
+
+          # Append daily summaries to CSV for historical tracking
+          DATE=$(date -u +%Y-%m-%d)
+
+          VIEWS_FILE=.github/traffic/views-history.csv
+          if [ ! -f "$VIEWS_FILE" ]; then
+            echo "date,views,unique_visitors" > "$VIEWS_FILE"
+          fi
+          TOTAL_VIEWS=$(jq '.count' .github/traffic/views-latest.json)
+          UNIQUE_VIEWS=$(jq '.uniques' .github/traffic/views-latest.json)
+          # Only append if today's date isn't already recorded
+          if ! grep -q "^${DATE}," "$VIEWS_FILE"; then
+            echo "${DATE},${TOTAL_VIEWS},${UNIQUE_VIEWS}" >> "$VIEWS_FILE"
+          fi
+
+          CLONES_FILE=.github/traffic/clones-history.csv
+          if [ ! -f "$CLONES_FILE" ]; then
+            echo "date,clones,unique_cloners" > "$CLONES_FILE"
+          fi
+          TOTAL_CLONES=$(jq '.count' .github/traffic/clones-latest.json)
+          UNIQUE_CLONES=$(jq '.uniques' .github/traffic/clones-latest.json)
+          if ! grep -q "^${DATE}," "$CLONES_FILE"; then
+            echo "${DATE},${TOTAL_CLONES},${UNIQUE_CLONES}" >> "$CLONES_FILE"
+          fi
+
+      - name: Commit if changed
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/traffic/
+          if git diff --cached --quiet; then
+            echo "No traffic changes to commit"
+          else
+            git commit -m "chore: daily traffic snapshot [skip ci]"
+            git push
+          fi

--- a/portal/index.html
+++ b/portal/index.html
@@ -12,5 +12,7 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script data-goatcounter="https://jvd-portal.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
   </body>
 </html>

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -196,10 +196,17 @@ export default function ByoaiSection() {
               />
             </div>
 
-            <div className="mt-4 text-[11px] text-muted-foreground">
-              <strong className="font-semibold text-foreground/80">Note:</strong> Gemini doesn&apos;t
-              currently support pre-filled prompts via URL; it&apos;s omitted here. The same BYOAI
-              prompt works on Gemini if pasted manually.
+            <div className="mt-4 space-y-2 text-[11px] text-muted-foreground">
+              <p>
+                <strong className="font-semibold text-foreground/80">Requires a free login:</strong>{" "}
+                Claude and ChatGPT require a (free) account to fetch the BYOAI prompt at launch.
+                No paid plan is needed — a free-tier login works.
+              </p>
+              <p>
+                <strong className="font-semibold text-foreground/80">Note:</strong> Gemini doesn&apos;t
+                currently support pre-filled prompts via URL; it&apos;s omitted here. The same BYOAI
+                prompt works on Gemini if pasted manually.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What's New
- Portal page-view analytics via GoatCounter (privacy-friendly, no cookies)
- Daily GitHub Action collects repo traffic (views, clones, referrers, paths) to `.github/traffic/` CSVs — builds permanent history beyond GitHub's 14-day window
- BYOAI section notes that a free login is required

## Why
Management needs portal + repo traffic numbers. GitHub provides no Pages analytics and only 14-day repo traffic.

## Changes
- `portal/index.html`: GoatCounter script tag
- `portal/src/components/ByoaiSection.tsx`: login-required note
- `.github/workflows/traffic-stats.yml`: daily traffic collection action

## Verified before merge
- [x] `bun run build` passes
- [x] No internal tooling or sensitive details exposed
- [x] Externally safe — GoatCounter is a well-known privacy-first analytics service