### PR TITLE
fix: rewrite traffic stats workflow

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -2,8 +2,8 @@ name: Repo Traffic Stats
 
 on:
   schedule:
-    - cron: '15 6 * * *'   # daily at 06:15 UTC (before GitHub's 14-day rolloff)
-  workflow_dispatch:        # manual trigger
+    - cron: '15 6 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,196 +12,107 @@ jobs:
   collect:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout traffic-stats branch
-        env:
-          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TRAFFIC_TOKEN }}
+          fetch-depth: 0
+
+      - name: Prepare traffic-stats branch
         run: |
-          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git clone --single-branch --branch traffic-stats "$REMOTE" repo 2>/dev/null || {
-            # Branch doesn't exist yet — create orphan
-            mkdir repo && cd repo && git init
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin traffic-stats >/dev/null 2>&1; then
+            git fetch origin traffic-stats
+            git checkout traffic-stats
+          else
             git checkout --orphan traffic-stats
+            git rm -rf . 2>/dev/null || true
             git commit --allow-empty -m "chore: initialize traffic-stats branch"
-            git remote add origin "$REMOTE"
-            git push -u origin traffic-stats
-          }
-          echo "REPO_DIR=$(cd repo && pwd)" >> $GITHUB_ENV
+          fi
 
       - name: Fetch traffic data
         env:
           GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: |
-          cd $REPO_DIR
           mkdir -p traffic
-
-          # Views (14-day rolling, per-day granularity)
-          gh api repos/${{ github.repository }}/traffic/views \
-            > traffic/views-latest.json
-
-          # Clones (14-day rolling, per-day granularity)
-          gh api repos/${{ github.repository }}/traffic/clones \
-            > traffic/clones-latest.json
-
-          # Top referrers (snapshot)
-          gh api repos/${{ github.repository }}/traffic/popular/referrers \
-            > traffic/referrers-latest.json
-
-          # Top paths (snapshot)
-          gh api repos/${{ github.repository }}/traffic/popular/paths \
-            > traffic/paths-latest.json
+          gh api repos/${{ github.repository }}/traffic/views > traffic/views-latest.json
+          gh api repos/${{ github.repository }}/traffic/clones > traffic/clones-latest.json
+          gh api repos/${{ github.repository }}/traffic/popular/referrers > traffic/referrers-latest.json
+          gh api repos/${{ github.repository }}/traffic/popular/paths > traffic/paths-latest.json
 
       - name: Merge per-day data into history CSVs
         run: |
-          cd $REPO_DIR
-          python3 << 'EOF'
+          python3 << 'PYEOF'
           import json, csv, os
-          from datetime import datetime
-
-          traffic_dir = "traffic"
 
           def merge_daily(json_file, csv_file, count_col, unique_col):
-              """Merge per-day API data into a cumulative CSV."""
-              # Load existing history
               existing = {}
               if os.path.exists(csv_file):
                   with open(csv_file) as f:
-                      reader = csv.DictReader(f)
-                      for row in reader:
+                      for row in csv.DictReader(f):
                           existing[row["date"]] = row
-
-              # Parse API response (has per-day breakdown)
               with open(json_file) as f:
                   data = json.load(f)
-
               for entry in data.get("views", data.get("clones", [])):
-                  ts = entry["timestamp"][:10]  # "2026-07-01T00:00:00Z" -> "2026-07-01"
-                  existing[ts] = {
-                      "date": ts,
-                      count_col: str(entry["count"]),
-                      unique_col: str(entry["uniques"]),
-                  }
-
-              # Write sorted
+                  ts = entry["timestamp"][:10]
+                  existing[ts] = {"date": ts, count_col: str(entry["count"]), unique_col: str(entry["uniques"])}
               fieldnames = ["date", count_col, unique_col]
               with open(csv_file, "w", newline="") as f:
-                  writer = csv.DictWriter(f, fieldnames=fieldnames)
-                  writer.writeheader()
-                  for date in sorted(existing.keys()):
-                      writer.writerow(existing[date])
+                  w = csv.DictWriter(f, fieldnames=fieldnames)
+                  w.writeheader()
+                  for d in sorted(existing): w.writerow(existing[d])
 
