### PR TITLE
Portal: accurate intent-based use-case browsing + fix false Config Generator warnings

### DIFF
--- a/portal/scripts/jvd-usecase-map.json
+++ b/portal/scripts/jvd-usecase-map.json
@@ -1,10 +1,22 @@
 {
-  "_comment": "Use-case tags applied to every snip from a given JVD folder. Tags are free-form strings; the snip browser groups by them in 'Use case' browse mode. Add new entries here as JVDs gain snip libraries — at minimum include the area name (Service Provider, Data Center, etc) so the JVD shows up under that bucket.",
+  "_comment": "Intent-based use-case tags applied to every snip from a given JVD folder. The snip browser's 'Use Case' mode groups snips as tag -> JVD -> snip, so a solution intent like 'Business VPN Services' surfaces every JVD that has it. Tags are a curated, intent-oriented vocabulary (NOT raw technology names — those live in 'Technology' mode). Keep tags reusable across JVDs. A JVD with no entry falls back to its area name. Only snip-equipped JVDs need entries.",
 
-  "broadband_edge": ["Service Provider", "BNG", "Subscriber Mgmt", "Metro"],
-  "metro_as_a_service": ["Service Provider", "Metro", "Business Services", "MEF"],
-  "metro_ethernet_business_services": ["Service Provider", "Metro", "Business Services", "MEF"],
-  "srv6_core_edge": ["Service Provider", "SRv6", "Core/Edge"],
-  "ewan_adv_core_edge": ["Enterprise WAN", "EVPN-VPWS", "EVPN-ELAN", "MPLS"],
-  "ewan_finance": ["Enterprise WAN", "L3VPN", "Multicast", "MPLS"]
+  "3stage_dc": ["Data Center Fabric", "Apstra-Managed Fabric"],
+  "5stage_evpn_vxlan": ["Data Center Fabric", "Apstra-Managed Fabric"],
+  "collapsed_dc_fabric": ["Data Center Fabric", "Apstra-Managed Fabric"],
+  "collapsed_dc_fabric_with_access": ["Data Center Fabric", "Apstra-Managed Fabric"],
+  "evpn_vxlan_dci": ["Data Center Fabric", "Data Center Interconnect", "Apstra-Managed Fabric"],
+  "aiml_inference_frontend": ["AI/ML Infrastructure", "Data Center Fabric", "Apstra-Managed Fabric"],
+  "aiml_multitenancy_backend": ["AI/ML Infrastructure", "Multitenancy", "Data Center Fabric"],
+  "ewan_adv_core_edge": ["Enterprise WAN", "Business VPN Services"],
+  "ewan_core_edge": ["Enterprise WAN", "Business VPN Services"],
+  "ewan_finance": ["Enterprise WAN", "Low-Latency Transport"],
+  "dci_over_ipodwdm": ["Data Center Interconnect", "Coherent Optics"],
+  "scale_out_firewall_nat": ["Network Security Services", "CGNAT"],
+  "scale_out_ipsec": ["Network Security Services", "Secure Connectivity (IPsec)"],
+  "broadband_edge": ["Cloud Metro", "Metro Fabric", "Broadband Subscriber Edge", "CGNAT"],
+  "low_latency_queueing": ["Low-Latency Transport", "Mobile Backhaul", "Mobile Fronthaul"],
+  "metro_as_a_service": ["Cloud Metro", "Metro Fabric", "Carrier Ethernet (MEF)", "Business VPN Services"],
+  "metro_ethernet_business_services": ["Cloud Metro", "Metro Fabric", "Carrier Ethernet (MEF)", "Business VPN Services", "Route Reflector", "Mobile Backhaul"],
+  "srv6_core_edge": ["SRv6", "Business VPN Services", "Route Reflector"]
 }

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T21:46:47.210Z",
+  "generatedAt": "2026-08-03T23:29:54.953Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -40,23 +40,26 @@
     "Transport"
   ],
   "usecases": [
-    "BNG",
-    "Business Services",
-    "Core/Edge",
-    "Data Center",
-    "EVPN-ELAN",
-    "EVPN-VPWS",
+    "AI/ML Infrastructure",
+    "Apstra-Managed Fabric",
+    "Broadband Subscriber Edge",
+    "Business VPN Services",
+    "CGNAT",
+    "Carrier Ethernet (MEF)",
+    "Cloud Metro",
+    "Coherent Optics",
+    "Data Center Fabric",
+    "Data Center Interconnect",
     "Enterprise WAN",
-    "L3VPN",
-    "MEF",
-    "MPLS",
-    "Metro",
-    "Multicast",
-    "Optical",
+    "Low-Latency Transport",
+    "Metro Fabric",
+    "Mobile Backhaul",
+    "Mobile Fronthaul",
+    "Multitenancy",
+    "Network Security Services",
+    "Route Reflector",
     "SRv6",
-    "Security",
-    "Service Provider",
-    "Subscriber Mgmt"
+    "Secure Connectivity (IPsec)"
   ],
   "jvds": [
     {
@@ -327,7 +330,8 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -381,7 +385,8 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -461,7 +466,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -533,7 +539,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -606,7 +613,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -679,7 +687,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -734,7 +743,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -778,7 +788,8 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -822,7 +833,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -870,7 +882,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -931,7 +944,8 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -996,7 +1010,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1095,7 +1110,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1159,7 +1175,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1231,7 +1248,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1284,7 +1302,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1337,7 +1356,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1388,7 +1408,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1456,7 +1477,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1519,7 +1541,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1657,7 +1680,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1743,7 +1767,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1839,7 +1864,8 @@
       "techFamily": "Transport",
       "subfamily": "BGP Underlay",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1899,7 +1925,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -1970,7 +1997,8 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2025,7 +2053,8 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2087,7 +2116,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2160,7 +2190,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2249,7 +2280,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2339,7 +2371,8 @@
       "techFamily": "Interfaces",
       "subfamily": "LAG / LACP",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2413,7 +2446,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2480,7 +2514,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2567,7 +2602,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2628,7 +2664,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2672,7 +2709,8 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2717,7 +2755,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2766,7 +2805,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2829,7 +2869,8 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2896,7 +2937,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -2997,7 +3039,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3063,7 +3106,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3137,7 +3181,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3191,7 +3236,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3245,7 +3291,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3296,7 +3343,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3367,7 +3415,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3433,7 +3482,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3555,7 +3605,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3696,7 +3747,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3783,7 +3835,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3880,7 +3933,8 @@
       "techFamily": "Transport",
       "subfamily": "BGP Underlay",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -3947,7 +4001,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4014,7 +4069,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4058,7 +4114,8 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4107,7 +4164,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4171,7 +4229,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4220,7 +4279,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4286,7 +4346,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4354,7 +4415,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4423,7 +4485,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4465,7 +4528,8 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4507,7 +4571,8 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4567,7 +4632,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4631,7 +4697,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4687,7 +4754,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4744,7 +4812,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4807,7 +4876,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4885,7 +4955,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -4958,7 +5029,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5024,7 +5096,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5083,7 +5156,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5147,7 +5221,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5229,7 +5304,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5302,7 +5378,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5351,7 +5428,8 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5412,7 +5490,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5463,7 +5543,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5530,7 +5612,9 @@
       "techFamily": "Other",
       "subfamily": "Security",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5610,7 +5694,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5680,7 +5766,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5748,7 +5836,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5847,7 +5937,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5896,7 +5988,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -5949,7 +6043,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6009,7 +6105,9 @@
       "techFamily": "Other",
       "subfamily": "Security",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6079,7 +6177,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6143,7 +6243,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6223,7 +6325,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "Data Center Fabric",
+        "Data Center Interconnect",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6275,7 +6379,9 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6337,7 +6443,9 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6418,7 +6526,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6483,7 +6593,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6535,7 +6647,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6608,7 +6722,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6653,7 +6769,9 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6700,7 +6818,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6752,7 +6872,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6809,7 +6931,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6862,7 +6986,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6919,7 +7045,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -6966,7 +7094,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -7034,7 +7164,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -7115,7 +7247,9 @@
       "techFamily": "Transport",
       "subfamily": "BGP Underlay",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -7182,7 +7316,9 @@
       "techFamily": "Transport",
       "subfamily": "Routing Options",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Data Center Fabric",
+        "Apstra-Managed Fabric"
       ],
       "parseWarnings": []
     },
