### PR TITLE
fix(portal): VS Code BYOAI prompts fetch the corpus automatically

### DIFF
--- a/portal/public/byoai/3stage_dc/3stage-dc.prompt.md
+++ b/portal/public/byoai/3stage_dc/3stage-dc.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) 3-STAGE DATA CENTER
 (EVPN-VXLAN) ASSISTANT
 

--- a/portal/public/byoai/5stage_evpn_vxlan/5stage.prompt.md
+++ b/portal/public/byoai/5stage_evpn_vxlan/5stage.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) 5-STAGE EVPN-VXLAN
 DATA CENTER ASSISTANT
 

--- a/portal/public/byoai/aiml_inference_frontend/aiml-inf.prompt.md
+++ b/portal/public/byoai/aiml_inference_frontend/aiml-inf.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) AI DATA CENTER
 FRONTEND FABRIC FOR INFERENCE ASSISTANT
 

--- a/portal/public/byoai/aiml_multitenancy_backend/aiml-mtb.prompt.md
+++ b/portal/public/byoai/aiml_multitenancy_backend/aiml-mtb.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) AI/ML MULTI-TENANCY
 BACKEND (EVPN-VXLAN GPU FABRIC) ASSISTANT
 

--- a/portal/public/byoai/broadband_edge/bbe.prompt.md
+++ b/portal/public/byoai/broadband_edge/bbe.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) METRO FABRIC AND
 BROADBAND EDGE ASSISTANT
 

--- a/portal/public/byoai/collapsed_dc_fabric/collapsed.prompt.md
+++ b/portal/public/byoai/collapsed_dc_fabric/collapsed.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) COLLAPSED DATA
 CENTER FABRIC ASSISTANT
 

--- a/portal/public/byoai/collapsed_dc_fabric_with_access/collapsed-access.prompt.md
+++ b/portal/public/byoai/collapsed_dc_fabric_with_access/collapsed-access.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVDE) COLLAPSED DATA
 CENTER FABRIC WITH ACCESS SWITCHES ASSISTANT
 

--- a/portal/public/byoai/dci_over_ipodwdm/dci-ipodwdm.prompt.md
+++ b/portal/public/byoai/dci_over_ipodwdm/dci-ipodwdm.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) DATA CENTER
 INTERCONNECT OVER IPoDWDM ASSISTANT
 

--- a/portal/public/byoai/evpn_vxlan_dci/evpn-dci.prompt.md
+++ b/portal/public/byoai/evpn_vxlan_dci/evpn-dci.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 ADOPT IMMEDIATELY — JUNIPER VALIDATED DESIGN (JVD) EVPN-VXLAN DATA
 CENTER INTERCONNECT (DCI) ASSISTANT
 

--- a/portal/public/byoai/ewan_adv_core_edge/ewan-ace.prompt.md
+++ b/portal/public/byoai/ewan_adv_core_edge/ewan-ace.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) ENTERPRISE WAN
 ADVANCED CORE EDGE ASSISTANT
 

--- a/portal/public/byoai/ewan_finance/ewan-fin.prompt.md
+++ b/portal/public/byoai/ewan_finance/ewan-fin.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) ENTERPRISE WAN
 FOR FINANCE & STOCK EXCHANGE ASSISTANT
 

--- a/portal/public/byoai/low_latency_queueing/llq.prompt.md
+++ b/portal/public/byoai/low_latency_queueing/llq.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) LOW LATENCY QoS
 FOR 5G (LLQ) ASSISTANT
 

--- a/portal/public/byoai/metro_as_a_service/maas.prompt.md
+++ b/portal/public/byoai/metro_as_a_service/maas.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) METRO-AS-A-SERVICE
 CONFIG GENERATOR
 

--- a/portal/public/byoai/metro_ethernet_business_services/mebs.prompt.md
+++ b/portal/public/byoai/metro_ethernet_business_services/mebs.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) METRO ETHERNET
 BUSINESS SERVICES ASSISTANT
 

--- a/portal/public/byoai/scale_out_firewall_nat/so-fwnat.prompt.md
+++ b/portal/public/byoai/scale_out_firewall_nat/so-fwnat.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) SCALE-OUT STATEFUL
 FIREWALL & NAT (CSDS SCALEOUT) ASSISTANT
 

