### PR TITLE
chore(portal): add noscript fallback, refresh sitemap date

### DIFF
--- a/portal/index.html
+++ b/portal/index.html
@@ -28,6 +28,22 @@
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <div style="max-width:42rem;margin:4rem auto;padding:0 1.5rem;font-family:system-ui,sans-serif;line-height:1.6">
+        <h1>JVD Portal &mdash; Juniper Validated Designs</h1>
+        <p>
+          The JVD Portal is an interactive catalog of Juniper Validated Designs:
+          production-ready reference architectures for data center, enterprise WAN,
+          optical, security, and service provider networks. Browse each design&rsquo;s
+          validated configuration building blocks, ask design questions grounded in
+          the documentation, and generate validated device configuration.
+        </p>
+        <p>
+          This portal requires JavaScript. Explore the designs and their source on
+          <a href="https://github.com/Juniper/jvd">GitHub (Juniper/jvd)</a>.
+        </p>
+      </div>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
     <script data-goatcounter="https://jvd-portal.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>

--- a/portal/public/sitemap.xml
+++ b/portal/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://juniper.github.io/jvd/portal/</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## What's New
Minor SEO/crawlability tweaks for the portal.

## Details
- `portal/index.html` — adds a `<noscript>` fallback with the portal name, description, and a link to the repo (crawlable text + graceful degradation when JS is off).
- `portal/public/sitemap.xml` — bumps `lastmod` to 2026-07-24.

## Testing
- Build clean; both present in `dist/`.

## Notes
No robots.txt: GitHub Pages only honors it at the host root, which this repo doesn't control.