@@ -7231,7 +7367,9 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7285,7 +7423,9 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7344,7 +7484,9 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7397,7 +7539,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7472,7 +7616,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7536,7 +7682,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7613,7 +7761,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7671,7 +7821,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7739,7 +7891,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7784,7 +7938,9 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7828,7 +7984,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7867,7 +8025,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7927,7 +8087,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -7989,7 +8151,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8060,7 +8224,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8114,7 +8280,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8178,7 +8346,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8276,7 +8446,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8360,7 +8532,9 @@
       "techFamily": "Transport",
       "subfamily": "EVPN",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8445,7 +8619,9 @@
       "techFamily": "Transport",
       "subfamily": "BGP Underlay",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8496,7 +8672,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8547,7 +8725,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8611,7 +8791,9 @@
       "techFamily": "Transport",
       "subfamily": "Routing Options",
       "usecases": [
-        "Data Center"
+        "AI/ML Infrastructure",
+        "Multitenancy",
+        "Data Center Fabric"
       ],
       "parseWarnings": []
     },
@@ -8669,9 +8851,7 @@
       "subfamily": "Chassis",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -8724,9 +8904,7 @@
       "subfamily": "CoS",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -8778,9 +8956,7 @@
       "subfamily": "Cos",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -8858,9 +9034,7 @@
       "subfamily": "CoS",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -8910,9 +9084,7 @@
       "subfamily": "Ddos Mitigation",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -8982,9 +9154,7 @@
       "subfamily": "Firewall",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9045,9 +9215,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9143,9 +9311,7 @@
       "subfamily": "LAG / LACP",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9204,9 +9370,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9284,9 +9448,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9357,9 +9519,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9440,9 +9600,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9518,9 +9676,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9579,9 +9735,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9634,9 +9788,7 @@
       "subfamily": "Policy",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9733,9 +9885,7 @@
       "subfamily": "EVPN-ELAN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9816,9 +9966,7 @@
       "subfamily": "EVPN-ELAN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -9915,9 +10063,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10002,9 +10148,7 @@
       "subfamily": "EVPN-VPWS",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10087,9 +10231,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10172,9 +10314,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10238,9 +10378,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10321,9 +10459,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10417,9 +10553,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10526,9 +10660,7 @@
       "subfamily": "OSPF",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10601,9 +10733,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10651,9 +10781,7 @@
       "subfamily": "Chassis",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10709,9 +10837,7 @@
       "subfamily": "CoS",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10767,9 +10893,7 @@
       "subfamily": "Cos",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10850,9 +10974,7 @@
       "subfamily": "CoS",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10907,9 +11029,7 @@
       "subfamily": "Ddos Mitigation",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -10983,9 +11103,7 @@
       "subfamily": "Firewall",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11048,9 +11166,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11143,9 +11259,7 @@
       "subfamily": "LAG / LACP",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11205,9 +11319,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11281,9 +11393,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11354,9 +11464,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11437,9 +11545,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11519,9 +11625,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11584,9 +11688,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11643,9 +11745,7 @@
       "subfamily": "Policy",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11739,9 +11839,7 @@
       "subfamily": "EVPN-ELAN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11820,9 +11918,7 @@
       "subfamily": "EVPN-ELAN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -11919,9 +12015,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12006,9 +12100,7 @@
       "subfamily": "EVPN-VPWS",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12091,9 +12183,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12177,9 +12267,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12238,9 +12326,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12322,9 +12408,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12421,9 +12505,7 @@
       "subfamily": "OSPF",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12472,9 +12554,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "EVPN-VPWS",
