### PR TITLE
feat(byoai): add Design-mode grounding rules to all assistant bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ block provably faithful to the design it was validated on.
   **578 configuration building blocks**, including the new Scale-Out Stateful
   Firewall & NAT design and its AI-assistant bundle.
 
+### AI assistant (BYOAI)
+
+- **More faithful design answers** — the AI-assistant bundle for every design
+  now answers design questions grounded strictly in that design's validated
+  documentation: it explains only what the design documents, says plainly when
+  the documentation doesn't cover a point (instead of guessing), and attributes
+  each explanation to its source document and section.
+
 ### What this means for you
 
 - A complete, ready-to-use Scale-Out security design — documentation, validated
@@ -59,6 +67,9 @@ block provably faithful to the design it was validated on.
 - Greater confidence that every configuration building block in the library
   faithfully reflects the design it was validated on, with clearer, better-
   documented variables when you adapt one to your network.
+- When you ask a design assistant *why* something is configured a certain way,
+  it answers from the validated design — or tells you the design doesn't say —
+  rather than inventing a plausible-sounding rationale.
 
 ### By the numbers
 
@@ -68,6 +79,7 @@ block provably faithful to the design it was validated on.
 | New design documents (overviews, design guides, test briefs, datasheet) | 7 |
 | New configuration building blocks | 21 |
 | Designs with configuration-fidelity corrections/verification | 6 |
+| Designs with hardened AI-assistant grounding | 11 |
 | Source configuration files cleaned | 14 |
 | Designs in the portal library | 11 |
 | Configuration building blocks in the portal library | 578 |

--- a/data_center/adc/3stage_dc/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/data_center/adc/3stage_dc/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -116,6 +116,22 @@ PART 1 — GROUND RULES
    general Junos knowledge beyond the corpus, say so. Do not fabricate
    scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Pick the file that matches the target device family:
      Junos: esi-leaf1/2, server-leaf1 (QFX5120-48Y),

--- a/data_center/adc/3stage_dc/configuration/snips/byoai/jvd-3stage-dc-byoai-prompt.txt
+++ b/data_center/adc/3stage_dc/configuration/snips/byoai/jvd-3stage-dc-byoai-prompt.txt
@@ -88,6 +88,22 @@ PART 1 — GROUND RULES
    general Junos knowledge beyond the corpus, say so. Do not fabricate
    scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Pick the file that matches the target device family:
      Junos: esi-leaf1/2, server-leaf1 (QFX5120-48Y),

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -109,6 +109,22 @@ PART 1 — GROUND RULES
    general Junos/EVPN/RoCE knowledge beyond the corpus, say so. Do not
    fabricate scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. Role selection (this JVD is EVO-only).
    Every snip is under evo/ and all eight devices are QFX5240-64OD.
    The distinction is ROLE, not OS: most snips carry a LEAF variant

--- a/data_center/aidc/aiml_multitenancy_backend/configuration/snips/byoai/jvd-aiml-mtb-byoai-prompt.txt
+++ b/data_center/aidc/aiml_multitenancy_backend/configuration/snips/byoai/jvd-aiml-mtb-byoai-prompt.txt
@@ -82,6 +82,22 @@ PART 1 — GROUND RULES
    general Junos/EVPN/RoCE knowledge beyond the corpus, say so. Do not
    fabricate scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. Role selection (this JVD is EVO-only).
    Every snip is under evo/ and all eight devices are QFX5240-64OD.
    The distinction is ROLE, not OS: most snips carry a LEAF variant

--- a/enterprise_wan/ewan_adv_core_edge/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/enterprise_wan/ewan_adv_core_edge/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -104,6 +104,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/enterprise_wan/ewan_adv_core_edge/configuration/snips/byoai/jvd-ewan-ace-byoai-prompt.txt
+++ b/enterprise_wan/ewan_adv_core_edge/configuration/snips/byoai/jvd-ewan-ace-byoai-prompt.txt
@@ -82,6 +82,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/enterprise_wan/ewan_finance/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/enterprise_wan/ewan_finance/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -109,6 +109,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/enterprise_wan/ewan_finance/configuration/snips/byoai/jvd-ewan-fin-byoai-prompt.txt
+++ b/enterprise_wan/ewan_finance/configuration/snips/byoai/jvd-ewan-fin-byoai-prompt.txt
@@ -87,6 +87,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/3stage_dc/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/3stage_dc/SYSTEM_PROMPT.md
@@ -116,6 +116,22 @@ PART 1 — GROUND RULES
    general Junos knowledge beyond the corpus, say so. Do not fabricate
    scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Pick the file that matches the target device family:
      Junos: esi-leaf1/2, server-leaf1 (QFX5120-48Y),

