### PR TITLE
Pair-with cleanup (srv6/broadband/scale-out) + Seen-on parser fix

### DIFF
--- a/portal/public/byoai/broadband_edge/MANIFEST.json
+++ b/portal/public/byoai/broadband_edge/MANIFEST.json
@@ -208,7 +208,7 @@
         "an4_acx7100-48l",
         "an5_acx7100-48l"
       ],
-      "size_bytes": 1861,
+      "size_bytes": 1814,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-pe-an.conf"
     },
     {
@@ -220,7 +220,7 @@
       "seen_on": [
         "cr1_ptx10004"
       ],
-      "size_bytes": 3681,
+      "size_bytes": 3634,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-core.conf"
     },
     {
@@ -233,7 +233,7 @@
         "agn1_acx7100-32c",
         "agn2_acx7100-32c"
       ],
-      "size_bytes": 3638,
+      "size_bytes": 3550,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-fabric.conf"
     },
     {

--- a/portal/public/byoai/broadband_edge/jvd-bbe-snips.md
+++ b/portal/public/byoai/broadband_edge/jvd-bbe-snips.md
@@ -818,7 +818,6 @@ routing-instances {
  * Pair with:
  *  - evo/services/evpn-vpws-an.conf
  *  - evo/services/evpn-vpws-fxc-an.conf
- *  - evo/transport/bgp-overlay-rr-fabric.conf
  *  - evo/transport/routing-options-pe.conf
  *
  * Variables (example values from an1_acx7024):
@@ -889,7 +888,6 @@ protocols {
  * Pair with:
  *  - evo/policy/bgp-rr-export.conf
  *  - evo/services/l3vpn-internet.conf
- *  - evo/transport/bgp-overlay-rr-fabric.conf
  *
  * Variables (example values from cr1_ptx10004):
  *   $LOOPBACK_V4   e.g. 192.168.0.11
@@ -1013,8 +1011,6 @@ protocols {
  *  - BFD 100ms x 3.
  *
  * Pair with:
- *  - evo/transport/bgp-overlay-pe-an.conf
- *  - evo/transport/bgp-overlay-rr-core.conf
  *  - evo/policy/bgp-rr-export.conf
  *
  * Variables (example values from agn1_acx7100-32c):

--- a/portal/public/byoai/scale_out_firewall_nat/MANIFEST.json
+++ b/portal/public/byoai/scale_out_firewall_nat/MANIFEST.json
@@ -82,7 +82,7 @@
       "seen_on": [
         "mx1_mx304"
       ],
-      "size_bytes": 2948,
+      "size_bytes": 2859,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/security/scale_out_firewall_nat/configuration/snips/junos/interfaces/mx-ae-uni-flexible.conf"
     },
     {
@@ -232,7 +232,7 @@
       "seen_on": [
         "gateway_emulator_mx304"
       ],
-      "size_bytes": 3489,
+      "size_bytes": 3392,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/security/scale_out_firewall_nat/configuration/snips/junos/transport/gw-emulator-bgp.conf"
     },
     {

--- a/portal/public/byoai/scale_out_firewall_nat/jvd-so-fwnat-snips.md
+++ b/portal/public/byoai/scale_out_firewall_nat/jvd-so-fwnat-snips.md
@@ -487,7 +487,6 @@ interfaces {
  * Pair with:
  *  - junos/firewall/mx-fbf-tlb-redirect.conf — the input filters applied here
  *  - junos/load-balancing/tlb-sfw-dsr.conf — TLB uses lo0.1/lo0.2 as health-check sources
- *  - junos/transport/gw-emulator-bgp.conf — the GW that terminates this north-side AC
  *  - junos/transport/mx-scaleout-export-policies.conf — export policies applied on this UNI's routing instance
  *
  * Variables:
@@ -1217,7 +1216,6 @@ forwarding-options {
  *  - Not a production device — it stands in for the customer CE / upstream router during validation.
  *
  * Pair with:
- *  - junos/interfaces/mx-ae-uni-flexible.conf — the MX north-side AC this emulator peers with
  *
  * JVD peer devices (observed interop):
  *   Junos: mx1_mx304

--- a/portal/public/byoai/srv6_core_edge/MANIFEST.json
+++ b/portal/public/byoai/srv6_core_edge/MANIFEST.json
@@ -111,7 +111,7 @@
         "mse1_mx480",
         "mse2_mx304"
       ],
-      "size_bytes": 2363,
+      "size_bytes": 2300,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/evo/interfaces/cpe-attachment.conf"
     },
     {
@@ -229,7 +229,7 @@
         "mse2_mx304",
         "br1_ptx10002-36qdd"
       ],
-      "size_bytes": 3835,
+      "size_bytes": 3796,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/evo/services/l3vpn-srv6-vrf.conf"
     },
     {
@@ -253,7 +253,7 @@
       "seen_on": [
         "br1_ptx10002-36qdd"
       ],
-      "size_bytes": 3897,
+      "size_bytes": 3858,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/evo/transport/bgp-overlay-rr-client.conf"
     },
     {
@@ -597,7 +597,7 @@
         "cpe2_mx240",
         "cpe4_mx240"
       ],
-      "size_bytes": 3515,
+      "size_bytes": 3309,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/junos/services/cpe-virtual-router.conf"
     },
     {
@@ -627,7 +627,7 @@
         "edge2_mx480",
         "edge3_mx480"
       ],
-      "size_bytes": 2780,
+      "size_bytes": 2707,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/junos/services/l3vpn-evpn-t5-srv6.conf"
     },
     {

--- a/portal/public/byoai/srv6_core_edge/jvd-srv6-snips.md
+++ b/portal/public/byoai/srv6_core_edge/jvd-srv6-snips.md
@@ -414,7 +414,6 @@ interfaces {
  *    service ID — per JVD convention.
  *
  * Pair with:
- *  - evo/services/evpn-vpws-srv6.conf  (consumes the AC unit)
  *  - evo/interfaces/pe-ce-direct.conf    (consumes the L3 sub-IFL)
  *  - evo/interfaces/pe-ce-irb.conf       (consumes the bridge AC)
  *
@@ -857,7 +856,6 @@ policy-options {
  *    bridge-domain stitched to L3 (see pe-ce-irb.conf).
  *
  * Pair with:
- *  - evo/services/evpn-vpws-srv6.conf
  *  - evo/transport/bgp-overlay-rr-client.conf
  *  - evo/apply-groups/gr-l3vpn.conf           (provides defaults)
  *  - evo/interfaces/pe-ce-direct.conf           (xe-*.<unit> attachment)
@@ -1007,7 +1005,6 @@ protocols {
  *
  * Pair with:
  *  - evo/policy/srv6-redistribution-policy.conf
- *  - evo/services/evpn-vpws-srv6.conf
  *  - evo/apply-groups/gr-bgp.conf            (TCP-AO, multipath, MSS)
  *  - evo/transport/bgp-overlay-rr.conf       (RR-side counterpart)
  *  - evo/services/l3vpn-srv6-vrf.conf        (per-VRF locator overrides)
@@ -2574,9 +2571,6 @@ policy-options {
  *  - cpe4 peers with MSE PEs (groups TO-MSE1, TO-MSE2).
  *
  * Pair with:
- *  - junos/services/l3vpn-srv6-vrf.conf       (PE-side VRF counterpart)
- *  - junos/services/l3vpn-evpn-t5-srv6.conf   (PE-side EVPN-T5 VRF)
- *  - junos/interfaces/cpe-attachment.conf     (physical trunk)
  *
  * JVD service mapping:
  *   1012 instances on cpe2_mx240, 12 on cpe4_mx240.
@@ -2747,7 +2741,6 @@ routing-instances {
  *
  * Pair with:
  *  - junos/services/l3vpn-srv6-vrf.conf       (PE-CE BGP alternative)
- *  - junos/services/cpe-virtual-router.conf   (CPE-side VR counterpart)
  *  - junos/interfaces/pe-ce-direct.conf       (CE-facing IFL)
  *  - junos/apply-groups/gr-l3vpn.conf         (provides defaults)
  *  - junos/transport/bgp-overlay-rr-client.conf

--- a/portal/scripts/generate-snips.mjs
+++ b/portal/scripts/generate-snips.mjs
@@ -174,10 +174,17 @@ function parseSnip(text) {
         // Also skip bare prose tokens like "—" used as a placeholder for
         // "not applicable".
         for (const tok of so[2].split(/\s+/).filter(Boolean)) {
-          if (tok.startsWith("(")) break;
+          if (tok.startsWith("(")) {
+            // A self-contained parenthetical like "(ACX7100-32C)" is a
+            // per-device platform annotation (MaaS-style Seen on:) — skip it
+            // and keep reading devices. One that doesn't close on this token
+            // begins a prose note like "(none in this JVD ...)" — stop there.
+            if (/\)[,;]?$/.test(tok)) continue;
+            break;
+          }
           // A real device token must start with a letter or digit.
           if (!/^[A-Za-z0-9]/.test(tok)) continue;
-          seenOn[bucket].push(tok);
+          seenOn[bucket].push(tok.replace(/[,;]+$/, ""));
         }
       }
       continue;

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T02:48:25.756Z",
+  "generatedAt": "2026-08-04T02:50:24.238Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -19181,11 +19181,6 @@
           "note": "— TLB uses lo0.1/lo0.2 as health-check sources"
         },
         {
-          "raw": "junos/transport/gw-emulator-bgp.conf — the GW that terminates this north-side AC",
-          "id": "scale_out_firewall_nat/junos/transport/gw-emulator-bgp",
-          "note": "— the GW that terminates this north-side AC"
-        },
-        {
           "raw": "junos/transport/mx-scaleout-export-policies.conf — export policies applied on this UNI's routing instance",
           "id": "scale_out_firewall_nat/junos/transport/mx-scaleout-export-policies",
           "note": "— export policies applied on this UNI's routing instance"
@@ -19998,13 +19993,7 @@
         "UNTRUST_VR statically discards a default and eBGPs it to the MX UNTRUST plane, emulating the internet-facing side.",
         "Not a production device — it stands in for the customer CE / upstream router during validation."
       ],
-      "pairWith": [
-        {
-          "raw": "junos/interfaces/mx-ae-uni-flexible.conf — the MX north-side AC this emulator peers with",
-          "id": "scale_out_firewall_nat/junos/interfaces/mx-ae-uni-flexible",
-          "note": "— the MX north-side AC this emulator peers with"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$GW_TRUST_AS",

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T02:34:03.953Z",
+  "generatedAt": "2026-08-04T02:46:52.193Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -45964,11 +45964,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/services/evpn-vpws-srv6.conf  (consumes the AC unit)",
-          "id": null,
-          "note": "consumes the AC unit"
-        },
-        {
           "raw": "evo/interfaces/pe-ce-direct.conf    (consumes the L3 sub-IFL)",
           "id": "srv6_core_edge/evo/interfaces/pe-ce-direct",
           "note": "consumes the L3 sub-IFL"
@@ -46506,11 +46501,6 @@
       ],
       "pairWith": [
         {
-          "raw": "evo/services/evpn-vpws-srv6.conf",
-          "id": null,
-          "note": null
-        },
-        {
           "raw": "evo/transport/bgp-overlay-rr-client.conf",
           "id": "srv6_core_edge/evo/transport/bgp-overlay-rr-client",
           "note": null
@@ -46707,11 +46697,6 @@
         {
           "raw": "evo/policy/srv6-redistribution-policy.conf",
           "id": "srv6_core_edge/evo/policy/srv6-redistribution-policy",
-          "note": null
-        },
-        {
-          "raw": "evo/services/evpn-vpws-srv6.conf",
-          "id": null,
           "note": null
         },
         {
@@ -48368,23 +48353,7 @@
         "Appears in two flavors: • Multi-homed (cpe2): 2 BGP groups (TO-AN2, TO-AN3) toward two edge PEs. • Single-homed EVPN-T5 variant (cpe2): 1 BGP group (TO-AN3) toward one PE — the PE originates EVPN Type-5 for these prefixes (see l3vpn-evpn-t5-srv6.conf).",
         "cpe4 peers with MSE PEs (groups TO-MSE1, TO-MSE2)."
       ],
-      "pairWith": [
-        {
-          "raw": "junos/services/l3vpn-srv6-vrf.conf       (PE-side VRF counterpart)",
-          "id": "srv6_core_edge/junos/services/l3vpn-srv6-vrf",
-          "note": "PE-side VRF counterpart"
-        },
-        {
-          "raw": "junos/services/l3vpn-evpn-t5-srv6.conf   (PE-side EVPN-T5 VRF)",
-          "id": "srv6_core_edge/junos/services/l3vpn-evpn-t5-srv6",
-          "note": "PE-side EVPN-T5 VRF"
-        },
-        {
-          "raw": "junos/interfaces/cpe-attachment.conf     (physical trunk)",
-          "id": "srv6_core_edge/junos/interfaces/cpe-attachment",
-          "note": "physical trunk"
-        }
-      ],
+      "pairWith": [],
       "variables": [
         {
           "name": "$VR_NAME",
@@ -48591,11 +48560,6 @@
           "raw": "junos/services/l3vpn-srv6-vrf.conf       (PE-CE BGP alternative)",
           "id": "srv6_core_edge/junos/services/l3vpn-srv6-vrf",
           "note": "PE-CE BGP alternative"
-        },
-        {
-          "raw": "junos/services/cpe-virtual-router.conf   (CPE-side VR counterpart)",
-          "id": "srv6_core_edge/junos/services/cpe-virtual-router",
-          "note": "CPE-side VR counterpart"
         },
         {
           "raw": "junos/interfaces/pe-ce-direct.conf       (CE-facing IFL)",

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T02:50:24.238Z",
+  "generatedAt": "2026-08-04T02:54:53.518Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -30196,7 +30196,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30233,7 +30239,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30270,7 +30282,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30333,7 +30351,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30396,7 +30420,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30433,7 +30463,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30471,7 +30507,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30509,7 +30551,13 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "AN3",
+          "MA1.2",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30546,7 +30594,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -30592,7 +30641,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA1.1"
+          "MA1.1",
+          "AN3"
         ]
       },
       "highlights": [
@@ -30637,7 +30687,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA3"
+          "MA3",
+          "MEG1",
+          "MEG2",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -30682,7 +30735,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -30728,7 +30782,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -30772,7 +30827,12 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG2",
+          "MEG1",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -30893,7 +30953,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -31037,7 +31098,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -31109,7 +31171,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -31425,7 +31488,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -31510,7 +31574,12 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2",
+          "AN3",
+          "MEG1",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -31672,7 +31741,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG2"
+          "MEG2",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -32268,7 +32338,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -32333,7 +32406,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -32560,7 +32634,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA1.2"
+          "MA1.2",
+          "AN3"
         ]
       },
       "highlights": [
@@ -32734,7 +32809,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -32824,7 +32902,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MA1.1"
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -32913,7 +32992,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -33159,7 +33241,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -33368,7 +33451,9 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -33426,7 +33511,11 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG2",
+          "MA1.2",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -33477,7 +33566,9 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -33634,7 +33725,9 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG2",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -33843,7 +33936,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -33942,7 +34036,11 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG1",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -34032,7 +34130,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -34271,7 +34370,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN2"
+          "AN2",
+          "AN3",
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -34365,7 +34467,9 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -34468,7 +34572,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -34562,7 +34669,10 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -34971,7 +35081,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.1"
         ]
       },
       "highlights": [
@@ -35073,7 +35184,9 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MA1.1",
+          "MA1.2"
         ]
       },
       "highlights": [
@@ -35189,7 +35302,9 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "AN3"
+          "AN3",
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -35493,7 +35608,8 @@
       "seenOn": {
         "junos": [],
         "evo": [
-          "MEG1"
+          "MEG1",
+          "MEG2"
         ]
       },
       "highlights": [
@@ -35911,7 +36027,13 @@
       "topic": "Class-of-service: classifiers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "AN1",
+          "AN2",
+          "AN4",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -35948,7 +36070,13 @@
       "topic": "Class-of-service: cos binding ieee8021p (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "AN1",
+          "AN2",
+          "AN4",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36016,7 +36144,13 @@
       "topic": "Class-of-service: cos binding mpls (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "AN1",
+          "AN2",
+          "AN4",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36084,7 +36218,13 @@
       "topic": "Class-of-service: forwarding classes (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "AN1",
+          "AN2",
+          "AN4",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36121,7 +36261,13 @@
       "topic": "Class-of-service: rewrite rules (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "AN1",
+          "AN2",
+          "AN4",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36159,7 +36305,13 @@
       "topic": "Class-of-service: scheduler map (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "AN1",
+          "AN2",
+          "AN4",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36250,7 +36402,8 @@
       "topic": "Class-of-service: schedulers legacy acx (MEF E-LAN / EVP-LAN, E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "AN2"
+          "AN2",
+          "AN4"
         ],
         "evo": []
       },
@@ -36287,7 +36440,10 @@
       "topic": "Class-of-service: schedulers (MEF E-Access, E-LAN / EP-LAN, E-LAN / EVP-LAN, E-Line / EPL, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA5"
+          "MA5",
+          "MSE1",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36462,7 +36618,10 @@
       "topic": "Firewall: filter bridge color blind (MEF E-LAN / EVP-LAN, E-Line / EVPL, E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "AN1",
+          "MSE2",
+          "MA4"
         ],
         "evo": []
       },
@@ -36689,7 +36848,8 @@
       "topic": "Firewall: filter ccc color blind (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "AN1"
         ],
         "evo": []
       },
@@ -36973,7 +37133,8 @@
       "topic": "Interface: pseudowire subscriber (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2"
         ],
         "evo": []
       },