-        "EVPN-ELAN",
-        "MPLS"
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12518,7 +12598,8 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12567,7 +12648,8 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12628,7 +12710,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Aggregated Ethernet",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12694,7 +12777,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Aggregated Ethernet",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12737,7 +12821,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "OSPF",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12807,7 +12892,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12877,7 +12963,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12919,7 +13006,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -12979,7 +13067,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13063,7 +13152,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13153,7 +13243,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13238,7 +13329,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13327,7 +13419,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13413,7 +13506,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13492,7 +13586,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13549,7 +13644,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13609,7 +13705,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13666,7 +13763,8 @@
       "techFamily": "Transport",
       "subfamily": "OSPF",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13728,7 +13826,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13770,7 +13869,8 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13825,7 +13925,8 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13875,7 +13976,8 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -13946,7 +14048,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Aggregated Ethernet",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14017,7 +14120,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Aggregated Ethernet",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14060,7 +14164,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "OSPF",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14126,7 +14231,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14192,7 +14298,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14264,7 +14371,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14359,7 +14467,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14450,7 +14559,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14541,7 +14651,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14631,7 +14742,8 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14703,7 +14815,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14781,7 +14894,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14850,7 +14964,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14919,7 +15034,8 @@
       "techFamily": "Transport",
       "subfamily": "OSPF",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -14982,7 +15098,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Enterprise WAN"