--- a/portal/public/byoai/3stage_dc/jvd-3stage-dc-byoai-prompt.txt
+++ b/portal/public/byoai/3stage_dc/jvd-3stage-dc-byoai-prompt.txt
@@ -88,6 +88,22 @@ PART 1 — GROUND RULES
    general Junos knowledge beyond the corpus, say so. Do not fabricate
    scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Pick the file that matches the target device family:
      Junos: esi-leaf1/2, server-leaf1 (QFX5120-48Y),

--- a/portal/public/byoai/aiml_multitenancy_backend/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/aiml_multitenancy_backend/SYSTEM_PROMPT.md
@@ -109,6 +109,22 @@ PART 1 — GROUND RULES
    general Junos/EVPN/RoCE knowledge beyond the corpus, say so. Do not
    fabricate scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. Role selection (this JVD is EVO-only).
    Every snip is under evo/ and all eight devices are QFX5240-64OD.
    The distinction is ROLE, not OS: most snips carry a LEAF variant

--- a/portal/public/byoai/aiml_multitenancy_backend/jvd-aiml-mtb-byoai-prompt.txt
+++ b/portal/public/byoai/aiml_multitenancy_backend/jvd-aiml-mtb-byoai-prompt.txt
@@ -82,6 +82,22 @@ PART 1 — GROUND RULES
    general Junos/EVPN/RoCE knowledge beyond the corpus, say so. Do not
    fabricate scale/convergence numbers — quote the corpus.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. Role selection (this JVD is EVO-only).
    Every snip is under evo/ and all eight devices are QFX5240-64OD.
    The distinction is ROLE, not OS: most snips carry a LEAF variant

--- a/portal/public/byoai/broadband_edge/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/broadband_edge/SYSTEM_PROMPT.md
@@ -108,6 +108,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Devices split cleanly by role:
      Access Nodes (an1_acx7024, an2..an5_acx7100-48l)  = EVO

--- a/portal/public/byoai/broadband_edge/jvd-bbe-byoai-prompt.txt
+++ b/portal/public/byoai/broadband_edge/jvd-bbe-byoai-prompt.txt
@@ -86,6 +86,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Devices split cleanly by role:
      Access Nodes (an1_acx7024, an2..an5_acx7100-48l)  = EVO

--- a/portal/public/byoai/ewan_adv_core_edge/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/ewan_adv_core_edge/SYSTEM_PROMPT.md
@@ -104,6 +104,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/portal/public/byoai/ewan_adv_core_edge/jvd-ewan-ace-byoai-prompt.txt
+++ b/portal/public/byoai/ewan_adv_core_edge/jvd-ewan-ace-byoai-prompt.txt
@@ -82,6 +82,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/portal/public/byoai/ewan_finance/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/ewan_finance/SYSTEM_PROMPT.md
@@ -109,6 +109,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/ewan_finance/jvd-ewan-fin-byoai-prompt.txt
+++ b/portal/public/byoai/ewan_finance/jvd-ewan-fin-byoai-prompt.txt
@@ -87,6 +87,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/low_latency_queueing/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/low_latency_queueing/SYSTEM_PROMPT.md
@@ -109,6 +109,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/portal/public/byoai/low_latency_queueing/jvd-llq-byoai-prompt.txt
+++ b/portal/public/byoai/low_latency_queueing/jvd-llq-byoai-prompt.txt
@@ -87,6 +87,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/metro_as_a_service/SYSTEM_PROMPT.md
@@ -112,6 +112,22 @@ PART 1 — GROUND RULES
    distinguish "this is how the JVD does it" from "this is general
    Junos capability." Cite URLs when possible.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
+++ b/portal/public/byoai/metro_as_a_service/jvd-maas-byoai-prompt.txt
@@ -90,6 +90,22 @@ PART 1 — GROUND RULES
    distinguish "this is how the JVD does it" from "this is general
    Junos capability." Cite URLs when possible.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/metro_ethernet_business_services/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/metro_ethernet_business_services/SYSTEM_PROMPT.md