-          merge_daily(
-              f"{traffic_dir}/views-latest.json",
-              f"{traffic_dir}/views-history.csv",
-              "views", "unique_visitors"
-          )
-          merge_daily(
-              f"{traffic_dir}/clones-latest.json",
-              f"{traffic_dir}/clones-history.csv",
-              "clones", "unique_cloners"
-          )
-          print("History CSVs updated")
-          EOF
+          merge_daily("traffic/views-latest.json", "traffic/views-history.csv", "views", "unique_visitors")
+          merge_daily("traffic/clones-latest.json", "traffic/clones-history.csv", "clones", "unique_cloners")
+          print("CSVs updated")
+          PYEOF
 
       - name: Generate SVG charts
         run: |
-          cd $REPO_DIR
-          python3 << 'EOF'
+          python3 << 'PYEOF'
           import csv, os
-          from datetime import datetime
 
-          traffic_dir = "traffic"
-
-          def generate_svg_chart(csv_file, svg_file, title, col1, col2, color1="#4ade80", color2="#60a5fa"):
-              """Generate a simple SVG sparkline chart from CSV data."""
-              dates, vals1, vals2 = [], [], []
-              if not os.path.exists(csv_file):
-                  return
+          def chart(csv_file, svg_file, title, col1, col2, c1="#4ade80", c2="#60a5fa"):
+              dates, v1, v2 = [], [], []
+              if not os.path.exists(csv_file): return
               with open(csv_file) as f:
-                  reader = csv.DictReader(f)
-                  for row in reader:
-                      dates.append(row["date"])
-                      vals1.append(int(row[col1]))
-                      vals2.append(int(row[col2]))
-
-              if len(dates) < 2:
-                  return
-
-              # Chart dimensions
-              w, h = 720, 200
-              pad_l, pad_r, pad_t, pad_b = 50, 20, 40, 50
-              chart_w = w - pad_l - pad_r
-              chart_h = h - pad_t - pad_b
-
-              max_val = max(max(vals1), max(vals2), 1)
-              n = len(dates)
-
-              def x_pos(i):
-                  return pad_l + (i / (n - 1)) * chart_w if n > 1 else pad_l
-
-              def y_pos(v):
-                  return pad_t + chart_h - (v / max_val) * chart_h
-
-              # Build polyline points
-              pts1 = " ".join(f"{x_pos(i):.1f},{y_pos(v):.1f}" for i, v in enumerate(vals1))
-              pts2 = " ".join(f"{x_pos(i):.1f},{y_pos(v):.1f}" for i, v in enumerate(vals2))
-
-              # X-axis labels (show every 7th date or first/last)
-              x_labels = ""
-              for i, d in enumerate(dates):
-                  if i == 0 or i == n - 1 or i % 7 == 0:
-                      x_labels += f'<text x="{x_pos(i):.1f}" y="{h - 10}" text-anchor="middle" font-size="11" fill="#9ca3af">{d[5:]}</text>\n'
-
-              # Latest values for legend
-              latest1 = vals1[-1]
-              latest2 = vals2[-1]
-
+                  for r in csv.DictReader(f):
+                      dates.append(r["date"]); v1.append(int(r[col1])); v2.append(int(r[col2]))
+              if len(dates) < 2: return
+              w, h, pl, pr, pt, pb = 720, 200, 50, 20, 40, 50
+              cw, ch = w-pl-pr, h-pt-pb
+              mv = max(max(v1), max(v2), 1); n = len(dates)
+              xp = lambda i: pl+(i/(n-1))*cw if n>1 else pl
+              yp = lambda v: pt+ch-(v/mv)*ch
+              p1 = " ".join(f"{xp(i):.1f},{yp(v):.1f}" for i,v in enumerate(v1))
+              p2 = " ".join(f"{xp(i):.1f},{yp(v):.1f}" for i,v in enumerate(v2))
+              xl = ""
+              for i,d in enumerate(dates):
+                  if i==0 or i==n-1 or i%7==0:
+                      xl += f'<text x="{xp(i):.1f}" y="{h-10}" text-anchor="middle" font-size="11" fill="#9ca3af">{d[5:]}</text>\n'
               svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">