+        "Enterprise WAN",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -15070,9 +15187,7 @@
       "subfamily": "Chassis",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15145,9 +15260,7 @@
       "subfamily": "CoS",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15225,9 +15338,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15293,9 +15404,7 @@
       "subfamily": "LAG / LACP",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15370,9 +15479,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15454,9 +15561,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15522,9 +15627,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15570,9 +15673,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15654,9 +15755,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15724,9 +15823,7 @@
       "subfamily": "Policy",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15798,9 +15895,7 @@
       "subfamily": "Policy",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -15913,9 +16008,7 @@
       "subfamily": "Services",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16010,9 +16103,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16093,9 +16184,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16186,9 +16275,7 @@
       "subfamily": "OSPF",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16265,9 +16352,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16365,9 +16450,7 @@
       "subfamily": "Chassis",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16433,9 +16516,7 @@
       "subfamily": "CoS",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16526,9 +16607,7 @@
       "subfamily": "Firewall",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16600,9 +16679,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16684,9 +16761,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16783,9 +16858,7 @@
       "subfamily": "LAG / LACP",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16860,9 +16933,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -16944,9 +17015,7 @@
       "subfamily": "Interfaces",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17007,9 +17076,7 @@
       "subfamily": "Multicast",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17055,9 +17122,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17144,9 +17209,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17227,9 +17290,7 @@
       "subfamily": "Oam",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17297,9 +17358,7 @@
       "subfamily": "Policy",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17371,9 +17430,7 @@
       "subfamily": "Policy",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17465,9 +17522,7 @@
       "subfamily": "EVPN",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17603,9 +17658,7 @@
       "subfamily": "Services",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17718,9 +17771,7 @@
       "subfamily": "Services",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17818,9 +17869,7 @@
       "subfamily": "L3VPN",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -17922,9 +17971,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -18034,9 +18081,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -18121,9 +18166,7 @@
       "subfamily": "OSPF",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -18192,9 +18235,7 @@
       "subfamily": "Transport",
       "usecases": [
         "Enterprise WAN",
-        "L3VPN",
-        "Multicast",
-        "MPLS"
+        "Low-Latency Transport"
       ],
       "parseWarnings": []
     },
@@ -18246,7 +18287,8 @@
       "techFamily": "Other",
       "subfamily": "Chassis",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18308,7 +18350,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18379,7 +18422,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18430,7 +18474,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18481,7 +18526,8 @@
       "techFamily": "Other",
       "subfamily": "Chassis",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18544,7 +18590,8 @@
       "techFamily": "Other",
       "subfamily": "Chassis",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18610,7 +18657,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18680,7 +18728,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18730,7 +18779,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Optical"
+        "Data Center Interconnect",
+        "Coherent Optics"
       ],
       "parseWarnings": []
     },
@@ -18780,7 +18830,8 @@
       "techFamily": "Chassis",
       "subfamily": "Bootstrap",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -18859,7 +18910,8 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -18940,7 +18992,8 @@
       "techFamily": "Other",
       "subfamily": "Chassis",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19026,7 +19079,8 @@
       "techFamily": "Other",
       "subfamily": "High Availability",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19098,7 +19152,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19188,7 +19243,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19276,7 +19332,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19344,7 +19401,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19396,7 +19454,8 @@
       "techFamily": "Other",
       "subfamily": "Load Balancing",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19491,7 +19550,8 @@
       "techFamily": "Other",
       "subfamily": "Load Balancing",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19564,7 +19624,8 @@
       "techFamily": "Other",
       "subfamily": "Nat",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19644,7 +19705,8 @@
       "techFamily": "Other",
       "subfamily": "Nat",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19736,7 +19798,8 @@
       "techFamily": "Other",
       "subfamily": "Nat",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19808,7 +19871,8 @@
       "techFamily": "Other",
       "subfamily": "Security",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19869,7 +19933,8 @@
       "techFamily": "Other",
       "subfamily": "Security",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19915,7 +19980,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -19987,7 +20053,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -20089,7 +20156,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -20140,7 +20208,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -20206,7 +20275,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -20302,7 +20372,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -20363,7 +20434,8 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20462,7 +20534,8 @@
       "techFamily": "Other",
       "subfamily": "Chassis",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20512,7 +20585,8 @@
       "techFamily": "Other",
       "subfamily": "High Availability",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20593,7 +20667,8 @@
       "techFamily": "Other",
       "subfamily": "High Availability",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20657,7 +20732,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20716,7 +20792,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20772,7 +20849,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20838,7 +20916,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20901,7 +20980,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -20950,7 +21030,8 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21002,7 +21083,8 @@
       "techFamily": "Other",
       "subfamily": "Ipsec",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21079,7 +21161,8 @@
       "techFamily": "Other",
       "subfamily": "Ipsec",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21153,7 +21236,8 @@
       "techFamily": "Other",
       "subfamily": "Ipsec",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21214,7 +21298,8 @@
       "techFamily": "Other",
       "subfamily": "Ipsec",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21261,7 +21346,8 @@
       "techFamily": "Other",
       "subfamily": "Load Balancing",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21345,7 +21431,8 @@
       "techFamily": "Other",
       "subfamily": "Load Balancing",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21401,7 +21488,8 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21464,7 +21552,8 @@
       "techFamily": "Other",
       "subfamily": "Security",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21525,7 +21614,8 @@
       "techFamily": "Other",
       "subfamily": "Security",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21607,7 +21697,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21684,7 +21775,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21719,7 +21811,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21775,7 +21868,8 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Security"
