### PR TITLE
chore: gitignore Python venv and caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 # Real scratch lives under the actual ~/git-tmp; never inside the repo.
 /~/
 **/~/
+# Python virtualenvs & caches (local dev only — must never be committed)
+.venv/
+**/.venv/
+__pycache__/
+**/__pycache__/
+*.pyc


### PR DESCRIPTION
## What's New
Ignore local Python virtualenvs and caches so they can never be accidentally committed.

## Why
The repo can contain a local `.venv/` during development (e.g. for the snip/portal tooling). It was untracked but **not** ignored, so a careless `git add -A` could have committed thousands of site-packages files. This adds the standard Python ignores.

## Details
- `.gitignore`: add `.venv/`, `**/.venv/`, `__pycache__/`, `**/__pycache__/`, `*.pyc`

## Testing
- `git check-ignore .venv` now resolves (ignored); no tracked files affected.

## Notes
Housekeeping only.