@@ -37043,7 +37204,8 @@
       "topic": "Interface: vlan bridge esi etree root (MEF E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2"
         ],
         "evo": []
       },
@@ -37200,7 +37362,8 @@
       "topic": "Interface: vlan bridge esi (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2"
         ],
         "evo": []
       },
@@ -37357,7 +37520,8 @@
       "topic": "Interface: vlan bridge etree leaf (MEF E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MA4"
+          "MA4",
+          "MA5"
         ],
         "evo": []
       },
@@ -37437,7 +37601,13 @@
       "topic": "Interface: vlan bridge etree root (MEF E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2",
+          "variant",
+          "of",
+          "the",
+          "MH",
+          "root]"
         ],
         "evo": []
       },
@@ -38099,7 +38269,8 @@
       "topic": "Interface: vlan ccc vlan map esi (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "AN1"
+          "AN1",
+          "AN2"
         ],
         "evo": []
       },
@@ -38375,7 +38546,10 @@
       "topic": "Policy: policy vpn rt export gold (MEF E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2",
+          "MA4",
+          "MA5"
         ],
         "evo": []
       },
@@ -38925,7 +39099,8 @@
       "topic": "Service instance: evpn elan vlan based floating pw (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2"
         ],
         "evo": []
       },
@@ -39215,7 +39390,10 @@
       "topic": "Service instance: evpn etree vlan based (MEF E-Tree / EVP-Tree)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2",
