### PR TITLE
Metro EBS: prune misleading pair-with edges + fix portal topic parser

### DIFF
--- a/portal/public/byoai/metro_ethernet_business_services/MANIFEST.json
+++ b/portal/public/byoai/metro_ethernet_business_services/MANIFEST.json
@@ -301,7 +301,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2498,
+      "size_bytes": 2312,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf"
     },
     {
@@ -360,7 +360,7 @@
         "mse2_mx304",
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2327,
+      "size_bytes": 2252,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf"
     },
     {
@@ -375,7 +375,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2828,
+      "size_bytes": 2776,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/bgp-vpls.conf"
     },
     {
@@ -389,7 +389,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2613,
+      "size_bytes": 2458,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf"
     },
     {
@@ -417,7 +417,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2311,
+      "size_bytes": 2134,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-fxc.conf"
     },
     {
@@ -433,7 +433,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2466,
+      "size_bytes": 2298,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf"
     },
     {
@@ -446,7 +446,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2012,
+      "size_bytes": 1909,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5-anchor.conf"
     },
     {
@@ -535,7 +535,7 @@
         "an3_acx7100-48l",
         "ma3_acx7100-48l"
       ],
-      "size_bytes": 2430,
+      "size_bytes": 2377,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-bgp.conf"
     },
     {
@@ -548,7 +548,7 @@
         "an3_acx7100-48l",
         "ma3_acx7100-48l"
       ],
