### PR TITLE
fix(portal): give VS Code BYOAI prompts read-only web access

### DIFF
--- a/portal/public/byoai/3stage_dc/3stage-dc.prompt.md
+++ b/portal/public/byoai/3stage_dc/3stage-dc.prompt.md
@@ -2,6 +2,7 @@
 description: '3-Stage Data Center — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-3stage-dc
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) 3-STAGE DATA CENTER

--- a/portal/public/byoai/5stage_evpn_vxlan/5stage.prompt.md
+++ b/portal/public/byoai/5stage_evpn_vxlan/5stage.prompt.md
@@ -2,6 +2,7 @@
 description: '5-Stage EVPN-VXLAN — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-5stage
 agent: ask
+tools: ['fetch']
 ---
 
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) 5-STAGE EVPN-VXLAN

--- a/portal/public/byoai/aiml_inference_frontend/aiml-inf.prompt.md
+++ b/portal/public/byoai/aiml_inference_frontend/aiml-inf.prompt.md
@@ -2,6 +2,7 @@
 description: 'AI Data Center Frontend Fabric for Inference — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-aiml-inf
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) AI DATA CENTER

--- a/portal/public/byoai/aiml_multitenancy_backend/aiml-mtb.prompt.md
+++ b/portal/public/byoai/aiml_multitenancy_backend/aiml-mtb.prompt.md
@@ -2,6 +2,7 @@
 description: 'AI/ML Multitenancy Backend — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-aiml-mtb
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) AI/ML MULTI-TENANCY

--- a/portal/public/byoai/broadband_edge/bbe.prompt.md
+++ b/portal/public/byoai/broadband_edge/bbe.prompt.md
@@ -2,6 +2,7 @@
 description: 'Broadband Edge — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-bbe
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) METRO FABRIC AND

--- a/portal/public/byoai/collapsed_dc_fabric/collapsed.prompt.md
+++ b/portal/public/byoai/collapsed_dc_fabric/collapsed.prompt.md
@@ -2,6 +2,7 @@
 description: 'Collapsed DC Fabric — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-collapsed
 agent: ask
+tools: ['fetch']
 ---
 
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) COLLAPSED DATA

--- a/portal/public/byoai/collapsed_dc_fabric_with_access/collapsed-access.prompt.md
+++ b/portal/public/byoai/collapsed_dc_fabric_with_access/collapsed-access.prompt.md
@@ -2,6 +2,7 @@
 description: 'Collapsed DC Fabric with Access — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-collapsed-access
 agent: ask
+tools: ['fetch']
 ---
 
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVDE) COLLAPSED DATA

--- a/portal/public/byoai/dci_over_ipodwdm/dci-ipodwdm.prompt.md
+++ b/portal/public/byoai/dci_over_ipodwdm/dci-ipodwdm.prompt.md
@@ -2,6 +2,7 @@
 description: 'DCI over IPoDWDM — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-dci-ipodwdm
 agent: ask
+tools: ['fetch']
 ---
 
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) DATA CENTER

--- a/portal/public/byoai/evpn_vxlan_dci/evpn-dci.prompt.md
+++ b/portal/public/byoai/evpn_vxlan_dci/evpn-dci.prompt.md
@@ -2,6 +2,7 @@
 description: 'EVPN-VXLAN DCI — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-evpn-dci
 agent: ask
+tools: ['fetch']
 ---
 
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) EVPN-VXLAN DATA

--- a/portal/public/byoai/ewan_adv_core_edge/ewan-ace.prompt.md
+++ b/portal/public/byoai/ewan_adv_core_edge/ewan-ace.prompt.md
@@ -2,6 +2,7 @@
 description: 'Enterprise WAN: Advanced Core/Edge — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-ewan-ace
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) ENTERPRISE WAN

--- a/portal/public/byoai/ewan_finance/ewan-fin.prompt.md
+++ b/portal/public/byoai/ewan_finance/ewan-fin.prompt.md
@@ -2,6 +2,7 @@
 description: 'Enterprise WAN: Finance — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-ewan-fin
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) ENTERPRISE WAN

--- a/portal/public/byoai/low_latency_queueing/llq.prompt.md
+++ b/portal/public/byoai/low_latency_queueing/llq.prompt.md
@@ -2,6 +2,7 @@
 description: 'Low Latency Queueing — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-llq
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) LOW LATENCY QoS