+          "MA4",
+          "MA5"
         ],
         "evo": []
       },
@@ -39497,7 +39675,9 @@
       "topic": "Service instance: evpn vpws vlan based (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "AN1"
+          "AN1",
+          "AN2",
+          "AN4"
         ],
         "evo": []
       },
@@ -39603,7 +39783,8 @@
       "topic": "Service instance: l2circuit floating pw (MEF E-Line / EVPL)",
       "seenOn": {
         "junos": [
-          "MSE1"
+          "MSE1",
+          "MSE2"
         ],
         "evo": []
       },

--- a/portal/src/data/snips.json
+++ b/portal/src/data/snips.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T02:46:52.193Z",
+  "generatedAt": "2026-08-04T02:48:25.756Z",
   "counts": {
     "total": 675,
     "junos": 344,
@@ -22812,11 +22812,6 @@
           "note": null
         },
         {
-          "raw": "evo/transport/bgp-overlay-rr-fabric.conf",
-          "id": "broadband_edge/evo/transport/bgp-overlay-rr-fabric",
-          "note": null
-        },
-        {
           "raw": "evo/transport/routing-options-pe.conf",
           "id": "broadband_edge/evo/transport/routing-options-pe",
           "note": null
@@ -22885,11 +22880,6 @@
         {
           "raw": "evo/services/l3vpn-internet.conf",
           "id": "broadband_edge/evo/services/l3vpn-internet",
-          "note": null
-        },
-        {
-          "raw": "evo/transport/bgp-overlay-rr-fabric.conf",
-          "id": "broadband_edge/evo/transport/bgp-overlay-rr-fabric",
           "note": null
         }
       ],