-      "size_bytes": 2276,
+      "size_bytes": 2222,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-ospf.conf"
     },
     {
@@ -986,7 +986,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 3036,
+      "size_bytes": 2878,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf"
     },
     {
@@ -998,7 +998,7 @@
       "seen_on": [
         "ma5_mx204"
       ],
-      "size_bytes": 2879,
+      "size_bytes": 2846,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf"
     },
     {
@@ -1011,7 +1011,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 3609,
+      "size_bytes": 3489,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-virtual-switch-irb.conf"
     },
     {
@@ -1038,7 +1038,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2581,
+      "size_bytes": 2498,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-etree.conf"
     },
     {
@@ -1051,7 +1051,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 3110,
+      "size_bytes": 2933,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-fxc.conf"
     },
     {
@@ -1063,7 +1063,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 3286,
+      "size_bytes": 3004,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf"
     },
     {
@@ -1076,7 +1076,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2690,
+      "size_bytes": 2533,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5-anchor.conf"
     },
     {
@@ -1115,7 +1115,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2860,
+      "size_bytes": 2691,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-floating-pw.conf"
     },
     {
@@ -1140,7 +1140,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2905,
+      "size_bytes": 2806,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-bgp.conf"
     },
     {
@@ -1153,7 +1153,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2409,
+      "size_bytes": 2309,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-ospf.conf"
     },
     {

--- a/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-snips.md
+++ b/portal/public/byoai/metro_ethernet_business_services/jvd-mebs-snips.md
@@ -965,9 +965,6 @@ interfaces {
  *  - evo/firewall/policers.conf
  *  - evo/services/l2circuit-lsw.conf
  *  - evo/services/l2circuit-hot-standby.conf
- *  - junos/services/l2circuit-floating-pw.conf  (cross-OS PW head
- *      on MX; the EVO AC unit on this interface is the customer-
- *      facing tail of the same floating pseudowire)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_PHYS    e.g. et-0/0/0   (the parent port; the per-unit
@@ -1264,8 +1261,6 @@ policy-options {
  *  - evo/services/evpn-type5.conf
  *  - evo/services/l3vpn-bgp.conf
  *  - evo/services/l3vpn-ospf.conf
- *  - evo/services/evpn-fxc.conf
- *  - evo/services/evpn-type5-anchor.conf
  *
  * Variables (example values from an3_acx7100-48l / METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101
@@ -1342,7 +1337,6 @@ policy-options {
  *  - evo/policy/communities.conf
  *  - evo/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging — supplies the AC interface plumbing)
- *  - junos/services/bgp-vpls.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   400 instances total (high 400 / med 0 / low 0)
@@ -1413,10 +1407,7 @@ routing-instances {
  *
  * Pair with:
  *  - evo/services/evpn-type5-anchor.conf
- *  - junos/services/evpn-type5-anchor.conf
  *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
- *  - junos/services/evpn-elan-virtual-switch-irb.conf  (cross-OS
- *      MX counterpart on the same VLAN/IRB)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)
@@ -1557,11 +1548,8 @@ routing-instances {
  * Pair with:
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *  - evo/policy/communities.conf
- *  - evo/policy/l3vpn-export-import.conf  (vrf-export policy
- *      shape — points at a per-EVI policy of the same name)
  *  - evo/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging on the FXC ACs)
- *  - junos/services/evpn-fxc.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   500 instances total (high 500 / med 0 / low 0)
@@ -1635,9 +1623,6 @@ routing-instances {
  * Pair with:
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *  - evo/policy/communities.conf
- *  - junos/services/evpn-port-based.conf  (cross-OS counterpart;
- *      Junos uses `instance-type evpn + vlan-id none +
- *      no-normalization` instead of mac-vrf)
  *
  * JVD service mapping:
  *   201 instances total (high 101 / med 100 / low 0)
@@ -1698,8 +1683,6 @@ routing-instances {
  *
  * Pair with:
  *  - evo/services/evpn-elan-mac-vrf-irb.conf
- *  - junos/services/evpn-type5-anchor.conf  (cross-OS peer)
- *  - evo/policy/l3vpn-export-import.conf
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *
  * JVD service mapping:
@@ -2078,7 +2061,6 @@ routing-instances {
  *  - evo/policy/communities.conf
  *  - evo/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - evo/services/l3vpn-ospf.conf  (sibling PE-CE peering shape)
- *  - junos/services/l3vpn-bgp.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   200 instances total (high 200 / med 0 / low 0)
@@ -2153,7 +2135,6 @@ routing-instances {
  *  - evo/policy/communities.conf
  *  - evo/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - evo/services/l3vpn-bgp.conf  (sibling PE-CE peering shape)
- *  - junos/services/l3vpn-ospf.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   100 instances total (high 100 / med 0 / low 0)
@@ -3681,10 +3662,6 @@ policy-options {
  *  - junos/services/l3vpn-ospf.conf
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/services/evpn-type5.conf
- *  - junos/services/evpn-port-based.conf
- *  - junos/services/evpn-etree.conf
- *  - junos/services/evpn-fxc.conf
- *  - junos/services/evpn-type5-anchor.conf
  *
  * Variables (example values from ma4_mx204 / METRO_BGPv4_L3VPN_1001):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_1001
@@ -3761,7 +3738,6 @@ policy-options {
  *    `l2vpn-id` form). For pure LDP-VPLS see the EVO snip.
  *
  * Pair with:
- *  - evo/services/bgp-vpls.conf
  *  - junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *
@@ -3855,8 +3831,6 @@ routing-instances {
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/policy/communities.conf
  *  - junos/services/evpn-type5-anchor.conf
- *  - evo/services/evpn-elan-mac-vrf-irb.conf  (cross-OS EVO
- *      counterpart on the same VLAN/IRB; mac-vrf flavour)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)
@@ -4001,8 +3975,6 @@ routing-instances {
  *  - junos/interfaces/ethernet-bridge.conf  (vlan-bridge UNI
  *      that the E-Tree EVI binds via `interface <ae>.<unit>;`)
  *  - junos/policy/communities.conf  (per-EVI export communities)
- *  - junos/policy/l3vpn-export-import.conf  (per-EVI export
- *      policy shape)
  *
  * JVD service mapping:
  *   1050 instances total (high 1050 / med 0 / low 0)
@@ -4071,11 +4043,8 @@ routing-instances {
  * Pair with:
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/policy/communities.conf
- *  - junos/policy/l3vpn-export-import.conf  (vrf-export policy
- *      shape — points at a per-EVI policy of the same name)
  *  - junos/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging on the FXC ACs)
- *  - evo/services/evpn-fxc.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   500 instances total (high 500 / med 0 / low 0)
@@ -4156,13 +4125,8 @@ routing-instances {
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf  (ae11 ESI for AA)
  *  - junos/policy/communities.conf  (map2gold colour community)
- *  - junos/policy/l3vpn-export-import.conf  (per-VRF export policy
- *      shape; this snip's vrf-export points at a per-EVI policy
- *      of the same name)
  *  - junos/services/evpn-vpws.conf  (sibling per-port EVPN service
  *      type — VPWS P2P co-deploys with ELAN E-LAN on the same PE)
- *  - evo/services/evpn-port-based.conf  (cross-OS EVO counterpart;
- *      mac-vrf + service-type vlan-bundle equivalent)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)
@@ -4234,11 +4198,8 @@ routing-instances {
  *
  * Pair with:
  *  - junos/services/evpn-elan-virtual-switch-irb.conf  (Junos L2 peer)
- *  - evo/services/evpn-elan-mac-vrf-irb.conf            (EVO L2 peer)
  *  - junos/services/evpn-type5.conf                     (full RT-5 variant)
  *  - junos/apply-groups/gr-l3vpn.conf                   (multipath + vrf-table-label inheritance)
- *  - junos/policy/l3vpn-export-import.conf
- *  - evo/services/evpn-type5-anchor.conf
  *  - junos/transport/bgp-overlay.conf                   (family evpn signaling)
  *
  * JVD service mapping:
@@ -4463,9 +4424,6 @@ routing-instances {
  *  - junos/interfaces/pseudowire-subscriber.conf  (the ps<N>
  *      logical interface this PW terminates on, via ps<N>.0 with
  *      encapsulation ethernet-ccc)
- *  - evo/interfaces/edge-vlan-normalization.conf  (cross-OS PW
- *      tail on the EVO access node, where the PW lands on the
- *      customer-facing vlan-ccc AC unit)
  *
  * JVD service mapping:
  *   20 instances total (high 20 / med 0 / low 0)
@@ -4596,11 +4554,9 @@ routing-instances {
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/apply-groups/gr-l3vpn.conf
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - junos/services/l3vpn-ospf.conf  (sibling PE-CE peering shape;
  *      same VRF infra, OSPF instead of BGP)
- *  - evo/services/l3vpn-bgp.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   2200 instances total (high 2200 / med 0 / low 0)
@@ -4674,11 +4630,9 @@ routing-instances {
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/apply-groups/gr-l3vpn.conf
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - junos/services/l3vpn-bgp.conf  (sibling PE-CE peering shape;
  *      same VRF infra, BGP instead of OSPF)
- *  - evo/services/l3vpn-ospf.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   1100 instances total (high 1100 / med 0 / low 0)

--- a/portal/scripts/generate-snips.mjs
+++ b/portal/scripts/generate-snips.mjs
@@ -139,7 +139,10 @@ function parseSnip(text) {
     // "Apply-group" is accepted as a synonym for "Topic" — apply-group snips
     // are routinely headed with "Apply-group: GR-NAME" since the group name
     // IS the topic.
-    const sec = trimmed.match(/^(Topic|Apply-groups?|Seen on|Highlights|Pair with|Variables|JVD service mapping)\b\s*:?\s*(.*)$/i);
+    // Match on the de-starred line (not `trimmed`) so the keyword must sit at
+    // the header's own indent level; an indented highlight continuation that
+    // merely mentions e.g. "apply-group `GR-X`" must NOT be read as a header.
+    const sec = line.match(/^\s{0,1}(Topic|Apply-groups?|Seen on|Highlights|Pair with|Variables|JVD service mapping)\b\s*:?\s*(.*)$/i);
     if (sec) {
       const key = sec[1].toLowerCase();
       if (key === "topic" || key === "apply-group" || key === "apply-groups") {

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T00:41:13.148Z",
+  "generatedAt": "2026-08-04T00:46:56.733Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -40768,11 +40768,6 @@
           "raw": "evo/services/l2circuit-hot-standby.conf",
           "id": "metro_ethernet_business_services/evo/services/l2circuit-hot-standby",
           "note": null
-        },
-        {
-          "raw": "junos/services/l2circuit-floating-pw.conf  (cross-OS PW head",
-          "id": "metro_ethernet_business_services/junos/services/l2circuit-floating-pw",
-          "note": "(cross-OS PW head"
         }
       ],
       "variables": [
@@ -41023,16 +41018,6 @@
           "raw": "evo/services/l3vpn-ospf.conf",
           "id": "metro_ethernet_business_services/evo/services/l3vpn-ospf",
           "note": null
-        },
-        {
-          "raw": "evo/services/evpn-fxc.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-fxc",
-          "note": null
-        },
-        {
-          "raw": "evo/services/evpn-type5-anchor.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-type5-anchor",
-          "note": null
         }
       ],
       "variables": [
@@ -41112,11 +41097,6 @@
           "raw": "evo/apply-groups/gr-edge-intf.conf  (parent UNI family",
           "id": "metro_ethernet_business_services/evo/apply-groups/gr-edge-intf",
           "note": "(parent UNI family"
-        },
-        {
-          "raw": "junos/services/bgp-vpls.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/junos/services/bgp-vpls",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [
@@ -41210,19 +41190,9 @@
           "note": null
         },
         {
-          "raw": "junos/services/evpn-type5-anchor.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-type5-anchor",
-          "note": null
-        },
-        {
           "raw": "evo/services/evpn-type5.conf  (IRB co-occurrence)",
           "id": "metro_ethernet_business_services/evo/services/evpn-type5",
           "note": "IRB co-occurrence"
-        },
-        {
-          "raw": "junos/services/evpn-elan-virtual-switch-irb.conf  (cross-OS",
-          "id": "metro_ethernet_business_services/junos/services/evpn-elan-virtual-switch-irb",
-          "note": "(cross-OS"
         }
       ],
       "variables": [
@@ -41421,19 +41391,9 @@
           "note": null
         },
         {
-          "raw": "evo/policy/l3vpn-export-import.conf  (vrf-export policy",
-          "id": "metro_ethernet_business_services/evo/policy/l3vpn-export-import",
-          "note": "(vrf-export policy"
-        },
-        {
           "raw": "evo/apply-groups/gr-edge-intf.conf  (parent UNI family",
           "id": "metro_ethernet_business_services/evo/apply-groups/gr-edge-intf",
           "note": "(parent UNI family"
-        },
-        {
-          "raw": "junos/services/evpn-fxc.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/junos/services/evpn-fxc",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [
@@ -41542,11 +41502,6 @@
           "raw": "evo/policy/communities.conf",
           "id": "metro_ethernet_business_services/evo/policy/communities",
           "note": null
-        },
-        {
-          "raw": "junos/services/evpn-port-based.conf  (cross-OS counterpart;",
-          "id": "metro_ethernet_business_services/junos/services/evpn-port-based",
-          "note": "(cross-OS counterpart;"
         }
       ],
       "variables": [
@@ -41629,16 +41584,6 @@
         {
           "raw": "evo/services/evpn-elan-mac-vrf-irb.conf",
           "id": "metro_ethernet_business_services/evo/services/evpn-elan-mac-vrf-irb",
-          "note": null
-        },
-        {
-          "raw": "junos/services/evpn-type5-anchor.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/junos/services/evpn-type5-anchor",
-          "note": "cross-OS peer"
-        },
-        {
-          "raw": "evo/policy/l3vpn-export-import.conf",
-          "id": "metro_ethernet_business_services/evo/policy/l3vpn-export-import",
           "note": null
         },
         {
@@ -42190,11 +42135,6 @@
           "raw": "evo/services/l3vpn-ospf.conf  (sibling PE-CE peering shape)",
           "id": "metro_ethernet_business_services/evo/services/l3vpn-ospf",
           "note": "sibling PE-CE peering shape"
-        },
-        {
-          "raw": "junos/services/l3vpn-bgp.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/junos/services/l3vpn-bgp",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [
@@ -42295,11 +42235,6 @@
           "raw": "evo/services/l3vpn-bgp.conf  (sibling PE-CE peering shape)",
           "id": "metro_ethernet_business_services/evo/services/l3vpn-bgp",
           "note": "sibling PE-CE peering shape"
-        },
-        {
-          "raw": "junos/services/l3vpn-ospf.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/junos/services/l3vpn-ospf",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [
@@ -43917,26 +43852,6 @@
           "raw": "junos/services/evpn-type5.conf",
           "id": "metro_ethernet_business_services/junos/services/evpn-type5",
           "note": null
-        },
-        {
-          "raw": "junos/services/evpn-port-based.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-port-based",
-          "note": null
-        },
-        {
-          "raw": "junos/services/evpn-etree.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-etree",
-          "note": null
-        },
-        {
-          "raw": "junos/services/evpn-fxc.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-fxc",
-          "note": null
-        },
-        {
-          "raw": "junos/services/evpn-type5-anchor.conf",
-          "id": "metro_ethernet_business_services/junos/services/evpn-type5-anchor",
-          "note": null
         }
       ],
       "variables": [
@@ -43999,11 +43914,6 @@
         "The JVD does NOT deploy LDP-VPLS on Junos PEs (no `vpls-id` + `neighbor` static config exists in any Junos conf/*.conf), nor does it deploy LDP-VPLS with BGP auto-discovery (no `l2vpn-id` form). For pure LDP-VPLS see the EVO snip."
       ],
       "pairWith": [
-        {
-          "raw": "evo/services/bgp-vpls.conf",
-          "id": "metro_ethernet_business_services/evo/services/bgp-vpls",
-          "note": null
-        },
         {
           "raw": "junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)",
           "id": "metro_ethernet_business_services/junos/apply-groups/gr-fatpw-label",
@@ -44134,11 +44044,6 @@
           "raw": "junos/services/evpn-type5-anchor.conf",
           "id": "metro_ethernet_business_services/junos/services/evpn-type5-anchor",
           "note": null
-        },
-        {
-          "raw": "evo/services/evpn-elan-mac-vrf-irb.conf  (cross-OS EVO",
-          "id": "metro_ethernet_business_services/evo/services/evpn-elan-mac-vrf-irb",
-          "note": "(cross-OS EVO"
         }
       ],
       "variables": [
@@ -44350,11 +44255,6 @@
           "raw": "junos/policy/communities.conf  (per-EVI export communities)",
           "id": "metro_ethernet_business_services/junos/policy/communities",
           "note": "per-EVI export communities"
-        },
-        {
-          "raw": "junos/policy/l3vpn-export-import.conf  (per-EVI export",
-          "id": "metro_ethernet_business_services/junos/policy/l3vpn-export-import",
-          "note": "(per-EVI export"
         }
       ],
       "variables": [
@@ -44452,19 +44352,9 @@
           "note": null
         },
         {
-          "raw": "junos/policy/l3vpn-export-import.conf  (vrf-export policy",
-          "id": "metro_ethernet_business_services/junos/policy/l3vpn-export-import",
-          "note": "(vrf-export policy"
-        },
-        {
           "raw": "junos/apply-groups/gr-edge-intf.conf  (parent UNI family",
           "id": "metro_ethernet_business_services/junos/apply-groups/gr-edge-intf",
           "note": "(parent UNI family"
-        },
-        {
-          "raw": "evo/services/evpn-fxc.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/evo/services/evpn-fxc",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [
@@ -44577,19 +44467,9 @@
           "note": "map2gold colour community"
         },
         {
-          "raw": "junos/policy/l3vpn-export-import.conf  (per-VRF export policy",
-          "id": "metro_ethernet_business_services/junos/policy/l3vpn-export-import",
-          "note": "(per-VRF export policy"
-        },
-        {
           "raw": "junos/services/evpn-vpws.conf  (sibling per-port EVPN service",
           "id": "metro_ethernet_business_services/junos/services/evpn-vpws",
           "note": "(sibling per-port EVPN service"
-        },
-        {
-          "raw": "evo/services/evpn-port-based.conf  (cross-OS EVO counterpart;",
-          "id": "metro_ethernet_business_services/evo/services/evpn-port-based",
-          "note": "(cross-OS EVO counterpart;"
         }
       ],
       "variables": [
@@ -44682,11 +44562,6 @@
           "note": "Junos L2 peer"
         },
         {
-          "raw": "evo/services/evpn-elan-mac-vrf-irb.conf            (EVO L2 peer)",
-          "id": "metro_ethernet_business_services/evo/services/evpn-elan-mac-vrf-irb",
-          "note": "EVO L2 peer"
-        },
-        {
           "raw": "junos/services/evpn-type5.conf                     (full RT-5 variant)",
           "id": "metro_ethernet_business_services/junos/services/evpn-type5",
           "note": "full RT-5 variant"
@@ -44695,16 +44570,6 @@
           "raw": "junos/apply-groups/gr-l3vpn.conf                   (multipath + vrf-table-label inheritance)",
           "id": "metro_ethernet_business_services/junos/apply-groups/gr-l3vpn",
           "note": "multipath + vrf-table-label inheritance"
-        },
-        {
-          "raw": "junos/policy/l3vpn-export-import.conf",
-          "id": "metro_ethernet_business_services/junos/policy/l3vpn-export-import",
-          "note": null
-        },
-        {
-          "raw": "evo/services/evpn-type5-anchor.conf",
-          "id": "metro_ethernet_business_services/evo/services/evpn-type5-anchor",
-          "note": null
         },
         {
           "raw": "junos/transport/bgp-overlay.conf                   (family evpn signaling)",
@@ -45001,11 +44866,6 @@
           "raw": "junos/interfaces/pseudowire-subscriber.conf  (the ps<N>",
           "id": "metro_ethernet_business_services/junos/interfaces/pseudowire-subscriber",
           "note": "(the ps<N>"
-        },
-        {
-          "raw": "evo/interfaces/edge-vlan-normalization.conf  (cross-OS PW",
-          "id": "metro_ethernet_business_services/evo/interfaces/edge-vlan-normalization",
-          "note": "(cross-OS PW"
         }
       ],
       "variables": [
@@ -45190,11 +45050,6 @@
           "note": null
         },
         {
-          "raw": "junos/services/evpn-elan-mac-vrf-irb.conf",
-          "id": null,
-          "note": null
-        },
-        {
           "raw": "junos/transport/bgp-overlay.conf  (family inet-vpn signaling)",
           "id": "metro_ethernet_business_services/junos/transport/bgp-overlay",
           "note": "family inet-vpn signaling"
@@ -45203,11 +45058,6 @@
           "raw": "junos/services/l3vpn-ospf.conf  (sibling PE-CE peering shape;",
           "id": "metro_ethernet_business_services/junos/services/l3vpn-ospf",
           "note": "(sibling PE-CE peering shape;"
-        },
-        {
-          "raw": "evo/services/l3vpn-bgp.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/evo/services/l3vpn-bgp",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [
@@ -45303,11 +45153,6 @@
           "note": null
         },
         {
-          "raw": "junos/services/evpn-elan-mac-vrf-irb.conf",
-          "id": null,
-          "note": null
-        },
-        {
           "raw": "junos/transport/bgp-overlay.conf  (family inet-vpn signaling)",
           "id": "metro_ethernet_business_services/junos/transport/bgp-overlay",
           "note": "family inet-vpn signaling"
@@ -45316,11 +45161,6 @@
           "raw": "junos/services/l3vpn-bgp.conf  (sibling PE-CE peering shape;",
           "id": "metro_ethernet_business_services/junos/services/l3vpn-bgp",
           "note": "(sibling PE-CE peering shape;"
-        },
-        {
-          "raw": "evo/services/l3vpn-ospf.conf  (cross-OS peer)",
-          "id": "metro_ethernet_business_services/evo/services/l3vpn-ospf",
-          "note": "cross-OS peer"
         }
       ],
       "variables": [

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T23:29:54.953Z",
+  "generatedAt": "2026-08-04T00:41:13.148Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -44662,7 +44662,7 @@
       "category": "services",
       "name": "evpn-type5-anchor",
       "path": "service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5-anchor.conf",
-      "topic": "Apply-group: `GR-L3VPN` on Junos PEs via inherited group",
+      "topic": "Slim L3VPN IRB-anchor VRF (paired with EVPN-ELAN",
       "seenOn": {
         "junos": [
           "mse1_mx304",
@@ -44672,7 +44672,8 @@
       },
       "highlights": [
         "Same role as `evpn-type5.conf` (the L3 half of the EVPN-IRB pattern, owning the IRB and the VRF) but written in the \"slim\" form: no `protocols evpn ip-prefix-routes { ... }` block. In this JVD's METRO_L3VPN_4050 EVI the host /32s and IRB subnet are advertised as RT-2 MAC+IP routes from the paired MAC-VRF, so no RT-5 prefix routes are needed — the VRF only needs to terminate the IRB and do egress L3 lookups for ingress-replicated/MAC-routed traffic.",
-        "`vrf-table-label` + `vrf-import / vrf-export` are the only VPN-RT plumbing; routing-options is just `router-id` (the `multipath { vpn-unequal-cost; }` knob comes from"
+        "`vrf-table-label` + `vrf-import / vrf-export` are the only VPN-RT plumbing; routing-options is just `router-id` (the `multipath { vpn-unequal-cost; }` knob comes from apply-group `GR-L3VPN` on Junos PEs via inherited group inheritance).",
+        "Compat-graph family `service.evpn-type5` covers both this slim variant and the explicit `evpn-type5.conf` variant (the regex matches `evpn-type5*`)."
       ],
       "pairWith": [
         {

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/MANIFEST.json
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/MANIFEST.json
@@ -301,7 +301,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2498,
+      "size_bytes": 2312,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf"
     },
     {
@@ -360,7 +360,7 @@
         "mse2_mx304",
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2327,
+      "size_bytes": 2252,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf"
     },
     {
@@ -375,7 +375,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2828,
+      "size_bytes": 2776,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/bgp-vpls.conf"
     },
     {
@@ -389,7 +389,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2613,
+      "size_bytes": 2458,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf"
     },
     {
@@ -417,7 +417,7 @@
       "seen_on": [
         "an3_acx7100-48l"
       ],
-      "size_bytes": 2311,
+      "size_bytes": 2134,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-fxc.conf"
     },
     {
@@ -433,7 +433,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2466,
+      "size_bytes": 2298,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf"
     },
     {
@@ -446,7 +446,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 2012,
+      "size_bytes": 1909,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5-anchor.conf"
     },
     {
@@ -535,7 +535,7 @@
         "an3_acx7100-48l",
         "ma3_acx7100-48l"
       ],
-      "size_bytes": 2430,
+      "size_bytes": 2377,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-bgp.conf"
     },
     {
@@ -548,7 +548,7 @@
         "an3_acx7100-48l",
         "ma3_acx7100-48l"
       ],
-      "size_bytes": 2276,
+      "size_bytes": 2222,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-ospf.conf"
     },
     {
@@ -986,7 +986,7 @@
         "meg1_acx7100-32c",
         "meg2_acx7509"
       ],
-      "size_bytes": 3036,
+      "size_bytes": 2878,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf"
     },
     {
@@ -998,7 +998,7 @@
       "seen_on": [
         "ma5_mx204"
       ],
-      "size_bytes": 2879,
+      "size_bytes": 2846,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf"
     },
     {
@@ -1011,7 +1011,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 3609,
+      "size_bytes": 3489,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-virtual-switch-irb.conf"
     },
     {
@@ -1038,7 +1038,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2581,
+      "size_bytes": 2498,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-etree.conf"
     },
     {
@@ -1051,7 +1051,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 3110,
+      "size_bytes": 2933,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-fxc.conf"
     },
     {
@@ -1063,7 +1063,7 @@
       "seen_on": [
         "an1_mx204"
       ],
-      "size_bytes": 3286,
+      "size_bytes": 3004,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf"
     },
     {
@@ -1076,7 +1076,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2690,
+      "size_bytes": 2533,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5-anchor.conf"
     },
     {
@@ -1115,7 +1115,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2860,
+      "size_bytes": 2691,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-floating-pw.conf"
     },
     {
@@ -1140,7 +1140,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2905,
+      "size_bytes": 2806,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-bgp.conf"
     },
     {
@@ -1153,7 +1153,7 @@
         "mse1_mx304",
         "mse2_mx304"
       ],
-      "size_bytes": 2409,
+      "size_bytes": 2309,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-ospf.conf"
     },
     {

--- a/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/byoai/jvd-mebs-snips.md
@@ -965,9 +965,6 @@ interfaces {
  *  - evo/firewall/policers.conf
  *  - evo/services/l2circuit-lsw.conf
  *  - evo/services/l2circuit-hot-standby.conf
- *  - junos/services/l2circuit-floating-pw.conf  (cross-OS PW head
- *      on MX; the EVO AC unit on this interface is the customer-
- *      facing tail of the same floating pseudowire)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_PHYS    e.g. et-0/0/0   (the parent port; the per-unit
@@ -1264,8 +1261,6 @@ policy-options {
  *  - evo/services/evpn-type5.conf
  *  - evo/services/l3vpn-bgp.conf
  *  - evo/services/l3vpn-ospf.conf
- *  - evo/services/evpn-fxc.conf
- *  - evo/services/evpn-type5-anchor.conf
  *
  * Variables (example values from an3_acx7100-48l / METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101
@@ -1342,7 +1337,6 @@ policy-options {
  *  - evo/policy/communities.conf
  *  - evo/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging — supplies the AC interface plumbing)
- *  - junos/services/bgp-vpls.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   400 instances total (high 400 / med 0 / low 0)
@@ -1413,10 +1407,7 @@ routing-instances {
  *
  * Pair with:
  *  - evo/services/evpn-type5-anchor.conf
- *  - junos/services/evpn-type5-anchor.conf
  *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
- *  - junos/services/evpn-elan-virtual-switch-irb.conf  (cross-OS
- *      MX counterpart on the same VLAN/IRB)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)
@@ -1557,11 +1548,8 @@ routing-instances {
  * Pair with:
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *  - evo/policy/communities.conf
- *  - evo/policy/l3vpn-export-import.conf  (vrf-export policy
- *      shape — points at a per-EVI policy of the same name)
  *  - evo/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging on the FXC ACs)
- *  - junos/services/evpn-fxc.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   500 instances total (high 500 / med 0 / low 0)
@@ -1635,9 +1623,6 @@ routing-instances {
  * Pair with:
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *  - evo/policy/communities.conf
- *  - junos/services/evpn-port-based.conf  (cross-OS counterpart;
- *      Junos uses `instance-type evpn + vlan-id none +
- *      no-normalization` instead of mac-vrf)
  *
  * JVD service mapping:
  *   201 instances total (high 101 / med 100 / low 0)
@@ -1698,8 +1683,6 @@ routing-instances {
  *
  * Pair with:
  *  - evo/services/evpn-elan-mac-vrf-irb.conf
- *  - junos/services/evpn-type5-anchor.conf  (cross-OS peer)
- *  - evo/policy/l3vpn-export-import.conf
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *
  * JVD service mapping:
@@ -2078,7 +2061,6 @@ routing-instances {
  *  - evo/policy/communities.conf
  *  - evo/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - evo/services/l3vpn-ospf.conf  (sibling PE-CE peering shape)
- *  - junos/services/l3vpn-bgp.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   200 instances total (high 200 / med 0 / low 0)
@@ -2153,7 +2135,6 @@ routing-instances {
  *  - evo/policy/communities.conf
  *  - evo/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - evo/services/l3vpn-bgp.conf  (sibling PE-CE peering shape)
- *  - junos/services/l3vpn-ospf.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   100 instances total (high 100 / med 0 / low 0)
@@ -3681,10 +3662,6 @@ policy-options {
  *  - junos/services/l3vpn-ospf.conf
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/services/evpn-type5.conf
- *  - junos/services/evpn-port-based.conf
- *  - junos/services/evpn-etree.conf
- *  - junos/services/evpn-fxc.conf
- *  - junos/services/evpn-type5-anchor.conf
  *
  * Variables (example values from ma4_mx204 / METRO_BGPv4_L3VPN_1001):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_1001
@@ -3761,7 +3738,6 @@ policy-options {
  *    `l2vpn-id` form). For pure LDP-VPLS see the EVO snip.
  *
  * Pair with:
- *  - evo/services/bgp-vpls.conf
  *  - junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *
@@ -3855,8 +3831,6 @@ routing-instances {
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/policy/communities.conf
  *  - junos/services/evpn-type5-anchor.conf
- *  - evo/services/evpn-elan-mac-vrf-irb.conf  (cross-OS EVO
- *      counterpart on the same VLAN/IRB; mac-vrf flavour)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)
@@ -4001,8 +3975,6 @@ routing-instances {
  *  - junos/interfaces/ethernet-bridge.conf  (vlan-bridge UNI
  *      that the E-Tree EVI binds via `interface <ae>.<unit>;`)
  *  - junos/policy/communities.conf  (per-EVI export communities)
- *  - junos/policy/l3vpn-export-import.conf  (per-EVI export
- *      policy shape)
  *
  * JVD service mapping:
  *   1050 instances total (high 1050 / med 0 / low 0)
@@ -4071,11 +4043,8 @@ routing-instances {
  * Pair with:
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/policy/communities.conf
- *  - junos/policy/l3vpn-export-import.conf  (vrf-export policy
- *      shape — points at a per-EVI policy of the same name)
  *  - junos/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging on the FXC ACs)
- *  - evo/services/evpn-fxc.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   500 instances total (high 500 / med 0 / low 0)
@@ -4156,13 +4125,8 @@ routing-instances {
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf  (ae11 ESI for AA)
  *  - junos/policy/communities.conf  (map2gold colour community)
- *  - junos/policy/l3vpn-export-import.conf  (per-VRF export policy
- *      shape; this snip's vrf-export points at a per-EVI policy
- *      of the same name)
  *  - junos/services/evpn-vpws.conf  (sibling per-port EVPN service
  *      type — VPWS P2P co-deploys with ELAN E-LAN on the same PE)
- *  - evo/services/evpn-port-based.conf  (cross-OS EVO counterpart;
- *      mac-vrf + service-type vlan-bundle equivalent)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)
@@ -4234,11 +4198,8 @@ routing-instances {
  *
  * Pair with:
  *  - junos/services/evpn-elan-virtual-switch-irb.conf  (Junos L2 peer)
- *  - evo/services/evpn-elan-mac-vrf-irb.conf            (EVO L2 peer)
  *  - junos/services/evpn-type5.conf                     (full RT-5 variant)
  *  - junos/apply-groups/gr-l3vpn.conf                   (multipath + vrf-table-label inheritance)
- *  - junos/policy/l3vpn-export-import.conf
- *  - evo/services/evpn-type5-anchor.conf
  *  - junos/transport/bgp-overlay.conf                   (family evpn signaling)
  *
  * JVD service mapping:
@@ -4463,9 +4424,6 @@ routing-instances {
  *  - junos/interfaces/pseudowire-subscriber.conf  (the ps<N>
  *      logical interface this PW terminates on, via ps<N>.0 with
  *      encapsulation ethernet-ccc)
- *  - evo/interfaces/edge-vlan-normalization.conf  (cross-OS PW
- *      tail on the EVO access node, where the PW lands on the
- *      customer-facing vlan-ccc AC unit)
  *
  * JVD service mapping:
  *   20 instances total (high 20 / med 0 / low 0)
@@ -4596,11 +4554,9 @@ routing-instances {
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/apply-groups/gr-l3vpn.conf
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - junos/services/l3vpn-ospf.conf  (sibling PE-CE peering shape;
  *      same VRF infra, OSPF instead of BGP)
- *  - evo/services/l3vpn-bgp.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   2200 instances total (high 2200 / med 0 / low 0)
@@ -4674,11 +4630,9 @@ routing-instances {
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/apply-groups/gr-l3vpn.conf
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - junos/services/l3vpn-bgp.conf  (sibling PE-CE peering shape;
  *      same VRF infra, BGP instead of OSPF)
- *  - evo/services/l3vpn-ospf.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   1100 instances total (high 1100 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/interfaces/edge-vlan-normalization.conf
@@ -24,9 +24,6 @@
  *  - evo/firewall/policers.conf
  *  - evo/services/l2circuit-lsw.conf
  *  - evo/services/l2circuit-hot-standby.conf
- *  - junos/services/l2circuit-floating-pw.conf  (cross-OS PW head
- *      on MX; the EVO AC unit on this interface is the customer-
- *      facing tail of the same floating pseudowire)
  *
  * Variables (example values from an3_acx7100-48l):
  *   $AC_PHYS    e.g. et-0/0/0   (the parent port; the per-unit

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/policy/l3vpn-export-import.conf
@@ -22,8 +22,6 @@
  *  - evo/services/evpn-type5.conf
  *  - evo/services/l3vpn-bgp.conf
  *  - evo/services/l3vpn-ospf.conf
- *  - evo/services/evpn-fxc.conf
- *  - evo/services/evpn-type5-anchor.conf
  *
  * Variables (example values from an3_acx7100-48l / METRO_BGPv4_L3VPN_2101):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_2101

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/bgp-vpls.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/bgp-vpls.conf
@@ -28,7 +28,6 @@
  *  - evo/policy/communities.conf
  *  - evo/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging — supplies the AC interface plumbing)
- *  - junos/services/bgp-vpls.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   400 instances total (high 400 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-elan-mac-vrf-irb.conf
@@ -20,10 +20,7 @@
  *
  * Pair with:
  *  - evo/services/evpn-type5-anchor.conf
- *  - junos/services/evpn-type5-anchor.conf
  *  - evo/services/evpn-type5.conf  (IRB co-occurrence)
- *  - junos/services/evpn-elan-virtual-switch-irb.conf  (cross-OS
- *      MX counterpart on the same VLAN/IRB)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-fxc.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-fxc.conf
@@ -15,11 +15,8 @@
  * Pair with:
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *  - evo/policy/communities.conf
- *  - evo/policy/l3vpn-export-import.conf  (vrf-export policy
- *      shape — points at a per-EVI policy of the same name)
  *  - evo/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging on the FXC ACs)
- *  - junos/services/evpn-fxc.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   500 instances total (high 500 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-port-based.conf
@@ -23,9 +23,6 @@
  * Pair with:
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *  - evo/policy/communities.conf
- *  - junos/services/evpn-port-based.conf  (cross-OS counterpart;
- *      Junos uses `instance-type evpn + vlan-id none +
- *      no-normalization` instead of mac-vrf)
  *
  * JVD service mapping:
  *   201 instances total (high 101 / med 100 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5-anchor.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/evpn-type5-anchor.conf
@@ -19,8 +19,6 @@
  *
  * Pair with:
  *  - evo/services/evpn-elan-mac-vrf-irb.conf
- *  - junos/services/evpn-type5-anchor.conf  (cross-OS peer)
- *  - evo/policy/l3vpn-export-import.conf
  *  - evo/transport/bgp-overlay.conf  (family evpn signaling)
  *
  * JVD service mapping:

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-bgp.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-bgp.conf
@@ -20,7 +20,6 @@
  *  - evo/policy/communities.conf
  *  - evo/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - evo/services/l3vpn-ospf.conf  (sibling PE-CE peering shape)
- *  - junos/services/l3vpn-bgp.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   200 instances total (high 200 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-ospf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/evo/services/l3vpn-ospf.conf
@@ -21,7 +21,6 @@
  *  - evo/policy/communities.conf
  *  - evo/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - evo/services/l3vpn-bgp.conf  (sibling PE-CE peering shape)
- *  - junos/services/l3vpn-ospf.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   100 instances total (high 100 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/policy/l3vpn-export-import.conf
@@ -30,10 +30,6 @@
  *  - junos/services/l3vpn-ospf.conf
  *  - junos/apply-groups/gr-l3vpn.conf
  *  - junos/services/evpn-type5.conf
- *  - junos/services/evpn-port-based.conf
- *  - junos/services/evpn-etree.conf
- *  - junos/services/evpn-fxc.conf
- *  - junos/services/evpn-type5-anchor.conf
  *
  * Variables (example values from ma4_mx204 / METRO_BGPv4_L3VPN_1001):
  *   $INSTANCE_NAME    e.g. METRO_BGPv4_L3VPN_1001

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/bgp-vpls.conf
@@ -24,7 +24,6 @@
  *    `l2vpn-id` form). For pure LDP-VPLS see the EVO snip.
  *
  * Pair with:
- *  - evo/services/bgp-vpls.conf
  *  - junos/apply-groups/gr-fatpw-label.conf  (vpls_* wildcard FAT-PW)
  *  - junos/transport/bgp-overlay.conf  (family l2vpn signaling)
  *

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-virtual-switch-irb.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-elan-virtual-switch-irb.conf
@@ -37,8 +37,6 @@
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/policy/communities.conf
  *  - junos/services/evpn-type5-anchor.conf
- *  - evo/services/evpn-elan-mac-vrf-irb.conf  (cross-OS EVO
- *      counterpart on the same VLAN/IRB; mac-vrf flavour)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-etree.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-etree.conf
@@ -25,8 +25,6 @@
  *  - junos/interfaces/ethernet-bridge.conf  (vlan-bridge UNI
  *      that the E-Tree EVI binds via `interface <ae>.<unit>;`)
  *  - junos/policy/communities.conf  (per-EVI export communities)
- *  - junos/policy/l3vpn-export-import.conf  (per-EVI export
- *      policy shape)
  *
  * JVD service mapping:
  *   1050 instances total (high 1050 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-fxc.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-fxc.conf
@@ -25,11 +25,8 @@
  * Pair with:
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/policy/communities.conf
- *  - junos/policy/l3vpn-export-import.conf  (vrf-export policy
- *      shape — points at a per-EVI policy of the same name)
  *  - junos/apply-groups/gr-edge-intf.conf  (parent UNI family
  *      / flexible-vlan-tagging on the FXC ACs)
- *  - evo/services/evpn-fxc.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   500 instances total (high 500 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-port-based.conf
@@ -28,13 +28,8 @@
  *  - junos/transport/bgp-overlay.conf  (family evpn signaling)
  *  - junos/interfaces/lag-esi-multihoming.conf  (ae11 ESI for AA)
  *  - junos/policy/communities.conf  (map2gold colour community)
- *  - junos/policy/l3vpn-export-import.conf  (per-VRF export policy
- *      shape; this snip's vrf-export points at a per-EVI policy
- *      of the same name)
  *  - junos/services/evpn-vpws.conf  (sibling per-port EVPN service
  *      type — VPWS P2P co-deploys with ELAN E-LAN on the same PE)
- *  - evo/services/evpn-port-based.conf  (cross-OS EVO counterpart;
- *      mac-vrf + service-type vlan-bundle equivalent)
  *
  * JVD service mapping:
  *   50 instances total (high 50 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5-anchor.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/evpn-type5-anchor.conf
@@ -26,11 +26,8 @@
  *
  * Pair with:
  *  - junos/services/evpn-elan-virtual-switch-irb.conf  (Junos L2 peer)
- *  - evo/services/evpn-elan-mac-vrf-irb.conf            (EVO L2 peer)
  *  - junos/services/evpn-type5.conf                     (full RT-5 variant)
  *  - junos/apply-groups/gr-l3vpn.conf                   (multipath + vrf-table-label inheritance)
- *  - junos/policy/l3vpn-export-import.conf
- *  - evo/services/evpn-type5-anchor.conf
  *  - junos/transport/bgp-overlay.conf                   (family evpn signaling)
  *
  * JVD service mapping:

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-floating-pw.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l2circuit-floating-pw.conf
@@ -33,9 +33,6 @@
  *  - junos/interfaces/pseudowire-subscriber.conf  (the ps<N>
  *      logical interface this PW terminates on, via ps<N>.0 with
  *      encapsulation ethernet-ccc)
- *  - evo/interfaces/edge-vlan-normalization.conf  (cross-OS PW
- *      tail on the EVO access node, where the PW lands on the
- *      customer-facing vlan-ccc AC unit)
  *
  * JVD service mapping:
  *   20 instances total (high 20 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-bgp.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-bgp.conf
@@ -26,11 +26,9 @@
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/apply-groups/gr-l3vpn.conf
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - junos/services/l3vpn-ospf.conf  (sibling PE-CE peering shape;
  *      same VRF infra, OSPF instead of BGP)
- *  - evo/services/l3vpn-bgp.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   2200 instances total (high 2200 / med 0 / low 0)

--- a/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-ospf.conf
+++ b/service_provider/metro_ethernet_business_services/configuration/snips/junos/services/l3vpn-ospf.conf
@@ -22,11 +22,9 @@
  *  - junos/policy/l3vpn-export-import.conf
  *  - junos/policy/communities.conf
  *  - junos/apply-groups/gr-l3vpn.conf
- *  - junos/services/evpn-elan-mac-vrf-irb.conf
  *  - junos/transport/bgp-overlay.conf  (family inet-vpn signaling)
  *  - junos/services/l3vpn-bgp.conf  (sibling PE-CE peering shape;
  *      same VRF infra, BGP instead of OSPF)
- *  - evo/services/l3vpn-ospf.conf  (cross-OS peer)
  *
  * JVD service mapping:
  *   1100 instances total (high 1100 / med 0 / low 0)


### PR DESCRIPTION
## What's New

Metro EBS's configuration building blocks now show accurate dependencies and correct titles.

- Cleaned up misleading "pair with" links in the **Metro Ethernet Business Services** snip library so the dependency graph reflects real co-configuration requirements, not look-alike associations.
- Fixed a portal bug where a building block that merely *mentioned* an apply-group in its notes could display that apply-group name as its title.

## Why

The snip dependency graph is the foundation of the portal. Metro EBS carried **18 cross-OS** pair-with links (which break the same-OS deployment model) and `l3vpn-export-import` was linked to unrelated L2 services via loose "policy-shape" notes — exactly the kind of misleading association that erodes trust. Separately, the portal's header parser could mistake an indented `apply-group \`X\`` mention in a highlight for the Topic field.

## Changes

- [x] Portal: anchor snip-header section matching to the header's own indent so an indented `apply-group` mention can't be read as the Topic (`generate-snips.mjs`)
- [x] Metro EBS: remove **18 cross-OS** pair-with edges (evo ↔ junos peer links)
- [x] Metro EBS: remove `l3vpn-export-import` over-links to `evpn-fxc` / `evpn-port-based` / `evpn-etree` / `evpn-type5-anchor` (kept the genuine consumers: `l3vpn-bgp/ospf`, `evpn-type5`, `communities`, `gr-l3vpn`)
- [x] Metro EBS: remove 2 broken `junos/l3vpn-{bgp,ospf}` refs to a snip that exists only under `evo/`
- [x] Regenerated Metro EBS BYOAI bundle + portal `snips.json`

## Verified before merge

- [x] Portal builds — `bun run build`
- [x] Snip audit: Metro EBS **18 errors → 0**; misleading warnings **40 → 14** (the 14 remaining are legitimate edges flagged only by sparse Seen-on)
- [x] Generated artifacts regenerated (BYOAI bundle + `snips.json` + Pages mirror)
- [x] No internal-only content in public files; externally-safe wording

## Notes

Snip **bodies are unchanged** (headers/metadata only) — no config-generation impact. Intentionally deferred to a **separate PR**: reconciling the BGP-vs-EVPN-Type-5 export/import policy naming (the ~20 `unresolved-symbol` findings) — a snip-body restructuring that needs per-snip source-config verification.
