### PR TITLE
docs(portal): recommend User install target for VS Code BYOAI prompt

### DIFF
--- a/portal/public/USING-BYOAI.md
+++ b/portal/public/USING-BYOAI.md
@@ -43,6 +43,12 @@ context that does not modify files or run commands. On VS Code Insiders, use the
 hosted assistants, the exact prompt is public — use **View prompt source** to read
 it first.
 
+> **Where to install:** when VS Code asks, choose **User** to make the assistant
+> available in every workspace and keep it out of any repository. Choosing
+> **Workspace** instead writes the prompt into the open project's
+> `.github/prompts/` folder — pick that only if you intend to commit it to that
+> project.
+
 ---
 
 ## Security & trust

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -292,7 +292,9 @@ export default function ByoaiSection() {
                 with a GitHub Copilot subscription. The button installs the prompt (it doesn&apos;t
                 pre-fill the chat) — run it with{" "}
                 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[10px]">{vscodeCmd}</code>.
-                It runs in read-only <em>ask</em> mode. Using Insiders? Swap the scheme to{" "}
+                It runs in read-only <em>ask</em> mode. When VS Code asks where to install, choose{" "}
+                <strong className="font-semibold text-foreground/80">User</strong> to keep it out of your
+                repo (Workspace adds it to the open project). Using Insiders? Swap the scheme to{" "}
                 <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[10px]">vscode-insiders:</code>.
               </p>
             </div>


### PR DESCRIPTION
## What's New
Adds a short guidance note to the BYOAI **Open in VS Code** flow: when VS Code asks where to install the prompt, choose **User** to keep it out of your repository.

## Why
The `vscode:chat-prompt/install` link can't pre-select the install location — VS Code asks the user to pick **User** (profile, all workspaces) or **Workspace** (`.github/prompts/` of the open project). Picking Workspace drops the prompt into whatever repo you have open, which is usually unintended for a cross-project assistant. This steers users to the right choice.

## Details
- `portal/src/components/ByoaiSection.tsx` — the VS Code footnote now recommends the **User** target.
- `portal/public/USING-BYOAI.md` — a "Where to install" callout in the Open in VS Code section.

## Testing
- Portal build clean; 0 TS errors.

## Notes
Follow-up to #174 (the doc tweak was authored after that PR was squash-merged, so it lands here). Docs-only.