### PR TITLE
fix: correct DCI-over-IPoDWDM BYOAI bundle title

### DIFF
--- a/optical/dci_over_ipodwdm/configuration/snips/byoai/jvd-dci-ipodwdm-snips.md
+++ b/optical/dci_over_ipodwdm/configuration/snips/byoai/jvd-dci-ipodwdm-snips.md
@@ -1,4 +1,4 @@
-# JVD Metro-as-a-Service snippet library
+# JVD Data Center Interconnect over IPoDWDM snippet library
 
 ## evo/chassis/aggregated-devices.conf
 

--- a/optical/dci_over_ipodwdm/configuration/snips/byoai/regenerate-bundle.sh
+++ b/optical/dci_over_ipodwdm/configuration/snips/byoai/regenerate-bundle.sh
@@ -13,7 +13,7 @@ cd "$(dirname "$0")/.."   # cd into snips/
 OUT="byoai/jvd-dci-ipodwdm-snips.md"
 
 {
-  echo "# JVD Metro-as-a-Service snippet library"
+  echo "# JVD Data Center Interconnect over IPoDWDM snippet library"
   echo
   for f in $(find junos evo -name '*.conf' | sort); do
     echo "## $f"

--- a/portal/public/byoai/dci_over_ipodwdm/jvd-dci-ipodwdm-snips.md
+++ b/portal/public/byoai/dci_over_ipodwdm/jvd-dci-ipodwdm-snips.md
@@ -1,4 +1,4 @@
-# JVD Metro-as-a-Service snippet library
+# JVD Data Center Interconnect over IPoDWDM snippet library
 
 ## evo/chassis/aggregated-devices.conf
 


### PR DESCRIPTION
## What's New
Corrects the title of the Data Center Interconnect over IPoDWDM BYOAI snip bundle.

## Why
The bundle header read `# JVD Metro-as-a-Service snippet library` — a leftover from when the DCI bundle scripts were seeded from the Metro-as-a-Service design. The wrong title shipped in both the bundle and the public portal mirror, so an AI (or user) loading the DCI bundle saw the Metro-as-a-Service name.

## Details
- Fixed the title line in `optical/dci_over_ipodwdm/configuration/snips/byoai/regenerate-bundle.sh`
- Regenerated `jvd-dci-ipodwdm-snips.md` and the portal mirror; refreshed `portal/src/data/snips.json`

## Testing
- Title now reads `# JVD Data Center Interconnect over IPoDWDM snippet library` in both the source bundle and the mirror
- Portal build passes (638 snips / 17 JVDs / 0 warnings)

## Notes
Title-only change; no snip content or prompt changes.