### PR TITLE
docs(byoai): note ChatGPT Instant can't fetch the full launch prompt

### DIFF
--- a/portal/public/USING-BYOAI.md
+++ b/portal/public/USING-BYOAI.md
@@ -53,16 +53,27 @@ launch. "Attach/paste" = the prompt was downloaded and attached or pasted.
 
 _Last updated: 2026-07-15_
 
+> **Bottom line:** ChatGPT **Instant** mode can't reliably fetch the launch prompt
+> — use a **Thinking / Medium** mode, or **download & attach** the prompt (always
+> works). Claude works in every mode tested.
+
 | AI | Tier | Model / mode | Launch-fetch | Attach / paste | Last tested | Notes |
 |----|------|--------------|:------------:|:--------------:|-------------|-------|
-| ChatGPT | Pro | GPT‑5.5 · Instant | ✅ | — | 2026-07-15 | Fetched cleanly. |
-| ChatGPT | Pro | GPT‑5.5 · Medium | ✅ | — | 2026-07-15 | Fetched cleanly. |
-| ChatGPT | Free | Instant (model not disclosed) | ✅ | — | 2026-07-15 | Fetched cleanly. Free tier often doesn't show the active model. |
-| Claude | Pro | Sonnet 5 (app) | ✅ | ✅ | 2026-07-15 | Real BYOAI prompt + portal launch work. See injection note below. |
-| Claude | Pro | Haiku 4.5 (app) | ✅ | ✅ | 2026-07-15 | Real BYOAI prompt + portal launch work. See injection note below. |
+| ChatGPT | Pro | GPT‑5.5 · Medium (Thinking) | ✅ | ✅ | 2026-07-15 | Full launch fetches and greets cleanly. |
+| ChatGPT | Pro | GPT‑5.5 · Instant | ⚠️ | ✅ | 2026-07-15 | Fetched a tiny test file, but **failed the full ~18 KB launch prompt** (“you can't perform that action at this time”). Use Medium or attach. |
+| ChatGPT | Free | Instant (model not disclosed) | ⚠️ | ✅ | 2026-07-15 | Same as Pro Instant — unreliable browsing on the full prompt. Switch to a Thinking mode or attach. |
+| Claude | Pro | Sonnet 5 (app / web) | ✅ | ✅ | 2026-07-15 | Full launch works. See injection note below. |
+| Claude | Pro | Haiku 4.5 (app / web) | ✅ | ✅ | 2026-07-15 | Full launch works. See injection note below. |
+| Claude | Pro | Opus 4.6 (web) | ✅ | ✅ | 2026-07-15 | Full launch works. |
 | Gemini | — | — | n/a | ❓ | — | No URL pre-fill; paste/attach the prompt manually. |
 
-Legend: ✅ works · ❌ does not work · ❓ untested · — not applicable.
+Legend: ✅ works · ⚠️ unreliable / partial · ❌ does not work · ❓ untested · — not applicable.
+
+> **Why Instant differs.** A tiny probe file can fetch on Instant, but the full
+> launch prompt (~18 KB) often fails with “you can't perform that action at this
+> time” — that's ChatGPT's fast **Instant** tier declining / throttling the web
+> tool, not a problem with the prompt (it's served as `text/plain` from both the
+> CDN and raw GitHub). The fix is a browsing-capable mode or the attach path.
 
 > **Injection note.** Some assistants (notably Claude) will **decline to obey an
 > instruction that lives inside a fetched file** — that's correct prompt-injection

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -192,7 +192,7 @@ export default function ByoaiSection() {
               <AiTile
                 name="ChatGPT"
                 description="OpenAI's web app. Wide reach and good for quick, single-shot config snippets."
-                tip="Tip: needs web access. If it can't fetch the prompt, attach the file instead."
+                tip="Tip: Instant mode often can't fetch — use a Thinking mode, or attach the prompt."
                 href={chatGptUrl}
                 disabled={!selected}
                 logo={<ChatGptLogo />}


### PR DESCRIPTION
## What's New
Corrects the BYOAI compatibility guidance with a real-world finding: **ChatGPT Instant mode can't reliably fetch the full launch prompt.**

- Compatibility matrix now marks ChatGPT **Instant** as ⚠️ unreliable for launch-fetch (Medium / Thinking ✅), with a note explaining why.
- ChatGPT launch tile tip now says: *"Instant mode often can't fetch — use a Thinking mode, or attach the prompt."*

## Why
Hands-on testing showed the ~18 KB launch prompt fails on ChatGPT Instant ("you can't perform that action at this time") while Medium and Claude work. The earlier matrix marked Instant ✅ — but that was from a tiny probe file; the full prompt behaves differently. Both hosts serve the prompt as identical `text/plain` (18 KB), so this is the Instant tier throttling/declining the web tool, not a prompt/host issue.

## Details
- `portal/public/USING-BYOAI.md` — matrix updated (Instant ⚠️, Medium/Claude ✅, added Opus 4.6 row), new "bottom line" + "why Instant differs" notes, ⚠️ added to the legend.
- `portal/src/components/ByoaiSection.tsx` — sharpened the ChatGPT tip.

## Testing
- `bun run build` passes.
- Fix is documentation/copy only; the attach/paste fallback (always works) is unchanged.