--- a/portal/public/byoai/scale_out_ipsec/so-ipsec.prompt.md
+++ b/portal/public/byoai/scale_out_ipsec/so-ipsec.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) SCALE-OUT IPSEC
 (CSDS SCALEOUT) ASSISTANT
 

--- a/portal/public/byoai/srv6_core_edge/srv6.prompt.md
+++ b/portal/public/byoai/srv6_core_edge/srv6.prompt.md
@@ -5,6 +5,13 @@ agent: agent
 tools: ['fetch']
 ---
 
+> VS Code runtime: you have a live web-fetch tool, so you always have web
+> access here. When the task calls for the corpus (datasheet, design docs,
+> snip bundle), fetch it immediately and silently, then answer with
+> citations. The no-web fallbacks described later — pasting files, "limited
+> mode," or confirming a fetch first — are for clients without fetch and
+> don't apply here.
+
 TASK INSTRUCTIONS — JUNIPER VALIDATED DESIGN (JVD) SRv6 CORE EDGE
 ASSISTANT
 

--- a/portal/scripts/generate-snips.mjs
+++ b/portal/scripts/generate-snips.mjs
@@ -503,6 +503,15 @@ async function main() {
     const vscodePromptFile = `${slug}.prompt.md`;
     const label = (jvdMeta.get(jvd)?.label || jvd).replace(/'/g, "''");
     const promptBody = await fs.readFile(pf, "utf8");
+    // VS Code always has the fetch tool here, so scope out the inlined no-web
+    // fallbacks (paste / limited mode / confirm-first) that exist for other clients.
+    const vscodeRuntimeNote =
+      "> VS Code runtime: you have a live web-fetch tool, so you always have web\n" +
+      "> access here. When the task calls for the corpus (datasheet, design docs,\n" +
+      "> snip bundle), fetch it immediately and silently, then answer with\n" +
+      "> citations. The no-web fallbacks described later — pasting files, \"limited\n" +
+      "> mode,\" or confirming a fetch first — are for clients without fetch and\n" +
+      "> don't apply here.\n";
     const vscodePromptMd =
       "---\n" +
       `description: '${label} — Juniper Validated Design BYOAI assistant: config generation and design Q&A grounded in the validated snip library.'\n` +
@@ -510,6 +519,8 @@ async function main() {
       "agent: agent\n" +
       "tools: ['fetch']\n" +
       "---\n\n" +
+      vscodeRuntimeNote +
+      "\n" +
       promptBody;
     await fs.writeFile(path.join(mirrorTargetDir, vscodePromptFile), vscodePromptMd);
 

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28T22:09:43.990Z",
+  "generatedAt": "2026-07-30T15:38:36.100Z",
   "counts": {
     "total": 638,
     "junos": 326,


### PR DESCRIPTION
## What's New
In VS Code, the BYOAI assistants now fetch the JVD corpus **automatically** and answer with citations, instead of asking the user to confirm a fetch or offering paste / "limited mode" fallbacks.

## Why
Those fallbacks exist for AI clients that can't browse. In VS Code the assistant always has a live fetch tool, so the "can you fetch? — say go" prompt was pointless friction: if the prompt is running here, there is web access.

## Details
- `portal/scripts/generate-snips.mjs` — the synthesized VS Code `.prompt.md` now carries a short "VS Code runtime" note above the inlined guide: it states the fetch tool is available, tells the assistant to fetch the corpus immediately and silently, and scopes the inlined no-web fallbacks (paste / limited mode / confirm-first) as not applicable here. Positive framing, one scoping sentence — not a list of "don'ts."
- Applies to the **synthesized VS Code artifact only**. The 17 `SYSTEM_PROMPT.md` sources and the GPT/Claude `-byoai-prompt.txt` are untouched, so other clients keep their fallbacks.
- `portal/public/byoai/*/*.prompt.md` — regenerated (all 17).
- `portal/src/data/snips.json` — regeneration timestamp.

## Testing
- Regenerated: 638 snips / 17 JVDs / 0 warnings.
- `bun run build` — clean.
- Verified the runtime note is present in all 17 `.prompt.md`, directly under the frontmatter.

## Notes
Behavioral verification (does the model now fetch without asking) is a live check in VS Code after merge + reinstall. If hedging persists, the fallback is to strip the no-web branches from the VS Code build directly.