-            <rect width="{w}" height="{h}" fill="#0d1117" rx="8"/>
-            <text x="{pad_l}" y="24" font-size="14" font-weight="600" fill="#e6edf3">{title}</text>
-            <text x="{w - pad_r}" y="24" text-anchor="end" font-size="11" fill="#9ca3af">Last {n} days</text>
-            <!-- Grid lines -->
-            <line x1="{pad_l}" y1="{pad_t}" x2="{pad_l}" y2="{pad_t + chart_h}" stroke="#21262d" stroke-width="1"/>
-            <line x1="{pad_l}" y1="{pad_t + chart_h}" x2="{pad_l + chart_w}" y2="{pad_t + chart_h}" stroke="#21262d" stroke-width="1"/>
-            <!-- Lines -->
-            <polyline points="{pts1}" fill="none" stroke="{color1}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-            <polyline points="{pts2}" fill="none" stroke="{color2}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,3"/>
-            <!-- Legend -->
-            <circle cx="{pad_l + 10}" cy="{h - 32}" r="4" fill="{color1}"/>
-            <text x="{pad_l + 20}" y="{h - 28}" font-size="11" fill="#e6edf3">{col1}: {latest1}</text>
-            <circle cx="{pad_l + 150}" cy="{h - 32}" r="4" fill="{color2}"/>
-            <text x="{pad_l + 160}" y="{h - 28}" font-size="11" fill="#e6edf3">{col2}: {latest2}</text>
-            <!-- X labels -->
-            {x_labels}
-            <!-- Y max -->
-            <text x="{pad_l - 5}" y="{pad_t + 4}" text-anchor="end" font-size="11" fill="#9ca3af">{max_val}</text>
-            <text x="{pad_l - 5}" y="{pad_t + chart_h}" text-anchor="end" font-size="11" fill="#9ca3af">0</text>
-          </svg>'''
-
-              with open(svg_file, "w") as f:
-                  f.write(svg)
+          <rect width="{w}" height="{h}" fill="#0d1117" rx="8"/>
+          <text x="{pl}" y="24" font-size="14" font-weight="600" fill="#e6edf3">{title}</text>
+          <text x="{w-pr}" y="24" text-anchor="end" font-size="11" fill="#9ca3af">Last {n} days</text>
+          <line x1="{pl}" y1="{pt}" x2="{pl}" y2="{pt+ch}" stroke="#21262d"/>
+          <line x1="{pl}" y1="{pt+ch}" x2="{pl+cw}" y2="{pt+ch}" stroke="#21262d"/>
+          <polyline points="{p1}" fill="none" stroke="{c1}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+          <polyline points="{p2}" fill="none" stroke="{c2}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6,3"/>
+          <circle cx="{pl+10}" cy="{h-32}" r="4" fill="{c1}"/><text x="{pl+20}" y="{h-28}" font-size="11" fill="#e6edf3">{col1}: {v1[-1]}</text>
+          <circle cx="{pl+150}" cy="{h-32}" r="4" fill="{c2}"/><text x="{pl+160}" y="{h-28}" font-size="11" fill="#e6edf3">{col2}: {v2[-1]}</text>
+          {xl}
+          <text x="{pl-5}" y="{pt+4}" text-anchor="end" font-size="11" fill="#9ca3af">{mv}</text>
+          <text x="{pl-5}" y="{pt+ch}" text-anchor="end" font-size="11" fill="#9ca3af">0</text>
+        </svg>'''
+              with open(svg_file, "w") as f: f.write(svg)
               print(f"Generated {svg_file}")
 
-          generate_svg_chart(
-              f"{traffic_dir}/views-history.csv",
-              f"{traffic_dir}/views.svg",
-              "Page Views", "views", "unique_visitors"
-          )
-          generate_svg_chart(
-              f"{traffic_dir}/clones-history.csv",
-              f"{traffic_dir}/clones.svg",
-              "Git Clones", "clones", "unique_cloners"
-          )
-          EOF
+          chart("traffic/views-history.csv", "traffic/views.svg", "Page Views", "views", "unique_visitors")
+          chart("traffic/clones-history.csv", "traffic/clones.svg", "Git Clones", "clones", "unique_cloners")
+          PYEOF
 
-      - name: Commit if changed
-        env:
-          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+      - name: Commit and push to traffic-stats
         run: |
-          cd $REPO_DIR
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add traffic/
           if git diff --cached --quiet; then
             echo "No traffic changes to commit"


### PR DESCRIPTION
## What's New
Rewrites the traffic stats workflow to work reliably with branch protection.

## Why
Previous iterations failed due to: GITHUB_TOKEN lacking traffic API access (403), branch protection blocking pushes to main (GH013), missing git identity for orphan commit, and REPO_DIR env var not propagating across steps.

## Changes
- Uses `actions/checkout` with `TRAFFIC_TOKEN` PAT (handles auth consistently)
- Creates/checks out orphan `traffic-stats` branch (never touches main)
- Simplified Python for CSV merge + SVG chart generation
- All steps run in `$GITHUB_WORKSPACE` (no manual clone/cd)

## Verified before merge
- [x] Workflow syntax valid (YAML lint)
- [x] No secrets exposed in logs