### PR TITLE
feat(portal): add BYOAI tips doc + de-duplicate help links

### DIFF
--- a/portal/public/BYOAI-TIPS.md
+++ b/portal/public/BYOAI-TIPS.md
@@ -1,0 +1,85 @@
+# BYOAI Tips — getting the most out of the assistants
+
+Practical tips for working with the Juniper Validated Design (JVD) **Bring Your
+Own AI** assistants. For the full how-it-works walkthrough and the
+**tested-&-working compatibility notes**, see
+[Using BYOAI](USING-BYOAI.md).
+
+> These assistants live in the **Design & Planner (BYOAI)** section of the
+> [JVD Portal](https://juniper.github.io/jvd/portal/#byoai). Pick a JVD, launch
+> Claude or ChatGPT, and the assistant works from that design's validated snip
+> library and documentation.
+
+---
+
+## Pick the right model
+
+- Use a **browsing-capable** model so the assistant can fetch the prompt and the
+  JVD docs on its own. Most current tiers can; a few can't.
+- On ChatGPT, prefer a **Thinking** mode — *Instant* mode often can't fetch. If
+  fetching fails, **download the prompt and paste/attach it** instead (no
+  fetching required). See [Using BYOAI](USING-BYOAI.md) for what's tested.
+- One JVD per chat. Start a fresh chat when you switch designs so the assistant
+  isn't mixing two designs' context.
+
+## Two modes — say which you want
+
+The assistant opens with a **mode menu**. You can pick, or just describe what you
+need and it will infer.
+
+- **Design mode** — questions, architecture, scale, "why." Ask for a *rundown*
+  of the design to get oriented. It answers **grounded in the JVD documentation
+  and cites its source** — and it will say plainly when the JVD doesn't cover
+  something rather than guessing.
+- **Configuration mode** — generates ready-to-deploy Junos / Junos Evolved config
+  from the validated snip library. Say "config mode" or "generate …".
+
+You can switch anytime ("design mode" / "config mode"), including "now generate
+that" after a design discussion.
+
+## Get better configuration output
+
+- **Interview vs. auto** — choose `interview` and the assistant batches a few
+  questions to get exact values; choose `auto` and it fills from the JVD lab
+  defaults and lists every value it used at the top.
+- **Form tiers** — `minimum` gives just the requested stanza; `as-deployed` adds
+  the supporting config the JVD renders alongside it (loopbacks, forwarding,
+  paired prerequisites). For a greenfield turn-up, prefer `as-deployed`.
+- **Be specific** — name the device(s), feature, and any IDs (VLAN/VNI, ASN,
+  interface). Anything you don't specify, the assistant defaults and tells you.
+- **Reproducibility** — every generation starts with an `Inputs used:` block.
+  Save it; paste it back later to regenerate the same output with your edits.
+- **Pair-with completeness** — the assistant pulls the snips a feature needs to
+  actually work. If it notes one was omitted, ask for it.
+
+## If an answer looks off — say so
+
+Every assistant has a built-in feedback loop: **tell it what looks wrong** and it
+re-checks the JVD's validated documentation and corrects itself, citing the
+source. It won't get defensive — that's the intended workflow.
+
+If you've found a real problem with a design (or want to suggest an improvement),
+open an issue at
+[github.com/Juniper/jvd/issues](https://github.com/Juniper/jvd/issues).
+
+## Guardrails to keep in mind
+
+- **It's still an LLM.** These assistants are *grounded* by the JVD prompt, but
+  large language models are ultimately built to be helpful and to follow your
+  instructions — so they **can** drift from the validated design, especially if
+  you push them to (e.g. "just make it work anyway," "ignore that," or asking for
+  something the JVD never covered). The grounding is a strong guide, not a hard
+  guarantee. If an answer strays, tell it to re-check the JVD, or reload the
+  prompt in a fresh chat.
+- Configuration is **meant to come strictly from the validated design** — if
+  something isn't in the snip library, the assistant should say so instead of
+  inventing syntax. That's by design: it keeps the output trustworthy.
+- Design answers should stay within what the JVD documents. Ask explicitly if you
+  want general context beyond the JVD, and it will label that clearly.
+- Always review generated config against your own environment before deploying —
+  and double-check anything that matters rather than assuming it's verbatim from
+  the design.
+
+---
+
+*More detail and the tested-&-working matrix: [Using BYOAI](USING-BYOAI.md).*

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -45,6 +45,10 @@ function buildChatGptUrl(promptUrl: string): string {
 const GUIDE_URL =
   "https://github.com/Juniper/jvd/blob/main/portal/public/USING-BYOAI.md";
 
+// Practical tips for getting the most out of the BYOAI assistants.
+const TIPS_URL =
+  "https://github.com/Juniper/jvd/blob/main/portal/public/BYOAI-TIPS.md";
+
 export default function ByoaiSection() {
   const allJvds = jvds as JvdEntry[];
   const byoaiJvds = snipBundle.byoaiJvds || [];
@@ -200,14 +204,14 @@ export default function ByoaiSection() {
                   </span>
                 )}
                 <a
-                  href={GUIDE_URL}
+                  href={TIPS_URL}
                   target="_blank"
                   rel="noreferrer"
-                  onClick={() => track("byoai-help-tips")}
+                  onClick={() => track("byoai-tips")}
                   className="inline-flex items-start gap-1.5 text-muted-foreground hover:text-primary"
                 >
                   <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>Need setup tips? See what&apos;s tested &amp; working</span>
+                  <span>Check out some BYOAI tips!</span>
                 </a>
               </div>
             </div>
@@ -251,22 +255,6 @@ export default function ByoaiSection() {
                   what&apos;s tested &amp; working
                 </a>
                 .
-              </p>
-              <p>
-                <strong className="font-semibold text-foreground/80">Having trouble?</strong>{" "}
-                {selected ? (
-                  <a
-                    href={selected.promptUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="underline hover:text-primary"
-                  >
-                    Download the prompt
-                  </a>
-                ) : (
-                  <span>Download the prompt</span>
-                )}{" "}
-                and attach or paste it into your chat instead — no fetching required.
               </p>
               <p>
                 <strong className="font-semibold text-foreground/80">Note:</strong> Gemini doesn&apos;t


### PR DESCRIPTION
## What's New
A dedicated BYOAI tips page and a cleanup of the help links in the Design & Planner section.

- 📄 **New "BYOAI Tips" guide** — practical advice for getting good results from the assistants (model choice, the two modes, interview/auto + form tiers, reproducibility, the feedback loop, and an honest "it's still an LLM" caveat)
- 🔗 **De-duplicated help** — removed the redundant second "Having trouble?" line; the help panel's tips link now points to the new guide, while "See what's tested & working" continues to point at the existing usage guide

## Why
The BYOAI usage help had grown two "Having trouble?" entry points after the recent discoverability pass. This consolidates to one clear panel and adds a genuinely useful, non-duplicative tips page — with the tips page linking back to the compatibility guide so information lives in one place.

## Details
- **ByoaiSection** — removed the duplicate "Having trouble? … download the prompt … no fetching required" paragraph from the right column; kept the "what's tested & working" link. Retargeted the help panel's second link from the usage guide to the new tips guide and relabeled it "Check out some BYOAI tips!"
- **New `portal/public/BYOAI-TIPS.md`** — covers picking a browsing-capable/Thinking model, Design vs Configuration mode, interview vs auto and minimum vs as-deployed tiers, reproducibility via the `Inputs used:` block, the self-correction/feedback loop, and guardrails. Leads the guardrails with a caveat that LLMs are ultimately built to follow instructions and can drift from the validated design — especially if pushed to — so the grounding is a strong guide, not a hard guarantee. Links back to `USING-BYOAI.md` for the tested-&-working matrix.

## Testing
- Portal build passes
- Verified in a local preview: a single "Having trouble?" panel, the new "Check out some BYOAI tips!" link, and the "what's tested & working" link all present; the old duplicate is gone

## Notes
Source + docs only; no snip data or BYOAI bundle regeneration.
