### PR TITLE
fix(portal): HSB no-normalize keeps encapsulation; enum fields allow custom values

### DIFF
--- a/portal/src/components/ConfigGenerator.tsx
+++ b/portal/src/components/ConfigGenerator.tsx
@@ -418,18 +418,20 @@ function VarField({
         </span>
       )}
       {spec?.type === "enum" ? (
-        <select
-          value={value ?? ""}
-          onChange={(e) => onChange(e.target.value)}
-          className={inputCls}
-        >
-          {Array.from(new Set([value, ...spec.values].filter(Boolean))).map((opt) => (
-            <option key={opt} value={opt}>
-              {opt}
-              {!spec.values.includes(opt) ? " (custom)" : ""}
-            </option>
-          ))}
-        </select>
+        <>
+          <input
+            value={value ?? ""}
+            list={`opts-${bare}`}
+            inputMode={/^\d+$/.test(spec.values[0] ?? "") ? "numeric" : undefined}
+            onChange={(e) => onChange(e.target.value)}
+            className={inputCls}
+          />
+          <datalist id={`opts-${bare}`}>
+            {spec.values.map((opt) => (
+              <option key={opt} value={opt} />
+            ))}
+          </datalist>
+        </>
       ) : (
         <input
           value={value ?? ""}
@@ -923,11 +925,10 @@ export default function ConfigGenerator() {
             firewall: sel.firewall,
             color: "color-blind",
             cos: sel.cos,
-            normalize: hsbNorm,
           })
         : [],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isHsb, osBlockA, sel.firewall, sel.cos, hsbNorm],
+    [isHsb, osBlockA, sel.firewall, sel.cos],
   );
   const hsbPeIds = useMemo(
     () =>
@@ -936,11 +937,10 @@ export default function ConfigGenerator() {
             firewall: sel.firewall,
             color: "color-blind",
             cos: sel.cos,
-            normalize: hsbNorm,
           })
         : [],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isHsb, osBlockA, sel.firewall, sel.cos, hsbNorm],
+    [isHsb, osBlockA, sel.firewall, sel.cos],
   );
   // Build the Hub / Primary / Backup value maps for HSB service instance `i`
   // (i=0 = the base service; i>0 increments VC-IDs, VLANs and units for a batch).
@@ -976,7 +976,7 @@ export default function ConfigGenerator() {
   };
   const hsbRender = useMemo(() => {
     if (!isHsb || hsbHubIds.length === 0) return null;
-    const rOpts = { stripUniFilter: !sel.firewall, derived: CATALOG.derivedVars };
+    const rOpts = { stripUniFilter: !sel.firewall, stripVlanMap: !hsbNorm, derived: CATALOG.derivedVars };
     const { hubVals, priVals, bakVals } = hsbValsFor(0);
     const hub = renderConfig(hsbHubIds, hubVals, byId, rOpts);
     const pri = renderConfig(hsbPeIds, priVals, byId, rOpts);
@@ -988,7 +988,7 @@ export default function ConfigGenerator() {
       missing: Array.from(new Set([...hub.missing, ...pri.missing, ...bak.missing])),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isHsb, hsbHubIds, hsbPeIds, hsb, byId, sel.firewall]);
+  }, [isHsb, hsbHubIds, hsbPeIds, hsb, byId, sel.firewall, hsbNorm]);
 
   const fullText = isHsb && hsbRender
     ? [hsbRender.hub, hsbRender.pri, hsbRender.bak].join("\n\n")