+        "Network Security Services",
+        "Secure Connectivity (IPsec)"
       ],
       "parseWarnings": []
     },
@@ -21860,10 +21954,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Aggregated Ethernet",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -21934,10 +22028,10 @@
       "techFamily": "Interfaces",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -21996,10 +22090,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22054,10 +22148,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22133,10 +22227,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22188,10 +22282,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22253,10 +22347,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22303,10 +22397,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "RADIUS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22405,10 +22499,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22510,10 +22604,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22601,10 +22695,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22682,10 +22776,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22760,10 +22854,10 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (PE)",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22847,10 +22941,10 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (Route Reflector)",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -22944,10 +23038,10 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (Route Reflector)",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23035,10 +23129,10 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS / SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23111,10 +23205,10 @@
       "techFamily": "Transport",
       "subfamily": "SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23180,10 +23274,10 @@
       "techFamily": "Transport",
       "subfamily": "Routing Options",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23261,10 +23355,10 @@
       "techFamily": "Chassis",
       "subfamily": "Chassis",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23314,10 +23408,10 @@
       "techFamily": "Firewall",
       "subfamily": "DHCP / Address Assignment",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23376,10 +23470,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Aggregated Ethernet",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23447,10 +23541,10 @@
       "techFamily": "Interfaces",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23564,10 +23658,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Pseudowire-Headend",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23677,10 +23771,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Pseudowire-Headend",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23735,10 +23829,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23813,10 +23907,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23869,10 +23963,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23939,10 +24033,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -23997,10 +24091,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "RADIUS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24098,10 +24192,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24198,10 +24292,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24304,10 +24398,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24472,10 +24566,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24605,10 +24699,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24690,10 +24784,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24776,10 +24870,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "RADIUS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24844,10 +24938,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "DHCP / Address Assignment",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -24939,10 +25033,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "Dynamic Profiles",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25003,10 +25097,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "Dynamic Profiles",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25066,10 +25160,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "Dynamic Profiles",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25134,10 +25228,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "DHCP / Address Assignment",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25197,10 +25291,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "Subscriber Management",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25273,10 +25367,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "RADIUS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25356,10 +25450,10 @@
       "techFamily": "Subscriber & BNG",
       "subfamily": "Subscriber Management",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25450,10 +25544,10 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (PE)",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25537,10 +25631,10 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS / SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25613,10 +25707,10 @@
       "techFamily": "Transport",
       "subfamily": "SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25685,10 +25779,10 @@
       "techFamily": "Transport",
       "subfamily": "Routing Options",
       "usecases": [
-        "Service Provider",
-        "BNG",
-        "Subscriber Mgmt",
-        "Metro"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Broadband Subscriber Edge",
+        "CGNAT"
       ],
       "parseWarnings": []
     },