@@ -102,6 +102,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-byoai-prompt.txt
+++ b/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-byoai-prompt.txt
@@ -80,6 +80,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/portal/public/byoai/scale_out_firewall_nat/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/scale_out_firewall_nat/SYSTEM_PROMPT.md
@@ -115,6 +115,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/portal/public/byoai/scale_out_firewall_nat/jvd-so-fwnat-byoai-prompt.txt
+++ b/portal/public/byoai/scale_out_firewall_nat/jvd-so-fwnat-byoai-prompt.txt
@@ -93,6 +93,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/portal/public/byoai/scale_out_ipsec/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/scale_out_ipsec/SYSTEM_PROMPT.md
@@ -111,6 +111,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/portal/public/byoai/scale_out_ipsec/jvd-so-ipsec-byoai-prompt.txt
+++ b/portal/public/byoai/scale_out_ipsec/jvd-so-ipsec-byoai-prompt.txt
@@ -89,6 +89,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/portal/public/byoai/srv6_core_edge/SYSTEM_PROMPT.md
+++ b/portal/public/byoai/srv6_core_edge/SYSTEM_PROMPT.md
@@ -104,6 +104,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each transport / apply-group / interface / policy snip exists under
    both junos/ and evo/ (byte-identical). Services differ:

--- a/portal/public/byoai/srv6_core_edge/jvd-srv6-byoai-prompt.txt
+++ b/portal/public/byoai/srv6_core_edge/jvd-srv6-byoai-prompt.txt
@@ -82,6 +82,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each transport / apply-group / interface / policy snip exists under
    both junos/ and evo/ (byte-identical). Services differ:

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T03:41:25.964Z",
+  "generatedAt": "2026-07-21T04:11:52.209Z",
   "counts": {
     "total": 578,
     "junos": 300,

--- a/security/scale_out_firewall_nat/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/security/scale_out_firewall_nat/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -115,6 +115,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/security/scale_out_firewall_nat/configuration/snips/byoai/jvd-so-fwnat-byoai-prompt.txt
+++ b/security/scale_out_firewall_nat/configuration/snips/byoai/jvd-so-fwnat-byoai-prompt.txt
@@ -93,6 +93,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/security/scale_out_ipsec/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/security/scale_out_ipsec/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -111,6 +111,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/security/scale_out_ipsec/configuration/snips/byoai/jvd-so-ipsec-byoai-prompt.txt
+++ b/security/scale_out_ipsec/configuration/snips/byoai/jvd-so-ipsec-byoai-prompt.txt
@@ -89,6 +89,22 @@ PART 1 — GROUND RULES
    Cite which document AND which variant your answer draws from. When
    your answer uses general Junos knowledge beyond the corpus, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Every device in this JVD is Junos:
      MX304 load balancer (mx1_mx304)               = Junos

--- a/service_provider/broadband_edge/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/broadband_edge/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -108,6 +108,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Devices split cleanly by role:
      Access Nodes (an1_acx7024, an2..an5_acx7100-48l)  = EVO

--- a/service_provider/broadband_edge/configuration/snips/byoai/jvd-bbe-byoai-prompt.txt
+++ b/service_provider/broadband_edge/configuration/snips/byoai/jvd-bbe-byoai-prompt.txt
@@ -86,6 +86,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Devices split cleanly by role:
      Access Nodes (an1_acx7024, an2..an5_acx7100-48l)  = EVO

--- a/service_provider/low_latency_queueing/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/low_latency_queueing/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -109,6 +109,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/service_provider/low_latency_queueing/configuration/snips/byoai/jvd-llq-byoai-prompt.txt
+++ b/service_provider/low_latency_queueing/configuration/snips/byoai/jvd-llq-byoai-prompt.txt
@@ -87,6 +87,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/ (with a few OS-only
    exceptions). Pick the file that matches the target device family:

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -112,6 +112,22 @@ PART 1 — GROUND RULES
    distinguish "this is how the JVD does it" from "this is general
    Junos capability." Cite URLs when possible.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
+++ b/service_provider/metro_as_a_service/configuration/snips/byoai/jvd-maas-byoai-prompt.txt
@@ -90,6 +90,22 @@ PART 1 — GROUND RULES
    distinguish "this is how the JVD does it" from "this is general
    Junos capability." Cite URLs when possible.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Most topics exist under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -102,6 +102,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-byoai-prompt.txt
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-byoai-prompt.txt
@@ -80,6 +80,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each topic exists under both junos/ and evo/. Pick the file that
    matches the target device family:

--- a/service_provider/srv6_core_edge/configuration/snips/byoai/SYSTEM_PROMPT.md
+++ b/service_provider/srv6_core_edge/configuration/snips/byoai/SYSTEM_PROMPT.md
@@ -104,6 +104,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each transport / apply-group / interface / policy snip exists under
    both junos/ and evo/ (byte-identical). Services differ:

--- a/service_provider/srv6_core_edge/configuration/snips/byoai/jvd-srv6-byoai-prompt.txt
+++ b/service_provider/srv6_core_edge/configuration/snips/byoai/jvd-srv6-byoai-prompt.txt
@@ -82,6 +82,22 @@ PART 1 — GROUND RULES
    Cite which document your answer draws from. When your answer uses
    general Junos knowledge beyond what the corpus contains, say so.
 
+1c. Faithfulness (Design mode) — accuracy over completeness.
+   Your role is a faithful INTERPRETER of this validated design, not a
+   general network expert. Answer truthfully from the JVD; do not aim to
+   answer every question.
+   - Explain only what the JVD documents. Do NOT infer design intent or
+     rationale from a configuration value — give a "why" only if the JVD
+     states it.
+   - If the JVD does not cover a point, say "the JVD does not specify."
+     Do not fill the gap with general networking / Junos / RFC knowledge.
+   - Add external context ONLY if the user explicitly asks, and label it
+     clearly as outside the JVD.
+   - REQUIRED: attribute every design explanation to its source document
+     and section (e.g. "Source: design-guide — <section title>"). Identify
+     the section; do not quote large passages. If you cannot name a
+     supporting section, do not present the claim as JVD guidance.
+
 2. OS selection.
    Each transport / apply-group / interface / policy snip exists under
    both junos/ and evo/ (byte-identical). Services differ:


### PR DESCRIPTION
## What's New
The AI-assistant (BYOAI) bundles for every design now include an explicit **Design-mode grounding rule** that keeps answers faithful to the validated design — reducing the chance the assistant invents design rationale the JVD never states.

- All **11** designs' assistant bundles gain a `1c. Faithfulness (Design mode)` rule.
- The assistant is now framed as a faithful **interpreter of the validated design**, not a general network expert.
- Every design explanation must **name its source document + section**; if the JVD is silent, the assistant says so instead of guessing.

## Why
Real-world testing surfaced a Design-mode drift: the assistant invented an engineering rationale for a config value that the JVD never documents, and presented it as if it were the design's reasoning. The existing rule required citing a document and flagging external knowledge, but did not forbid **inferring rationale** or require the assistant to admit when the JVD is silent — the exact gap that allowed the drift.

## Changes
- [x] Added a compact `1c. Faithfulness (Design mode)` block after the existing Design-mode source-of-truth rule in all 11 `SYSTEM_PROMPT.md` bundles: don't infer rationale, say "the JVD does not specify" when silent, prefer accuracy over completeness, label external context, and **require source attribution** (identify the section — no large quotes).
- [x] Regenerated each bundle's shareable prompt from its updated system prompt (11 bundles).
- [x] Refreshed the portal BYOAI mirror + snip index.
- [x] Updated the bundle-authoring guidance so future designs include the rule automatically.

## Verified before merge
- [x] **Insertion correctness** — `1b → 1c → rule 2` sequence verified; idempotent (re-runnable without duplication); all 11 bundles updated.
- [x] **Bundle regeneration** — all 11 prompt files regenerated cleanly; no snip-content churn (manifests unchanged).
- [x] **Portal index guard** — `generate-snips.mjs --check` OK (**578 snips, 11 JVDs, 0 warnings**).
- [x] **Portal build** — `bun run build` ✓.
- [x] **Markdown links** — lychee `--offline --include-fragments` on changed prompts: **2 OK, 0 errors**.
- [x] **Scope** — Design mode only; Configuration-mode snip generation unchanged.

## Notes
- Low risk and fully revertible — this is additive prompt guidance, no configuration or snip changes.
- Prompt addition is intentionally compact (~10 lines) to protect launch-prompt fetch reliability on lighter AI tiers.
- Prompting reduces but cannot fully eliminate model drift; the required source-attribution bullet also makes any unsupported claim easy to spot.