@@ -22966,16 +22956,6 @@
         "BFD 100ms x 3."
       ],
       "pairWith": [
-        {
-          "raw": "evo/transport/bgp-overlay-pe-an.conf",
-          "id": "broadband_edge/evo/transport/bgp-overlay-pe-an",
-          "note": null
-        },
-        {
-          "raw": "evo/transport/bgp-overlay-rr-core.conf",
-          "id": "broadband_edge/evo/transport/bgp-overlay-rr-core",
-          "note": null
-        },
         {
           "raw": "evo/policy/bgp-rr-export.conf",
           "id": "broadband_edge/evo/policy/bgp-rr-export",

--- a/security/scale_out_firewall_nat/configuration/snips/byoai/MANIFEST.json
+++ b/security/scale_out_firewall_nat/configuration/snips/byoai/MANIFEST.json
@@ -82,7 +82,7 @@
       "seen_on": [
         "mx1_mx304"
       ],
-      "size_bytes": 2948,
+      "size_bytes": 2859,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/security/scale_out_firewall_nat/configuration/snips/junos/interfaces/mx-ae-uni-flexible.conf"
     },
     {
@@ -232,7 +232,7 @@
       "seen_on": [
         "gateway_emulator_mx304"
       ],
-      "size_bytes": 3489,
+      "size_bytes": 3392,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/security/scale_out_firewall_nat/configuration/snips/junos/transport/gw-emulator-bgp.conf"
     },
     {

--- a/security/scale_out_firewall_nat/configuration/snips/byoai/jvd-so-fwnat-snips.md
+++ b/security/scale_out_firewall_nat/configuration/snips/byoai/jvd-so-fwnat-snips.md
@@ -487,7 +487,6 @@ interfaces {
  * Pair with:
  *  - junos/firewall/mx-fbf-tlb-redirect.conf — the input filters applied here
  *  - junos/load-balancing/tlb-sfw-dsr.conf — TLB uses lo0.1/lo0.2 as health-check sources
- *  - junos/transport/gw-emulator-bgp.conf — the GW that terminates this north-side AC
  *  - junos/transport/mx-scaleout-export-policies.conf — export policies applied on this UNI's routing instance
  *
  * Variables:
@@ -1217,7 +1216,6 @@ forwarding-options {
  *  - Not a production device — it stands in for the customer CE / upstream router during validation.
  *
  * Pair with:
- *  - junos/interfaces/mx-ae-uni-flexible.conf — the MX north-side AC this emulator peers with
  *
  * JVD peer devices (observed interop):
  *   Junos: mx1_mx304

--- a/security/scale_out_firewall_nat/configuration/snips/junos/interfaces/mx-ae-uni-flexible.conf
+++ b/security/scale_out_firewall_nat/configuration/snips/junos/interfaces/mx-ae-uni-flexible.conf
@@ -11,7 +11,6 @@
  * Pair with:
  *  - junos/firewall/mx-fbf-tlb-redirect.conf — the input filters applied here
  *  - junos/load-balancing/tlb-sfw-dsr.conf — TLB uses lo0.1/lo0.2 as health-check sources
- *  - junos/transport/gw-emulator-bgp.conf — the GW that terminates this north-side AC
  *  - junos/transport/mx-scaleout-export-policies.conf — export policies applied on this UNI's routing instance
  *
  * Variables:

--- a/security/scale_out_firewall_nat/configuration/snips/junos/transport/gw-emulator-bgp.conf
+++ b/security/scale_out_firewall_nat/configuration/snips/junos/transport/gw-emulator-bgp.conf
@@ -10,7 +10,6 @@
  *  - Not a production device — it stands in for the customer CE / upstream router during validation.
  *
  * Pair with:
- *  - junos/interfaces/mx-ae-uni-flexible.conf — the MX north-side AC this emulator peers with
  *
  * JVD peer devices (observed interop):
  *   Junos: mx1_mx304

--- a/service_provider/broadband_edge/configuration/snips/byoai/MANIFEST.json
+++ b/service_provider/broadband_edge/configuration/snips/byoai/MANIFEST.json
@@ -208,7 +208,7 @@
         "an4_acx7100-48l",
         "an5_acx7100-48l"
       ],
-      "size_bytes": 1861,
+      "size_bytes": 1814,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-pe-an.conf"
     },
     {
@@ -220,7 +220,7 @@
       "seen_on": [
         "cr1_ptx10004"
       ],
-      "size_bytes": 3681,
+      "size_bytes": 3634,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-core.conf"
     },
     {
@@ -233,7 +233,7 @@
         "agn1_acx7100-32c",
         "agn2_acx7100-32c"
       ],
-      "size_bytes": 3638,
+      "size_bytes": 3550,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-fabric.conf"
     },
     {

--- a/service_provider/broadband_edge/configuration/snips/byoai/jvd-bbe-snips.md
+++ b/service_provider/broadband_edge/configuration/snips/byoai/jvd-bbe-snips.md
@@ -818,7 +818,6 @@ routing-instances {
  * Pair with:
  *  - evo/services/evpn-vpws-an.conf
  *  - evo/services/evpn-vpws-fxc-an.conf
- *  - evo/transport/bgp-overlay-rr-fabric.conf
  *  - evo/transport/routing-options-pe.conf
  *
  * Variables (example values from an1_acx7024):
@@ -889,7 +888,6 @@ protocols {
  * Pair with:
  *  - evo/policy/bgp-rr-export.conf
  *  - evo/services/l3vpn-internet.conf
- *  - evo/transport/bgp-overlay-rr-fabric.conf
  *
  * Variables (example values from cr1_ptx10004):
  *   $LOOPBACK_V4   e.g. 192.168.0.11
@@ -1013,8 +1011,6 @@ protocols {
  *  - BFD 100ms x 3.
  *
  * Pair with:
- *  - evo/transport/bgp-overlay-pe-an.conf
- *  - evo/transport/bgp-overlay-rr-core.conf
  *  - evo/policy/bgp-rr-export.conf
  *
  * Variables (example values from agn1_acx7100-32c):

--- a/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-pe-an.conf
+++ b/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-pe-an.conf
@@ -17,7 +17,6 @@
  * Pair with:
  *  - evo/services/evpn-vpws-an.conf
  *  - evo/services/evpn-vpws-fxc-an.conf
- *  - evo/transport/bgp-overlay-rr-fabric.conf
  *  - evo/transport/routing-options-pe.conf
  *
  * Variables (example values from an1_acx7024):

--- a/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-core.conf
+++ b/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-core.conf
@@ -25,7 +25,6 @@
  * Pair with:
  *  - evo/policy/bgp-rr-export.conf
  *  - evo/services/l3vpn-internet.conf
- *  - evo/transport/bgp-overlay-rr-fabric.conf
  *
  * Variables (example values from cr1_ptx10004):
  *   $LOOPBACK_V4   e.g. 192.168.0.11

--- a/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-fabric.conf
+++ b/service_provider/broadband_edge/configuration/snips/evo/transport/bgp-overlay-rr-fabric.conf
@@ -26,8 +26,6 @@
  *  - BFD 100ms x 3.
  *
  * Pair with:
- *  - evo/transport/bgp-overlay-pe-an.conf
- *  - evo/transport/bgp-overlay-rr-core.conf
  *  - evo/policy/bgp-rr-export.conf
  *
  * Variables (example values from agn1_acx7100-32c):

--- a/service_provider/srv6_core_edge/configuration/snips/byoai/MANIFEST.json
+++ b/service_provider/srv6_core_edge/configuration/snips/byoai/MANIFEST.json
@@ -111,7 +111,7 @@
         "mse1_mx480",
         "mse2_mx304"
       ],
-      "size_bytes": 2363,
+      "size_bytes": 2300,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/evo/interfaces/cpe-attachment.conf"
     },
     {
@@ -229,7 +229,7 @@
         "mse2_mx304",
         "br1_ptx10002-36qdd"
       ],
-      "size_bytes": 3835,
+      "size_bytes": 3796,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/evo/services/l3vpn-srv6-vrf.conf"
     },
     {
@@ -253,7 +253,7 @@
       "seen_on": [
         "br1_ptx10002-36qdd"
       ],
-      "size_bytes": 3897,
+      "size_bytes": 3858,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/evo/transport/bgp-overlay-rr-client.conf"
     },
     {
@@ -597,7 +597,7 @@
         "cpe2_mx240",
         "cpe4_mx240"
       ],
-      "size_bytes": 3515,
+      "size_bytes": 3309,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/junos/services/cpe-virtual-router.conf"
     },
     {
@@ -627,7 +627,7 @@
         "edge2_mx480",
         "edge3_mx480"
       ],
-      "size_bytes": 2780,
+      "size_bytes": 2707,
       "raw_url": "https://raw.githubusercontent.com/Juniper/jvd/main/service_provider/srv6_core_edge/configuration/snips/junos/services/l3vpn-evpn-t5-srv6.conf"
     },
     {

--- a/service_provider/srv6_core_edge/configuration/snips/byoai/jvd-srv6-snips.md
+++ b/service_provider/srv6_core_edge/configuration/snips/byoai/jvd-srv6-snips.md
@@ -414,7 +414,6 @@ interfaces {
  *    service ID — per JVD convention.
  *
  * Pair with:
- *  - evo/services/evpn-vpws-srv6.conf  (consumes the AC unit)
  *  - evo/interfaces/pe-ce-direct.conf    (consumes the L3 sub-IFL)
  *  - evo/interfaces/pe-ce-irb.conf       (consumes the bridge AC)
  *
@@ -857,7 +856,6 @@ policy-options {
  *    bridge-domain stitched to L3 (see pe-ce-irb.conf).
  *
  * Pair with:
- *  - evo/services/evpn-vpws-srv6.conf
  *  - evo/transport/bgp-overlay-rr-client.conf
  *  - evo/apply-groups/gr-l3vpn.conf           (provides defaults)
  *  - evo/interfaces/pe-ce-direct.conf           (xe-*.<unit> attachment)
@@ -1007,7 +1005,6 @@ protocols {
  *
  * Pair with:
  *  - evo/policy/srv6-redistribution-policy.conf
- *  - evo/services/evpn-vpws-srv6.conf
  *  - evo/apply-groups/gr-bgp.conf            (TCP-AO, multipath, MSS)
  *  - evo/transport/bgp-overlay-rr.conf       (RR-side counterpart)
  *  - evo/services/l3vpn-srv6-vrf.conf        (per-VRF locator overrides)
@@ -2574,9 +2571,6 @@ policy-options {
  *  - cpe4 peers with MSE PEs (groups TO-MSE1, TO-MSE2).
  *
  * Pair with:
- *  - junos/services/l3vpn-srv6-vrf.conf       (PE-side VRF counterpart)
- *  - junos/services/l3vpn-evpn-t5-srv6.conf   (PE-side EVPN-T5 VRF)
- *  - junos/interfaces/cpe-attachment.conf     (physical trunk)
  *
  * JVD service mapping:
  *   1012 instances on cpe2_mx240, 12 on cpe4_mx240.
@@ -2747,7 +2741,6 @@ routing-instances {
  *
  * Pair with:
  *  - junos/services/l3vpn-srv6-vrf.conf       (PE-CE BGP alternative)
- *  - junos/services/cpe-virtual-router.conf   (CPE-side VR counterpart)
  *  - junos/interfaces/pe-ce-direct.conf       (CE-facing IFL)
  *  - junos/apply-groups/gr-l3vpn.conf         (provides defaults)
  *  - junos/transport/bgp-overlay-rr-client.conf

--- a/service_provider/srv6_core_edge/configuration/snips/evo/interfaces/cpe-attachment.conf
+++ b/service_provider/srv6_core_edge/configuration/snips/evo/interfaces/cpe-attachment.conf
@@ -18,7 +18,6 @@
  *    service ID — per JVD convention.
  *
  * Pair with:
- *  - evo/services/evpn-vpws-srv6.conf  (consumes the AC unit)
  *  - evo/interfaces/pe-ce-direct.conf    (consumes the L3 sub-IFL)
  *  - evo/interfaces/pe-ce-irb.conf       (consumes the bridge AC)
  *

--- a/service_provider/srv6_core_edge/configuration/snips/evo/services/l3vpn-srv6-vrf.conf
+++ b/service_provider/srv6_core_edge/configuration/snips/evo/services/l3vpn-srv6-vrf.conf
@@ -26,7 +26,6 @@
  *    bridge-domain stitched to L3 (see pe-ce-irb.conf).
  *
  * Pair with:
- *  - evo/services/evpn-vpws-srv6.conf
  *  - evo/transport/bgp-overlay-rr-client.conf
  *  - evo/apply-groups/gr-l3vpn.conf           (provides defaults)
  *  - evo/interfaces/pe-ce-direct.conf           (xe-*.<unit> attachment)

--- a/service_provider/srv6_core_edge/configuration/snips/evo/transport/bgp-overlay-rr-client.conf
+++ b/service_provider/srv6_core_edge/configuration/snips/evo/transport/bgp-overlay-rr-client.conf
@@ -30,7 +30,6 @@
  *
  * Pair with:
  *  - evo/policy/srv6-redistribution-policy.conf
- *  - evo/services/evpn-vpws-srv6.conf
  *  - evo/apply-groups/gr-bgp.conf            (TCP-AO, multipath, MSS)
  *  - evo/transport/bgp-overlay-rr.conf       (RR-side counterpart)
  *  - evo/services/l3vpn-srv6-vrf.conf        (per-VRF locator overrides)

--- a/service_provider/srv6_core_edge/configuration/snips/junos/services/cpe-virtual-router.conf
+++ b/service_provider/srv6_core_edge/configuration/snips/junos/services/cpe-virtual-router.conf
@@ -21,9 +21,6 @@
  *  - cpe4 peers with MSE PEs (groups TO-MSE1, TO-MSE2).
  *
  * Pair with:
- *  - junos/services/l3vpn-srv6-vrf.conf       (PE-side VRF counterpart)
- *  - junos/services/l3vpn-evpn-t5-srv6.conf   (PE-side EVPN-T5 VRF)
- *  - junos/interfaces/cpe-attachment.conf     (physical trunk)
  *
  * JVD service mapping:
  *   1012 instances on cpe2_mx240, 12 on cpe4_mx240.

--- a/service_provider/srv6_core_edge/configuration/snips/junos/services/l3vpn-evpn-t5-srv6.conf
+++ b/service_provider/srv6_core_edge/configuration/snips/junos/services/l3vpn-evpn-t5-srv6.conf
@@ -24,7 +24,6 @@
  *
  * Pair with:
  *  - junos/services/l3vpn-srv6-vrf.conf       (PE-CE BGP alternative)
- *  - junos/services/cpe-virtual-router.conf   (CPE-side VR counterpart)
  *  - junos/interfaces/pe-ce-direct.conf       (CE-facing IFL)
  *  - junos/apply-groups/gr-l3vpn.conf         (provides defaults)
  *  - junos/transport/bgp-overlay-rr-client.conf


### PR DESCRIPTION
## What's New

Removes **cross-device relationships** that were miscategorized as same-device `Pair with:` dependencies, across three more designs — keeping the snip dependency graph a true same-device deploy graph.

## Why

`Pair with:` = same-device dependency. Cross-device relationships (BGP peering, client↔server, CPE↔PE, MX↔emulator) are real but belong in **service mapping**, not pair-with — otherwise automation walking the graph would try to co-deploy both ends of a cross-device relationship on one box.

## Changes

- [x] **srv6_core_edge** — removed cross-device `cpe-virtual-router` (CPE nodes) ↔ PE-side VRF/attachment edges; removed 3 broken refs to `evo/services/evpn-vpws-srv6.conf` (a snip that was never extracted)
- [x] **broadband_edge** — removed 4 BGP route-reflector *peering* edges (AN↔AGN client-RR, CR↔AGN RR-to-RR); kept the same-device service↔overlay pairs
- [x] **scale_out_firewall_nat** — removed the MX↔gateway-emulator eBGP edge (a separate emulator node — already documented in the snip's own "JVD peer devices" block)
- [x] Reviewed **ewan_adv_core_edge** + **low_latency_queueing** — their warnings are legit same-device edges (hash↔SR-LFA; iBGP↔ISIS), left as-is
- [x] **Portal Seen-on parser fix** — the parser broke at the first `(`, so MaaS-style per-device platform annotations (`MEG1 (ACX7100-32C), MEG2 (ACX7509)`) dropped every device after the first (e.g. `l2circuit-hsb-pe` showed only MEG1). Now handles both formats; recovers dropped devices on **63 MaaS snips**.
- [x] Regenerated affected BYOAI bundles + portal `snips.json`

## Verified before merge

- [x] Portal builds — `bun run build`
- [x] Audit warnings: srv6 **8→1**, broadband **6→2**, scale_out **2→0** (residuals are legit same-device edges flagged only by sparse Seen-on)
- [x] Generated artifacts regenerated (BYOAI + `snips.json` + mirror)
- [x] Kept same-device service↔overlay pairs (issue #3)

## Notes

Same-device optional add-ons (category C) left as `Pair with:` pending the `Augments with:` schema pass (tracked). Coverage gap noted for a follow-up: srv6 EVPN-VPWS is deployed but has no extracted snip.