@@ -25752,7 +25846,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -25822,7 +25918,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -25887,7 +25985,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -25952,7 +26052,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26035,7 +26137,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26114,7 +26218,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26194,7 +26300,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26264,7 +26372,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26324,7 +26434,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26425,7 +26537,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26493,7 +26607,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26567,7 +26683,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26632,7 +26750,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26702,7 +26822,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26771,7 +26893,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26836,7 +26960,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26886,7 +27012,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -26956,7 +27084,9 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27011,7 +27141,9 @@
       "techFamily": "Firewall",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27066,7 +27198,9 @@
       "techFamily": "Firewall",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27131,7 +27265,9 @@
       "techFamily": "Interfaces",
       "subfamily": "LAG / LACP",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27187,7 +27323,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27238,7 +27376,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27292,7 +27432,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27342,7 +27484,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27391,7 +27535,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27445,7 +27591,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27495,7 +27643,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27558,7 +27708,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27623,7 +27775,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27686,7 +27840,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27752,7 +27908,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27812,7 +27970,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27873,7 +28033,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -27930,7 +28092,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28002,7 +28166,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28058,7 +28224,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28111,7 +28279,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28173,7 +28343,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28235,7 +28407,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28303,7 +28477,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28366,7 +28542,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28419,7 +28597,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28517,7 +28697,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28575,7 +28757,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28659,7 +28843,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28720,7 +28906,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28787,7 +28975,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28850,7 +29040,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28903,7 +29095,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -28965,7 +29159,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29018,7 +29214,9 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29083,7 +29281,9 @@
       "techFamily": "Firewall",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29138,7 +29338,9 @@
       "techFamily": "Firewall",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29193,7 +29395,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29243,7 +29447,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29291,7 +29497,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29338,7 +29546,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29385,7 +29595,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29433,7 +29645,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29486,7 +29700,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29547,7 +29763,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29595,7 +29813,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29645,7 +29865,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29707,7 +29929,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29762,7 +29986,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29831,7 +30057,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29884,7 +30112,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29930,7 +30160,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -29985,7 +30217,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider"
+        "Low-Latency Transport",
+        "Mobile Backhaul",
+        "Mobile Fronthaul"
       ],
       "parseWarnings": []
     },
@@ -30019,10 +30253,10 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30056,10 +30290,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30119,10 +30353,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30182,10 +30416,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30219,10 +30453,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30257,10 +30491,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30295,10 +30529,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30332,10 +30566,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30378,10 +30612,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30423,10 +30657,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30468,10 +30702,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30514,10 +30748,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30558,10 +30792,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30603,10 +30837,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30679,10 +30913,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30751,10 +30985,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30823,10 +31057,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30895,10 +31129,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30949,10 +31183,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -30999,10 +31233,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31131,10 +31365,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31211,10 +31445,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31296,10 +31530,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31382,10 +31616,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31458,10 +31692,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31538,10 +31772,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31618,10 +31852,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31694,10 +31928,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31759,10 +31993,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31820,10 +32054,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31885,10 +32119,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -31966,10 +32200,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32054,10 +32288,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32119,10 +32353,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32200,10 +32434,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32261,10 +32495,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32346,10 +32580,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32427,10 +32661,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32520,10 +32754,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32610,10 +32844,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32699,10 +32933,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32800,10 +33034,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32885,10 +33119,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -32945,10 +33179,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33035,10 +33269,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33111,10 +33345,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33154,10 +33388,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33212,10 +33446,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33263,10 +33497,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33314,10 +33548,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33420,10 +33654,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33534,10 +33768,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33629,10 +33863,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33728,10 +33962,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33818,10 +34052,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -33933,10 +34167,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34049,10 +34283,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34143,10 +34377,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34246,10 +34480,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34340,10 +34574,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34442,10 +34676,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34536,10 +34770,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34634,10 +34868,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34749,10 +34983,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34851,10 +35085,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -34967,10 +35201,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35075,10 +35309,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35173,10 +35407,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35271,10 +35505,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35356,10 +35590,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35449,10 +35683,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35553,10 +35787,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35653,10 +35887,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35690,10 +35924,10 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35727,10 +35961,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35795,10 +36029,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35863,10 +36097,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35900,10 +36134,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35938,10 +36172,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -35976,10 +36210,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36029,10 +36263,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36066,10 +36300,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36103,10 +36337,10 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36148,10 +36382,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36195,10 +36429,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36241,10 +36475,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36286,10 +36520,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36333,10 +36567,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36378,10 +36612,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36423,10 +36657,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36468,10 +36702,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36513,10 +36747,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36558,10 +36792,10 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36634,10 +36868,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36706,10 +36940,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36752,10 +36986,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36822,10 +37056,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36903,10 +37137,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -36979,10 +37213,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37060,10 +37294,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37136,10 +37370,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37216,10 +37450,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37293,10 +37527,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37373,10 +37607,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37453,10 +37687,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37529,10 +37763,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37594,10 +37828,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37655,10 +37889,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37721,10 +37955,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37802,10 +38036,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37878,10 +38112,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -37963,10 +38197,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38038,10 +38272,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38096,10 +38330,10 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38154,10 +38388,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38205,10 +38439,10 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38316,10 +38550,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38426,10 +38660,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38512,10 +38746,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38598,10 +38832,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38700,10 +38934,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38809,10 +39043,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38899,10 +39133,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -38990,10 +39224,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39094,10 +39328,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39189,10 +39423,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39272,10 +39506,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39378,10 +39612,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39453,10 +39687,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39548,10 +39782,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39647,10 +39881,10 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services"
       ],
       "parseWarnings": []
     },
