### PR TITLE
feat(portal): discoverable BYOAI help + collapsible Config Explorer with clear-snip

### DIFF
--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Sparkles, ExternalLink, Github, Info } from "lucide-react";
+import { Sparkles, ExternalLink, Github, Info, LifeBuoy, Download } from "lucide-react";
 import jvds from "@/data/jvds.json";
 import { snipBundle } from "@/lib/snips";
 import { track } from "@/lib/analytics";
@@ -172,6 +172,44 @@ export default function ByoaiSection() {
                 Both providers accept a query-param to pre-fill the chat. The assistant fetches the
                 public BYOAI prompt at launch and adopts it as task instructions.
               </span>
+            </div>
+
+            {/* Help / troubleshooting — discoverable entry point */}
+            <div className="mt-4 rounded-md border border-primary/30 bg-primary/5 p-3">
+              <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                <LifeBuoy className="h-4 w-4 shrink-0 text-primary" />
+                Having trouble?
+              </div>
+              <div className="mt-2 flex flex-col gap-2 text-[11px]">
+                {selected ? (
+                  <a
+                    href={selected.promptUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    download
+                    onClick={() => track(`byoai-download-prompt-${selected.id}`)}
+                    className="inline-flex items-start gap-1.5 text-muted-foreground hover:text-primary"
+                  >
+                    <Download className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>Download the prompt and paste it into the chat</span>
+                  </a>
+                ) : (
+                  <span className="inline-flex items-start gap-1.5 text-muted-foreground">
+                    <Download className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>Download the prompt and paste it into the chat</span>
+                  </span>
+                )}
+                <a
+                  href={GUIDE_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => track("byoai-help-tips")}
+                  className="inline-flex items-start gap-1.5 text-muted-foreground hover:text-primary"
+                >
+                  <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>Need setup tips? See what&apos;s tested &amp; working</span>
+                </a>
+              </div>
             </div>
           </div>
 

--- a/portal/src/components/SnipLibrary.tsx
+++ b/portal/src/components/SnipLibrary.tsx
@@ -165,6 +165,7 @@ function TreeNode({
   node,
   depth,
   expanded,
+  forceOpen,
   toggle,
   selectedId,
   onSelectSnip,
@@ -174,6 +175,7 @@ function TreeNode({
   node: GroupNode;
   depth: number;
   expanded: Set<string>;
+  forceOpen: boolean;
   toggle: (id: string) => void;
   selectedId: string;
   onSelectSnip: (id: string) => void;
@@ -191,7 +193,7 @@ function TreeNode({
     visibleSnipIds.length + visibleChildren.reduce((n, c) => n + c.visibleCount, 0);
   if (visibleCount === 0) return null;
 
-  const isOpen = expanded.has(node.id);
+  const isOpen = forceOpen || expanded.has(node.id);
   const isLeafGroup = !!node.snipIds;
 
   const padding = { paddingLeft: `${0.5 + depth * 0.75}rem` };
@@ -227,6 +229,7 @@ function TreeNode({
                   node={child}
                   depth={depth + 1}
                   expanded={expanded}
+                  forceOpen={forceOpen}
                   toggle={toggle}
                   selectedId={selectedId}
                   onSelectSnip={onSelectSnip}
@@ -334,10 +337,12 @@ function CopyButton({ text }: { text: string }) {
 function SnipDetail({
   snip,
   onSelectSnip,
+  onClose,
   snipById,
 }: {
   snip: SnipRecord;
   onSelectSnip: (id: string) => void;
+  onClose: () => void;
   snipById: Map<string, SnipRecord>;
 }) {
   const githubUrl = REPO_BLOB_BASE + snip.path;
@@ -349,8 +354,16 @@ function SnipDetail({
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="border-b border-border px-6 py-5">
-        <div className="flex flex-wrap items-center gap-2">
+      <div className="relative border-b border-border px-6 py-5">
+        <button
+          onClick={onClose}
+          aria-label="Close snip"
+          title="Close"
+          className="absolute right-4 top-4 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <div className="flex flex-wrap items-center gap-2 pr-10">
           <Pill tone="primary">{snip.jvdLabel}</Pill>
           <Pill tone="outline">{snip.os}</Pill>
           <Pill>{titleize(snip.category)}</Pill>
@@ -565,18 +578,9 @@ export default function SnipLibrary() {
 
   const tree = useMemo(() => buildTree(allSnips, mode), [allSnips, mode]);
 
-  // Auto-expand: top level always; if a single top group, also expand its children
-  useEffect(() => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      // First time on this mode? Open top level by default.
-      const topIds = tree.map((n) => n.id);
-      if (topIds.every((id) => !prev.has(id)) && topIds.length <= 4) {
-        for (const id of topIds) next.add(id);
-      }
-      return next;
-    });
-  }, [tree]);
+  // Tracks start collapsed by default (compact). While a search query or JVD
+  // filter is active, groups with matches are force-opened at render time (see
+  // `forceOpen` below) so results are always visible without manual expansion.
 
   // Auto-expand the path to the selected snip so it's visible
   useEffect(() => {
@@ -679,7 +683,7 @@ export default function SnipLibrary() {
         )}
 
         {/* Two-pane layout */}
-        <div className="mt-8 grid min-h-[36rem] grid-cols-1 gap-6 lg:grid-cols-[minmax(20rem,24rem)_1fr]">
+        <div className="mt-8 grid grid-cols-1 items-start gap-6 lg:grid-cols-[minmax(20rem,24rem)_1fr]">
           {/* Left: tree */}
           <div className="rounded-lg border border-border bg-surface/40 p-3">
             <div className="max-h-[calc(100vh-12rem)] overflow-y-auto">
@@ -694,6 +698,7 @@ export default function SnipLibrary() {
                     node={n}
                     depth={0}
                     expanded={expanded}
+                    forceOpen={!!query.trim() || !!jvdF}
                     toggle={toggle}
                     selectedId={selectedId}
                     onSelectSnip={setSelectedId}
@@ -716,10 +721,11 @@ export default function SnipLibrary() {
               <SnipDetail
                 snip={selectedSnip}
                 onSelectSnip={setSelectedId}
+                onClose={() => setSelectedId("")}
                 snipById={snipById}
               />
             ) : (
-              <div className="flex h-full min-h-[28rem] flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+              <div className="flex h-full min-h-[16rem] flex-col items-center justify-center gap-3 px-6 py-12 text-center">
                 <FileCode className="h-10 w-10 text-muted-foreground/50" />
                 <div>
                   <p className="text-sm font-medium text-foreground">Pick a snip to view</p>


### PR DESCRIPTION
## What's New
Three portal navigation and usability improvements to the Design & Planner and Config Explorer sections.

- 🆘 **Discoverable BYOAI help** — a "Having trouble?" panel in the Design & Planner picker with two clear actions: download the prompt to paste manually, and a link to setup tips / what's tested & working
- 📁 **Config Explorer starts tidy** — the JVD tracks (Data Center, Enterprise WAN, etc.) now start collapsed and the section is sized to fit, so it no longer takes over the page; it grows as you expand
- ✖️ **Clear a snip** — a close (X) button on the selected snip so you can "start over" instead of being stuck with a config on the right until you pick another

## Why
The BYOAI usage help existed but was buried and hard to find. The Config Explorer opened fully expanded and consumed a lot of vertical space before you'd done anything. And once a snip was selected there was no way to dismiss it. These changes make the two sections easier to navigate.

## Details
- **ByoaiSection** — added a "Having trouble?" help panel (lifebuoy icon) to the Step 1 card: a download-the-prompt link (falls back to paste when the AI can't fetch) and a tips link to the existing `USING-BYOAI.md` guide. The right-column "what's tested & working" link is unchanged and points to the same guide.
- **SnipLibrary** — tracks now start collapsed; removed the fixed min-height and let the two-pane layout size to content (`items-start`) so the section stays compact and grows on expand. While a search query or JVD filter is active, matching groups force-open at render time so results are never hidden. Added an X "Close snip" control to the detail header that clears the selection.

## Testing
- Portal build passes
- Verified in a local preview: tracks collapsed on load; typing a query expands straight to matching snips; selecting a snip shows the detail with an X; clicking X returns to the "Pick a snip to view" empty state (and drops the `id` from the URL)

## Notes
Source-only change (no snip data or BYOAI bundle regeneration). The demo video and its portal embed are tracked separately.