--- a/portal/public/byoai/metro_as_a_service/maas.prompt.md
+++ b/portal/public/byoai/metro_as_a_service/maas.prompt.md
@@ -2,6 +2,7 @@
 description: 'Metro as a Service — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-maas
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) METRO-AS-A-SERVICE

--- a/portal/public/byoai/metro_ethernet_business_services/mebs.prompt.md
+++ b/portal/public/byoai/metro_ethernet_business_services/mebs.prompt.md
@@ -2,6 +2,7 @@
 description: 'Metro Ethernet Business Services — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-mebs
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) METRO ETHERNET

--- a/portal/public/byoai/scale_out_firewall_nat/so-fwnat.prompt.md
+++ b/portal/public/byoai/scale_out_firewall_nat/so-fwnat.prompt.md
@@ -2,6 +2,7 @@
 description: 'Scale-Out Firewall NAT — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-so-fwnat
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) SCALE-OUT STATEFUL

--- a/portal/public/byoai/scale_out_ipsec/so-ipsec.prompt.md
+++ b/portal/public/byoai/scale_out_ipsec/so-ipsec.prompt.md
@@ -2,6 +2,7 @@
 description: 'Scale-Out IPsec — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-so-ipsec
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) SCALE-OUT IPSEC

--- a/portal/public/byoai/srv6_core_edge/srv6.prompt.md
+++ b/portal/public/byoai/srv6_core_edge/srv6.prompt.md
@@ -2,6 +2,7 @@
 description: 'SRv6 Core/Edge — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'
 name: jvd-srv6
 agent: ask
+tools: ['fetch']
 ---
 
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) SRv6 CORE EDGE

--- a/portal/scripts/generate-snips.mjs
+++ b/portal/scripts/generate-snips.mjs
@@ -491,6 +491,10 @@ async function main() {
     // Q&A — no file edits, no terminal) and inlines the guide so it is pinned
     // and self-contained. This is a build artifact: it stays in sync with the
     // .txt on every run and powers the portal's "Open in VS Code" install link.
+    // The `fetch` tool is granted so the assistant can retrieve the published
+    // JVD corpus (documentation + snip bundle) it is instructed to load. This
+    // is a read-only web fetch — the prompt still performs no file edits and
+    // runs no terminal commands, preserving the hardened posture.
     const slug = promptFile.replace(/^jvd-/, "").replace(/-byoai-prompt\.txt$/, "");
     const vscodePromptName = `jvd-${slug}`;
     const vscodePromptFile = `${slug}.prompt.md`;
@@ -501,6 +505,7 @@ async function main() {
       `description: '${label} — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'\n` +
       `name: ${vscodePromptName}\n` +
       "agent: ask\n" +
+      "tools: ['fetch']\n" +
       "---\n\n" +
       promptBody;
     await fs.writeFile(path.join(mirrorTargetDir, vscodePromptFile), vscodePromptMd);

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-23T17:21:18.340Z",
+  "generatedAt": "2026-07-28T21:00:44.028Z",
   "counts": {
     "total": 638,
     "junos": 326,


### PR DESCRIPTION
## What's New
The **Open in VS Code** BYOAI assistants can now load the published JVD corpus (design docs + snip bundle) instead of falling back to a limited, ungrounded mode.

- All 17 synthesized VS Code prompts now request a read-only web-fetch capability.
- Design mode returns cited, JVD-grounded answers in VS Code, matching the browser experience.

## Why
The synthesized `.prompt.md` files ran in `ask` mode but were granted no tools. VS Code's `ask` agent has no web-fetch capability by default, so when a prompt tried to load its corpus it had no way to reach the URL and correctly fell back to "LIMITED design mode" — answers were no longer grounded in the validated design.

## Details
- `portal/scripts/generate-snips.mjs` — the prompt synthesizer now emits `tools: ['fetch']` in the frontmatter. `fetch` is read-only: prompts still make no file edits and run no terminal commands, so the hardened posture is unchanged.
- `portal/public/byoai/*/*.prompt.md` — all 17 prompts regenerated with the new frontmatter.
- `portal/src/data/snips.json` — regeneration timestamp only.

## Testing
- Regenerated: 638 snips / 17 JVDs / 0 warnings.
- `bun run build` — clean.
- Verified frontmatter now carries `agent: ask` + `tools: ['fetch']`.