@@ -39708,10 +39942,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -39777,10 +40013,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -39838,10 +40076,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -39916,10 +40156,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -39959,10 +40201,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40002,10 +40246,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40053,10 +40299,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40088,10 +40336,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40125,10 +40375,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40167,10 +40419,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40200,10 +40454,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40258,10 +40514,12 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40316,10 +40574,12 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40368,10 +40628,12 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall / Policer",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40454,10 +40716,12 @@
       "techFamily": "Interfaces",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40525,10 +40789,12 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40597,10 +40863,12 @@
       "techFamily": "Interfaces",
       "subfamily": "LAG / LACP",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40664,10 +40932,12 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40697,10 +40967,12 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40789,10 +41061,12 @@
       "techFamily": "Policy & Routing",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -40894,10 +41168,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41004,10 +41280,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41101,10 +41379,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41216,10 +41496,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41311,10 +41593,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41406,10 +41690,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41496,10 +41782,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41591,10 +41879,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41689,10 +41979,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41762,10 +42054,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41844,10 +42138,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -41947,10 +42243,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42046,10 +42344,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "OSPF",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42112,10 +42412,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42235,10 +42537,12 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42336,10 +42640,12 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS / SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42408,10 +42714,12 @@
       "techFamily": "Transport",
       "subfamily": "SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42450,10 +42758,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42492,10 +42802,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42534,10 +42846,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42576,10 +42890,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42639,10 +42955,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42694,10 +43012,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42736,10 +43056,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42805,10 +43127,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42865,10 +43189,12 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42908,10 +43234,12 @@
       "techFamily": "QoS / CoS",
       "subfamily": "Cos",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -42956,10 +43284,12 @@
       "techFamily": "QoS / CoS",
       "subfamily": "CoS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43002,10 +43332,12 @@
       "techFamily": "Firewall",
       "subfamily": "Firewall / Policer",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43063,10 +43395,12 @@
       "techFamily": "Interfaces",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43125,10 +43459,12 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43199,10 +43535,12 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43280,10 +43618,12 @@
       "techFamily": "Interfaces",
       "subfamily": "LAG / LACP",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43357,10 +43697,12 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43429,10 +43771,12 @@
       "techFamily": "OAM",
       "subfamily": "Telemetry / OAM",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43511,10 +43855,12 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43619,10 +43965,12 @@
       "techFamily": "Policy & Routing",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43716,10 +44064,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "VPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43850,10 +44200,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -43943,10 +44295,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-ELAN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44053,10 +44407,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44171,10 +44527,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44285,10 +44643,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44394,10 +44754,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44488,10 +44850,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44592,10 +44956,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "EVPN-VPWS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44678,10 +45044,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44770,10 +45138,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44882,10 +45252,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -44983,10 +45355,12 @@
       "techFamily": "Service Overlay",
       "subfamily": "OSPF",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -45109,10 +45483,12 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -45194,10 +45570,12 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS / SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -45254,10 +45632,12 @@
       "techFamily": "Transport",
       "subfamily": "SR-MPLS",
       "usecases": [
-        "Service Provider",
-        "Metro",
-        "Business Services",
-        "MEF"
+        "Cloud Metro",
+        "Metro Fabric",
+        "Carrier Ethernet (MEF)",
+        "Business VPN Services",
+        "Route Reflector",
+        "Mobile Backhaul"
       ],
       "parseWarnings": []
     },