@@ -1181,7 +1181,7 @@ export default function ConfigGenerator() {
     // each merged across all `count` services.
     if (isHsb) {
       if (hsbHubIds.length === 0) return;
-      const rOpts = { stripUniFilter: !sel.firewall, derived: CATALOG.derivedVars };
+      const rOpts = { stripUniFilter: !sel.firewall, stripVlanMap: !hsbNorm, derived: CATALOG.derivedVars };
       const N = Math.max(1, Math.min(count, 500));
       const hubBodies: string[] = [];
       const priBodies: string[] = [];

--- a/portal/src/data/generator/metro_as_a_service.json
+++ b/portal/src/data/generator/metro_as_a_service.json
@@ -271,7 +271,6 @@
                   "service": ["evo/services/l2circuit-hsb-pe"],
                   "hubService": ["evo/services/l2circuit-hsb-hub"],
                   "interface": { "single-homed": "evo/interfaces/vlan-ccc-vlan-map" },
-                  "interfacePlain": "evo/interfaces/vlan-ccc",
                   "interfaceExtras": ["evo/interfaces/physical-mtu"],
                   "filter": { "color-blind": "evo/firewall/filter-ccc-color-blind" }
                 }

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -50,9 +50,6 @@ export type GenOsBlock = {
   /** L2circuit hot-standby: the Hub device's service snip. The two PE devices
    *  use the default `service`; the Hub uses this instead. */
   hubService?: string[];
-  /** L2circuit hot-standby: the attachment-circuit interface snip used when VLAN
-   *  normalization is OFF (plain vlan-id, no input/output vlan-map). */
-  interfacePlain?: string;
 };
 
 export type GenDeployment = {
@@ -695,13 +692,10 @@ export function resolveHsbSnipIds(
   osb: GenOsBlock,
   os: GenOsKey,
   role: "hub" | "pe",
-  opts: { firewall: boolean; color: string; cos: boolean; normalize?: boolean },
+  opts: { firewall: boolean; color: string; cos: boolean },
 ): string[] {
   const rel: string[] = [...(role === "hub" ? osb.hubService ?? [] : osb.service)];
-  const iface =
-    opts.normalize === false && osb.interfacePlain
-      ? osb.interfacePlain
-      : osb.interface["single-homed"] ?? Object.values(osb.interface)[0];
+  const iface = osb.interface["single-homed"] ?? Object.values(osb.interface)[0];
   if (iface) rel.push(iface);
   rel.push(...osb.interfaceExtras);
   if (opts.firewall) {
@@ -808,6 +802,15 @@ function stripCommunity(body: string): string {
   return body.replace(/\n?[^\S\n]*community\s+\S+;/g, "");
 }
 
+/** Remove the `input-vlan-map { … }` block and the `output-vlan-map …;` line from
+ *  an interface body — the "no VLAN normalization" mode. Everything else
+ *  (flexible-vlan-tagging, the encapsulation, the unit vlan-id and family) stays. */
+function stripVlanMap(body: string): string {
+  return body
+    .replace(/\n?[^\S\n]*input-vlan-map\s*\{[^{}]*\}/g, "")
+    .replace(/\n?[^\S\n]*output-vlan-map\s+[^;]*;/g, "");
+}
+
 /** Compute auto-derived variable values (e.g. POLICY_NAME = INSTANCE_NAME,
  *  VPN_RT_COMM = INSTANCE_NAME + "_RT") from the resolved base values. */
 function applyDerived(
@@ -847,6 +850,7 @@ export function renderConfig(
     stripUniFilter?: boolean;
     stripVrfExport?: boolean;
     stripCommunity?: boolean;
+    stripVlanMap?: boolean;
     derived?: Record<string, DerivedVar>;
   },
 ): RenderResult {
@@ -870,6 +874,10 @@ export function renderConfig(
     // opted out of the firewall filter (else it dangles).
     if (opts?.stripUniFilter && snip.category === "interfaces") {
       body = stripUniFilterBinding(body);
+    }
+    // No VLAN normalization: drop the input/output vlan-map statements only.
+    if (opts?.stripVlanMap && snip.category === "interfaces") {
+      body = stripVlanMap(body);
     }
     // Route-target-only mode: drop the vrf-export policy reference.
     if (opts?.stripVrfExport && snip.category === "services") {


### PR DESCRIPTION
Two fixes from review of the L2circuit hot-standby wizard (#186).

## What's New
- **Normalize VLAN → off** now keeps `flexible-vlan-tagging` and `encapsulation flexible-ethernet-services`, removing **only** the `input-vlan-map` block and `output-vlan-map` line (previously it swapped to a leaner snip that also dropped those two lines).
- **MTU / label-block-size** fields are now an editable combobox — pick a validated value from the dropdown or type your own.

## Why
Review of #186: (1) turning off VLAN normalization stripped too much (lost the physical-interface encapsulation, not just the vlan-maps); (2) the MTU dropdown (a pre-existing `enum` field rendered as `<select>`) blocked entering a custom MTU.

## Changes
- [x] New `stripVlanMap` render option — removes just the input/output vlan-map statements from an interface body
- [x] HSB always uses the `vlan-ccc-vlan-map` interface; normalization off = `stripVlanMap` at render time (removed the `interfacePlain` swap)
- [x] `VarField` enum → `<input>` + `<datalist>` editable combobox (soft "not a validated value" note still shows for out-of-domain input)

## Verified before merge
- [x] Portal builds — `bun run build` (clean)
- [x] Render check — normalize **off** keeps `flexible-vlan-tagging` + `encapsulation flexible-ethernet-services` + unit `vlan-id`/`family`, dropping only the vlan-maps; normalize **on** unchanged
- [x] Externally-safe wording

## Notes
- No snip-body changes this round, so `snips.json` / BYOAI bundle are unchanged.