@@ -45309,9 +45689,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45403,9 +45783,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45534,9 +45914,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45576,9 +45956,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45623,9 +46003,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45706,9 +46086,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45806,9 +46186,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45903,9 +46283,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -45987,9 +46367,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46055,9 +46435,9 @@
       "techFamily": "OAM",
       "subfamily": "BFD",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46109,9 +46489,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46183,9 +46563,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46242,9 +46622,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46385,9 +46765,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46449,9 +46829,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46533,9 +46913,9 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (Route Reflector)",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46624,9 +47004,9 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (Route Reflector)",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46692,9 +47072,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46773,9 +47153,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -46952,9 +47332,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS / SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47024,9 +47404,9 @@
       "techFamily": "Transport",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47093,9 +47473,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47157,9 +47537,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47253,9 +47633,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "Apply Groups",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47388,9 +47768,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47444,9 +47824,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "L3VPN",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47502,9 +47882,9 @@
       "techFamily": "Apply-groups",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47584,9 +47964,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47683,9 +48063,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47779,9 +48159,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47862,9 +48242,9 @@
       "techFamily": "Interfaces",
       "subfamily": "Interfaces",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47929,9 +48309,9 @@
       "techFamily": "OAM",
       "subfamily": "BFD",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -47982,9 +48362,9 @@
       "techFamily": "OAM",
       "subfamily": "Oam",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48050,9 +48430,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48113,9 +48493,9 @@
       "techFamily": "Policy & Routing",
       "subfamily": "Policy",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48227,9 +48607,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "Services",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48329,9 +48709,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48433,9 +48813,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48575,9 +48955,9 @@
       "techFamily": "Service Overlay",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48645,9 +49025,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48730,9 +49110,9 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (Route Reflector)",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48832,9 +49212,9 @@
       "techFamily": "Transport",
       "subfamily": "BGP Overlay (Route Reflector)",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48897,9 +49277,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -48981,9 +49361,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -49165,9 +49545,9 @@
       "techFamily": "Transport",
       "subfamily": "IS-IS / SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -49239,9 +49619,9 @@
       "techFamily": "Transport",
       "subfamily": "SRv6",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     },
@@ -49307,9 +49687,9 @@
       "techFamily": "Transport",
       "subfamily": "Transport",
       "usecases": [
-        "Service Provider",
         "SRv6",
-        "Core/Edge"
+        "Business VPN Services",
+        "Route Reflector"
       ],
       "parseWarnings": []
     }

--- a/portal/src/lib/generator.ts
+++ b/portal/src/lib/generator.ts
@@ -241,9 +241,9 @@ export function validateSpec(
   if (!spec || value === undefined || value === "") return undefined;
   switch (spec.type) {
     case "enum":
-      return spec.values.includes(value)
-        ? undefined
-        : `not a validated value (${spec.values.join(", ")})`;
+      // Enum values render as an editable combobox (suggestions, not a closed set),
+      // so a value outside the list is permitted — don't flag it.
+      return undefined;
     case "range": {
       if (!/^\d+$/.test(value)) return "expected a number";
       const n = Number(value);


### PR DESCRIPTION
## What's New

Snip Library **Use Case** browsing is more accurate, and the Config Generator stops flagging valid inputs.

- Every design with a snip library (18) now appears under **intent-based use-case tags** — a service intent surfaces on *every* design that has it, not just one.
- Config Generator dropdown fields (e.g. MTU, label-block size) accept any value without a false "not a validated value" warning; the suggested values still appear.

## Why

The Use Case browse mode tagged only **6 of 18** snip-equipped designs and used inconsistent free-form labels, so an intent like "Business VPN Services" showed a single design when several qualified (it now lists 5). Enum fields render as editable dropdowns, so flagging a typed value as invalid was misleading.

## Changes

- [x] Portal: curated intent-based use-case vocabulary (21 tags) applied across all 18 snip-equipped designs (`portal/scripts/jvd-usecase-map.json`)
- [x] Portal: regenerated `snips.json` (675 snips, 18 designs, 0 warnings)
- [x] Portal: remove the enum "not a validated value" warning; keep dropdown suggestions (`portal/src/lib/generator.ts`)

## Verified before merge

- [x] Portal builds — `bun run build`
- [x] Generated artifacts regenerated where source changed (`snips.json`; no BYOAI mirror diff)
- [x] No internal-only content in public files
- [x] Externally-safe wording (watcher/customer-appropriate)

## Notes

Markdown link-check N/A (no markdown files changed). Snip-header description consistency and Pair-with dependency-graph correctness are intentionally deferred to a separate, incremental workstream.
