### PR TITLE
feat(portal): UX refresh — premium look, clearer journey, ask-a-question BYOAI

### DIFF
--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -21,24 +21,32 @@ type JvdEntry = {
   area: string;
 };
 
-function buildBootstrapMessage(promptUrl: string): string {
-  return (
+type ByoaiMode = "" | "learn" | "configure";
+
+function buildBootstrapMessage(promptUrl: string, mode: ByoaiMode, question: string): string {
+  let msg =
     "Please fetch this URL and use its contents as task instructions for our " +
     "conversation — it is a public, user-authored guide that tells you how to " +
     "help me generate Juniper network configuration from a published library " +
     "of validated config snippets. After fetching, follow its instructions to " +
-    `greet me. URL: ${promptUrl}`
-  );
+    `greet me. URL: ${promptUrl}`;
+  // Optional mode hint maps to the prompt's built-in modes (portal labels the
+  // "Design" mode "Learn & Design" for users; the keyword stays for the prompt).
+  if (mode === "learn")
+    msg += " Begin in Design mode — help me learn and reason about this JVD.";
+  else if (mode === "configure")
+    msg += " Begin in Configuration mode — help me build config.";
+  const q = question.trim();
+  if (q) msg += ` My first question: ${q}`;
+  return msg;
 }
 
-function buildClaudeUrl(promptUrl: string): string {
-  const msg = buildBootstrapMessage(promptUrl);
-  return `https://claude.ai/new?q=${encodeURIComponent(msg)}`;
+function buildClaudeUrl(promptUrl: string, mode: ByoaiMode, question: string): string {
+  return `https://claude.ai/new?q=${encodeURIComponent(buildBootstrapMessage(promptUrl, mode, question))}`;
 }
 
-function buildChatGptUrl(promptUrl: string): string {
-  const msg = buildBootstrapMessage(promptUrl);
-  return `https://chatgpt.com/?q=${encodeURIComponent(msg)}`;
+function buildChatGptUrl(promptUrl: string, mode: ByoaiMode, question: string): string {
+  return `https://chatgpt.com/?q=${encodeURIComponent(buildBootstrapMessage(promptUrl, mode, question))}`;
 }
 
 // VS Code + Copilot: install the JVD's .prompt.md as a reusable /slash-command.
@@ -101,6 +109,9 @@ export default function ByoaiSection() {
 
   const [selectedId, setSelectedId] = useState<string>(() => pickDefaultJvd(pickerItems));
   const selected = pickerItems.find((p) => p.id === selectedId) ?? pickerItems[0];
+  const [mode, setMode] = useState<ByoaiMode>("");
+  const [question, setQuestion] = useState("");
+  const hasQuestion = question.trim().length > 0;
 
   // Deep link: "#byoai?jvd=<id>" from the Catalog pre-selects that JVD here.
   useEffect(() => {
@@ -117,8 +128,8 @@ export default function ByoaiSection() {
     return () => window.removeEventListener("hashchange", applyHash);
   }, [pickerItems]);
 
-  const claudeUrl = selected ? buildClaudeUrl(selected.promptUrl) : "#";
-  const chatGptUrl = selected ? buildChatGptUrl(selected.promptUrl) : "#";
+  const claudeUrl = selected ? buildClaudeUrl(selected.promptUrl, mode, question) : "#";
+  const chatGptUrl = selected ? buildChatGptUrl(selected.promptUrl, mode, question) : "#";
   const vscodeUrl = selected?.vscodePromptUrl
     ? buildVscodeInstallUrl(selected.vscodePromptUrl)
     : "#";
@@ -149,8 +160,8 @@ export default function ByoaiSection() {
             <p className="mt-3 max-w-2xl text-sm text-muted-foreground">
               <span className="font-medium text-foreground">Bring Your Own AI (BYOAI)</span> launches
               a JVD-aware assistant in Claude, ChatGPT, or VS Code. Using complete JVD
-              documentation and validated config snippet libraries, it supports Design
-              and Configuration modes to answer architecture, scale, and design questions,
+              documentation and validated config snippet libraries, it supports Learn &amp; Design
+              and Configure modes to answer architecture, scale, and design questions,
               cite its sources, and guide conversation-driven configuration builds.
             </p>
           </div>
@@ -206,12 +217,34 @@ export default function ByoaiSection() {
               </>
             )}
 
-            <div className="mt-6 flex items-start gap-2 rounded-md border border-border bg-background p-3 text-[11px] text-muted-foreground">
-              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
-              <span>
-                Both providers accept a query-param to pre-fill the chat. The assistant fetches the
-                public BYOAI prompt at launch and adopts it as task instructions.
-              </span>
+            {/* Optional: ask a question up front + pick a mode (both blank by default) */}
+            <div className="mt-6 rounded-lg border border-primary/25 bg-primary/5 p-4">
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                Ask your AI — optional
+              </div>
+              <select
+                value={mode}
+                onChange={(e) => setMode(e.target.value as ByoaiMode)}
+                aria-label="Assistant mode"
+                className="mt-2 h-10 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground focus:border-primary/60 focus:outline-none"
+              >
+                <option value="">Any mode — let the assistant guide me</option>
+                <option value="learn">Learn &amp; Design</option>
+                <option value="configure">Configure</option>
+              </select>
+              <textarea
+                value={question}
+                onChange={(e) => setQuestion(e.target.value)}
+                rows={2}
+                placeholder="Pick a JVD and launch — or ask a question…"
+                aria-label="Question for the assistant"
+                className="search-accent mt-2 w-full resize-none rounded-md border px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <p className="mt-2 text-xs text-muted-foreground">
+                {hasQuestion
+                  ? "Your question launches with the JVD prompt in Claude or ChatGPT. VS Code install can’t carry a question."
+                  : "Optionally send a question with the JVD prompt to Claude or ChatGPT."}
+              </p>
             </div>
 
             {/* Help / troubleshooting — discoverable entry point */}
@@ -285,42 +318,51 @@ export default function ByoaiSection() {
                 description="GitHub Copilot Chat. Installs the JVD prompt as a reusable /slash-command — no copy-paste, kept for every future session."
                 tip={`Tip: after installing, run it with ${vscodeCmd} in Copilot Chat.`}
                 href={vscodeUrl}
-                disabled={!selected?.vscodePromptUrl}
-                disabledLabel="Coming soon"
+                disabled={!selected?.vscodePromptUrl || hasQuestion}
+                disabledLabel={hasQuestion ? "Ask via Claude or ChatGPT" : "Coming soon"}
                 onLaunch={() => track(`byoai-launch-vscode-${selected?.id ?? "none"}`)}
                 logo={<VsCodeLogo />}
                 accentClass="hover:border-[#0098ff]/60"
               />
             </div>
 
-            <div className="mt-4 space-y-2 text-[11px] text-muted-foreground">
-              <p>
-                <strong className="font-semibold text-foreground/80">Requires web access:</strong>{" "}
-                the AI must be able to fetch a URL to load the prompt. Most current tiers —
-                including many free ones — can; a few will decline. If yours can&apos;t, attach the
-                prompt instead. See{" "}
-                <a href={GUIDE_URL} target="_blank" rel="noreferrer" className="underline hover:text-primary">
-                  what&apos;s tested &amp; working
-                </a>
-                .
-              </p>
-              <p>
-                <strong className="font-semibold text-foreground/80">Note:</strong> Gemini doesn&apos;t
-                currently support pre-filled prompts via URL; it&apos;s omitted here. The same BYOAI
-                prompt works on Gemini if pasted manually.
-              </p>
-              <p>
-                <strong className="font-semibold text-foreground/80">VS Code:</strong> requires VS Code
-                with a GitHub Copilot subscription. The button installs the prompt (it doesn&apos;t
-                pre-fill the chat) — run it with{" "}
-                <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[10px]">{vscodeCmd}</code>.
-                It runs in read-only <em>ask</em> mode. After you approve VS Code&apos;s prompt, it asks for a
-                destination — pick a location outside your repo (the default is the open project&apos;s{" "}
-                <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[10px]">.github/prompts/</code>).
-                Using Insiders? Swap the scheme to{" "}
-                <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-[10px]">vscode-insiders:</code>.
-              </p>
-            </div>
+            <details className="mt-6 rounded-lg border border-border bg-surface p-4">
+              <summary className="cursor-pointer select-none text-sm font-medium text-foreground">
+                BYOAI — frequently asked questions
+              </summary>
+              <div className="mt-3 space-y-3 text-sm leading-relaxed text-muted-foreground">
+                <div>
+                  <div className="font-medium text-foreground">Does my AI need web access?</div>
+                  <p className="mt-1">
+                    Yes — it must fetch a URL to load the prompt. Most current tiers, including many
+                    free ones, can; a few will decline. If yours can’t, download the prompt (left) and
+                    paste it in. See{" "}
+                    <a href={GUIDE_URL} target="_blank" rel="noreferrer" className="text-primary hover:underline">
+                      what’s tested &amp; working
+                    </a>
+                    .
+                  </p>
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">What about Gemini?</div>
+                  <p className="mt-1">
+                    Gemini doesn’t currently support pre-filled prompts via URL, so it’s omitted from
+                    the launch tiles. The same BYOAI prompt works on Gemini if you paste it manually.
+                  </p>
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">How does the VS Code option work?</div>
+                  <p className="mt-1">
+                    It requires VS Code with a GitHub Copilot subscription. The button installs the
+                    prompt as a reusable{" "}
+                    <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">{vscodeCmd}</code>{" "}
+                    slash-command (it doesn’t pre-fill the chat) and runs read-only. After you approve
+                    it, pick a destination outside your repo. Using Insiders? Swap the scheme to{" "}
+                    <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">vscode-insiders:</code>.
+                  </p>
+                </div>
+              </div>
+            </details>
           </div>
         </div>
       </div>

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -131,7 +131,7 @@ export default function ByoaiSection() {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-              Stage 3 · Design
+              Stage 3 · Learn & Design
             </div>
             <div className="mt-1 flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-primary" />

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -85,6 +85,28 @@ function pickDefaultJvd(items: { id: string }[]): string {
   return items[items.length - 1].id;
 }
 
+// Example questions shown when the Ask field is focused. Reshuffled each time and
+// lightly personalized with the selected JVD's name.
+const QUESTION_TEMPLATES = [
+  "Walk me through the {jvd} architecture.",
+  "How do I scale {jvd} for a larger deployment?",
+  "What platforms and device roles does {jvd} use?",
+  "Generate a starter configuration for {jvd}.",
+  "What are the key design decisions behind {jvd}?",
+  "How does {jvd} handle redundancy and failover?",
+  "What should I watch out for when deploying {jvd}?",
+  "Which services does {jvd} support?",
+];
+
+function shuffledSuggestions(jvdName: string, n = 3): string[] {
+  const pool = [...QUESTION_TEMPLATES];
+  for (let i = pool.length - 1; i > 0; i--) {
+    const k = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[k]] = [pool[k], pool[i]];
+  }
+  return pool.slice(0, n).map((t) => t.replace(/\{jvd\}/g, jvdName || "this JVD"));
+}
+
 export default function ByoaiSection() {
   const allJvds = jvds as JvdEntry[];
   const byoaiJvds = snipBundle.byoaiJvds || [];
@@ -112,6 +134,8 @@ export default function ByoaiSection() {
   const [mode, setMode] = useState<ByoaiMode>("");
   const [question, setQuestion] = useState("");
   const hasQuestion = question.trim().length > 0;
+  const [showSuggest, setShowSuggest] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
 
   // Deep link: "#byoai?jvd=<id>" from the Catalog pre-selects that JVD here.
   useEffect(() => {
@@ -235,11 +259,34 @@ export default function ByoaiSection() {
               <textarea
                 value={question}
                 onChange={(e) => setQuestion(e.target.value)}
+                onFocus={() => {
+                  setSuggestions(shuffledSuggestions(selected?.label ?? ""));
+                  setShowSuggest(true);
+                }}
+                onBlur={() => setShowSuggest(false)}
                 rows={2}
                 placeholder="Pick a JVD and launch — or ask a question…"
                 aria-label="Question for the assistant"
                 className="search-accent mt-2 w-full resize-none rounded-md border px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
               />
+              {showSuggest && !hasQuestion && suggestions.length > 0 && (
+                <div className="mt-2 flex flex-col gap-1.5">
+                  {suggestions.map((q) => (
+                    <button
+                      key={q}
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        setQuestion(q);
+                        setShowSuggest(false);
+                      }}
+                      className="rounded-md border border-border bg-background px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground"
+                    >
+                      {q}
+                    </button>
+                  ))}
+                </div>
+              )}
               <p className="mt-2 text-xs text-muted-foreground">
                 {hasQuestion
                   ? "Your question launches with the JVD prompt in Claude or ChatGPT. VS Code install can’t carry a question."
@@ -294,8 +341,8 @@ export default function ByoaiSection() {
             <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <AiTile
                 name="Claude"
-                description="Anthropic's web app. Best for nuanced config refactoring and long, multi-turn JVD walk-throughs."
-                tip="Tip: works with any browsing-capable model."
+                description="Anthropic's Claude — reliable for config and multi-turn design."
+                tip="Works well on Claude Haiku (fast)."
                 href={claudeUrl}
                 disabled={!selected}
                 onLaunch={() => track(`byoai-launch-claude-${selected?.id ?? "none"}`)}
@@ -304,8 +351,8 @@ export default function ByoaiSection() {
               />
               <AiTile
                 name="ChatGPT"
-                description="OpenAI's web app. Wide reach and good for quick, single-shot config snippets."
-                tip="Tip: Instant mode often can't fetch — use a Thinking mode, or attach the prompt."
+                description="OpenAI's ChatGPT — quick, single-shot configs."
+                tip="Try GPT-5.5. If the first fetch fails, just resend."
                 href={chatGptUrl}
                 disabled={!selected}
                 onLaunch={() => track(`byoai-launch-chatgpt-${selected?.id ?? "none"}`)}
@@ -315,8 +362,8 @@ export default function ByoaiSection() {
               <AiTile
                 name="VS Code"
                 launchLabel="Install in VS Code"
-                description="GitHub Copilot Chat. Installs the JVD prompt as a reusable /slash-command — no copy-paste, kept for every future session."
-                tip={`Tip: after installing, run it with ${vscodeCmd} in Copilot Chat.`}
+                description="GitHub Copilot Chat — installs a reusable /slash-command."
+                tip={`Experimental. Run it with ${vscodeCmd} after installing.`}
                 href={vscodeUrl}
                 disabled={!selected?.vscodePromptUrl || hasQuestion}
                 disabledLabel={hasQuestion ? "Ask via Claude or ChatGPT" : "Coming soon"}
@@ -353,12 +400,11 @@ export default function ByoaiSection() {
                 <div>
                   <div className="font-medium text-foreground">How does the VS Code option work?</div>
                   <p className="mt-1">
-                    It requires VS Code with a GitHub Copilot subscription. The button installs the
+                    Experimental — it needs VS Code with GitHub Copilot. The button installs the JVD
                     prompt as a reusable{" "}
                     <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">{vscodeCmd}</code>{" "}
-                    slash-command (it doesn’t pre-fill the chat) and runs read-only. After you approve
-                    it, pick a destination outside your repo. Using Insiders? Swap the scheme to{" "}
-                    <code className="rounded bg-surface-2 px-1 py-0.5 font-mono text-xs">vscode-insiders:</code>.
+                    slash-command (it doesn’t pre-fill the chat); run it after installing. Behavior can
+                    vary by version.
                   </p>
                 </div>
               </div>

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -170,7 +170,7 @@ export default function ByoaiSection() {
             </div>
             <div className="mt-1 flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-primary" />
-              <h2 className="text-3xl font-semibold tracking-tight">Design &amp; Planner</h2>
+              <h2 className="text-3xl font-semibold tracking-tight">JVD AI Assistant</h2>
               <span className="ml-1 inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
                 Available now
               </span>
@@ -182,11 +182,10 @@ export default function ByoaiSection() {
               AI-assisted engineering grounded in validated designs.
             </p>
             <p className="mt-3 max-w-2xl text-sm text-muted-foreground">
-              <span className="font-medium text-foreground">Bring Your Own AI (BYOAI)</span> launches
-              a JVD-aware assistant in Claude, ChatGPT, or VS Code. Using complete JVD
-              documentation and validated config snippet libraries, it supports Learn &amp; Design
-              and Configure modes to answer architecture, scale, and design questions,
-              cite its sources, and guide conversation-driven configuration builds.
+              <span className="font-medium text-foreground">Bring Your Own AI (BYOAI)</span> to
+              launch a JVD-aware assistant in Claude, ChatGPT, or VS Code. Use Learn &amp; Design
+              or Configure mode to explore architecture, evaluate design choices, cite JVD
+              sources, and guide configuration builds.
             </p>
           </div>
         </div>

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -340,8 +340,8 @@ export default function ByoaiSection() {
             <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <AiTile
                 name="Claude"
-                description="Anthropic's Claude — reliable for config and multi-turn design."
-                tip="Works well on Claude Haiku (fast)."
+                description="Launch the selected JVD prompt in Anthropic’s Claude."
+                tip="Haiku is currently a fast, consistent option."
                 href={claudeUrl}
                 disabled={!selected}
                 onLaunch={() => track(`byoai-launch-claude-${selected?.id ?? "none"}`)}
@@ -350,8 +350,8 @@ export default function ByoaiSection() {
               />
               <AiTile
                 name="ChatGPT"
-                description="OpenAI's ChatGPT — quick, single-shot configs."
-                tip="Try GPT-5.5. If the first fetch fails, just resend."
+                description="Launch the selected JVD prompt in OpenAI’s ChatGPT."
+                tip="Fast mode is usually sufficient for most workflows."
                 href={chatGptUrl}
                 disabled={!selected}
                 onLaunch={() => track(`byoai-launch-chatgpt-${selected?.id ?? "none"}`)}

--- a/portal/src/components/CatalogCarousel.tsx
+++ b/portal/src/components/CatalogCarousel.tsx
@@ -42,7 +42,7 @@ export function CatalogCarousel({
     <div className="mt-12 overflow-hidden" ref={emblaRef}>
       <div className="flex">
         {items.map((j, i) => (
-          <div key={`${j.id}-${i}`} className="mr-5 min-w-0 shrink-0 basis-80">
+          <div key={`${j.id}-${i}`} className="mr-5 flex min-w-0 shrink-0 basis-80">
             {renderCard(j, i)}
           </div>
         ))}

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -37,7 +37,7 @@ const NAV = [
   { label: "Home", href: "#home" },
   { label: "Catalog", href: "#catalog" },
   { label: "Explorer", href: "#snips" },
-  { label: "Assistant", href: "#byoai" },
+  { label: "Design", href: "#byoai" },
   { label: "Generator", href: "#generator" },
   { label: "Deploy", href: "#mcp" },
   { label: "Why JVDs", href: "#about" },

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -37,7 +37,7 @@ const NAV = [
   { label: "Home", href: "#home" },
   { label: "Catalog", href: "#catalog" },
   { label: "Explorer", href: "#snips" },
-  { label: "Design", href: "#byoai" },
+  { label: "Assistant", href: "#byoai" },
   { label: "Generator", href: "#generator" },
   { label: "Deploy", href: "#mcp" },
   { label: "Why JVDs", href: "#about" },
@@ -70,22 +70,22 @@ const LADDER = [
   },
   {
     stage: "Learn & Design",
-    title: "Design & Planner",
-    desc: "Ask architecture, scaling, and configuration questions grounded in validated JVD content.",
+    title: "JVD AI Assistant",
+    desc: "Explore architecture and design with AI grounded in complete JVD content.",
     href: "#byoai",
     cta: "Start Designing",
   },
   {
     stage: "Build",
-    title: "Service Config Generator",
-    desc: "Generate downloadable configuration deterministically from JVD building blocks.",
+    title: "Config Generator",
+    desc: "Generate deterministic configuration from validated JVD building blocks.",
     href: "#generator",
     cta: "Build Something",
   },
   {
     stage: "Deploy",
     title: "JVD MCP Server",
-    desc: "Access validated designs from your AI agent and carry grounded configuration into automation.",
+    desc: "Bring validated JVD knowledge and configuration into AI automation.",
     href: "#mcp",
     comingSoon: true,
     cta: "Deploy It!",
@@ -481,7 +481,7 @@ export default function JvdPortal() {
                   key={s.href}
                   href={s.href}
                   className={
-                    "premium-card lift group relative flex flex-col rounded-xl border border-border bg-surface p-5 " +
+                    "premium-card lift glow group relative flex flex-col rounded-xl border border-border bg-surface p-5 " +
                     ((s as any).comingSoon ? "opacity-75 hover:opacity-100" : "")
                   }
                 >
@@ -495,13 +495,13 @@ export default function JvdPortal() {
                       </span>
                     )}
                   </div>
-                  <span className="mt-3 text-base font-bold uppercase tracking-wide text-primary md:text-lg">
+                  <span className="mt-3 text-base font-bold uppercase tracking-wide text-primary">
                     {s.stage}
                   </span>
-                  <div className="mt-2 font-semibold tracking-tight text-foreground">{s.title}</div>
+                  <div className="mt-2 text-[15px] font-semibold tracking-tight text-foreground">{s.title}</div>
                   <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{s.desc}</p>
                   <div className="flex-1" />
-                  <span className="mt-4 inline-flex items-center gap-1.5 text-xs font-semibold text-primary">
+                  <span className="mt-4 inline-flex items-center gap-1.5 text-xs font-semibold text-primary opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
                     {s.cta}
                     <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
                   </span>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -61,13 +61,13 @@ const LADDER = [
     href: "#catalog",
   },
   {
-    stage: "Learn",
+    stage: "Explore",
     title: "Config Explorer",
     desc: "Explore reusable config building blocks traced to their source JVDs.",
     href: "#snips",
   },
   {
-    stage: "Design",
+    stage: "Learn & Design",
     title: "Design & Planner",
     desc: "Ask architecture, scaling, and configuration questions grounded in validated JVD content.",
     href: "#byoai",
@@ -155,7 +155,7 @@ function JvdCard({ j, className = "" }: { j: Jvd; className?: string }) {
   return (
     <article
       className={
-        "group flex flex-col rounded-lg border border-border bg-surface p-6 transition-colors hover:border-primary/50 " +
+        "premium-card lift group flex flex-col rounded-xl border border-border bg-surface p-6 " +
         className
       }
     >
@@ -236,6 +236,7 @@ export default function JvdPortal() {
   const [osF, setOsF] = useState<string | null>(null);
   const [queryF, setQueryF] = useState("");
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState("home");
 
   // Global shortcut: ⌘K / Ctrl+K toggles search; "/" opens it (unless typing).
   useEffect(() => {
@@ -250,6 +251,25 @@ export default function JvdPortal() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Scrollspy: highlight the nav entry for whichever section owns the viewport.
+  useEffect(() => {
+    const sections = NAV.map((n) => document.getElementById(n.href.slice(1))).filter(
+      (el): el is HTMLElement => !!el,
+    );
+    if (sections.length === 0) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const top = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (top) setActiveSection(top.target.id);
+      },
+      { rootMargin: "-45% 0px -50% 0px", threshold: [0, 0.25, 0.5, 1] },
+    );
+    sections.forEach((s) => observer.observe(s));
+    return () => observer.disconnect();
   }, []);
 
   // A JVD chosen from the palette: clear filters, pre-fill the catalog search
@@ -326,15 +346,6 @@ export default function JvdPortal() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      {/* Marquee */}
-      <div className="marquee-pause overflow-hidden border-b border-border bg-surface">
-        <div className="marquee-track flex w-max whitespace-nowrap py-2">
-          {[...MARQUEE_TAGS, ...MARQUEE_TAGS].map((t, i) => (
-            <MarqueeTag key={`${t}-${i}`} label={t} />
-          ))}
-        </div>
-      </div>
-
       {/* Nav */}
       <header className="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
@@ -342,12 +353,13 @@ export default function JvdPortal() {
             <img src={brandLogo} alt="" className="h-7 w-auto" style={{ filter: "invert(1) brightness(1.1)" }} />
             <span>JVD Portal</span>
           </a>
-          <nav className="hidden gap-8 md:flex">
+          <nav className="hidden items-center gap-7 lg:flex">
             {NAV.map((n) => (
               <a
                 key={n.href}
                 href={n.href}
-                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                data-active={activeSection === n.href.slice(1)}
+                className="nav-link whitespace-nowrap text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 {n.label}
               </a>
@@ -425,12 +437,12 @@ export default function JvdPortal() {
               {stats.map((s) => (
                 <div
                   key={s.label}
-                  className="rounded-lg border border-border bg-surface px-5 py-5"
+                  className="premium-card rounded-xl border border-border bg-surface px-5 py-6"
                 >
-                  <div className="text-3xl font-semibold tracking-tight text-primary">
+                  <div className="text-4xl font-semibold tracking-tight text-primary">
                     {s.value}
                   </div>
-                  <div className="mt-1 text-xs uppercase tracking-wider text-muted-foreground">
+                  <div className="mt-1.5 text-xs uppercase tracking-wider text-muted-foreground">
                     {s.label}
                   </div>
                 </div>
@@ -440,38 +452,41 @@ export default function JvdPortal() {
 
           {/* Journey ladder */}
           <div id="how" className="mt-24 scroll-mt-24">
-            <h2 className="text-2xl font-semibold tracking-tight">
-              Find. Learn. Design. Build. Deploy.
+            <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
+              Learn. Design. Automate.
             </h2>
-            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+            <p className="mt-3 max-w-2xl text-base text-muted-foreground">
               <span className="font-medium text-foreground">Explore Juniper Validated Designs in a new way.</span>{" "}
-              Discover the right architecture, learn how it is built, design against
+              Find the right architecture, examine how it is built, design against
               your requirements, generate validated configuration, and connect it to
-              automation. Five stages, one path.
+              automation. Five stages, one journey.
             </p>
             <div className="mt-8 grid gap-4 md:grid-cols-5">
               {LADDER.map((s, i) => (
                 <a
                   key={s.href}
                   href={s.href}
-                  className="group relative rounded-lg border border-border bg-surface p-5 transition-colors hover:border-primary/60"
+                  className={
+                    "premium-card lift group relative flex flex-col rounded-xl border border-border bg-surface p-5 " +
+                    ((s as any).comingSoon ? "opacity-75 hover:opacity-100" : "")
+                  }
                 >
-                  <div className="flex items-center gap-2 text-primary">
-                    <span className="flex h-6 w-6 items-center justify-center rounded-full border border-primary/40 text-xs font-semibold">
+                  <div className="flex items-center gap-2">
+                    <span className="flex h-7 w-7 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-sm font-bold text-primary">
                       {i + 1}
                     </span>
-                    <span className="text-[11px] font-semibold uppercase tracking-wider">
-                      {s.stage}
-                    </span>
                     {(s as any).comingSoon && (
-                      <span className="rounded-full border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-primary">
+                      <span className="ml-auto rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
                         Soon
                       </span>
                     )}
                   </div>
-                  <div className="mt-3 font-semibold tracking-tight">{s.title}</div>
-                  <p className="mt-1 text-sm text-muted-foreground">{s.desc}</p>
-                  <span className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
+                  <span className="mt-3 text-base font-bold uppercase tracking-wide text-primary md:text-lg">
+                    {s.stage}
+                  </span>
+                  <div className="mt-2 font-semibold tracking-tight text-foreground">{s.title}</div>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{s.desc}</p>
+                  <span className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
                     Open <ArrowRight className="h-3 w-3" />
                   </span>
                 </a>
@@ -483,6 +498,15 @@ export default function JvdPortal() {
           </div>
         </div>
       </section>
+
+      {/* Technologies marquee */}
+      <div className="marquee-pause overflow-hidden border-b border-border bg-surface">
+        <div className="marquee-track flex w-max whitespace-nowrap py-2">
+          {[...MARQUEE_TAGS, ...MARQUEE_TAGS].map((t, i) => (
+            <MarqueeTag key={`${t}-${i}`} label={t} />
+          ))}
+        </div>
+      </div>
 
       {/* Catalog */}
       <section id="catalog" className="border-b border-border">
@@ -514,16 +538,16 @@ export default function JvdPortal() {
           </div>
 
           <div className="mt-10 space-y-4">
-            <div className="relative max-w-xl">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <div className="search-accent relative max-w-xl rounded-lg border">
+              <Search className="pointer-events-none absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-primary" />
               <input
                 type="search"
                 value={queryF}
                 onChange={(e) => setQueryF(e.target.value)}
                 onFocus={() => track("catalog-search")}
-                placeholder="Search by tech, use case, platform…"
+                placeholder="Search designs by tech, use case, or platform…"
                 aria-label="Search the JVD catalog"
-                className="w-full rounded-md border border-border bg-surface py-2.5 pl-10 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary/60"
+                className="w-full rounded-lg border-0 bg-transparent py-3 pl-11 pr-3 text-base outline-none placeholder:text-muted-foreground"
               />
             </div>
             <FilterRow label="Area" options={AREAS} value={areaF} onChange={setAreaF} />
@@ -684,7 +708,7 @@ export default function JvdPortal() {
                 href={AREA_DOC_LINKS[a]}
                 target="_blank"
                 rel="noreferrer"
-                className="rounded-lg border border-border bg-surface p-4 text-left transition-colors hover:border-primary/60"
+                className="premium-card lift rounded-xl border border-border bg-surface p-4 text-left"
               >
                 <div className="text-2xl font-semibold tracking-tight text-primary">
                   {areaCounts[a]}

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -59,24 +59,28 @@ const LADDER = [
     title: "JVD Catalog",
     desc: "Find the validated architecture that fits your requirements.",
     href: "#catalog",
+    cta: "Discover JVDs",
   },
   {
     stage: "Explore",
     title: "Config Explorer",
     desc: "Explore reusable config building blocks traced to their source JVDs.",
     href: "#snips",
+    cta: "Explore Configs",
   },
   {
     stage: "Learn & Design",
     title: "Design & Planner",
     desc: "Ask architecture, scaling, and configuration questions grounded in validated JVD content.",
     href: "#byoai",
+    cta: "Start Designing",
   },
   {
     stage: "Build",
     title: "Service Config Generator",
     desc: "Generate downloadable configuration deterministically from JVD building blocks.",
     href: "#generator",
+    cta: "Build Something",
   },
   {
     stage: "Deploy",
@@ -84,6 +88,7 @@ const LADDER = [
     desc: "Access validated designs from your AI agent and carry grounded configuration into automation.",
     href: "#mcp",
     comingSoon: true,
+    cta: "Deploy It!",
   },
 ];
 
@@ -346,14 +351,23 @@ export default function JvdPortal() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      {/* Technologies marquee */}
+      <div className="marquee-pause overflow-hidden border-b border-border bg-surface">
+        <div className="marquee-track flex w-max whitespace-nowrap py-2">
+          {[...MARQUEE_TAGS, ...MARQUEE_TAGS].map((t, i) => (
+            <MarqueeTag key={`${t}-${i}`} label={t} />
+          ))}
+        </div>
+      </div>
+
       {/* Nav */}
       <header className="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur-md">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
-          <a href="#home" className="flex items-center gap-2 font-semibold tracking-tight">
+          <a href="#home" className="flex shrink-0 items-center gap-2 font-semibold tracking-tight">
             <img src={brandLogo} alt="" className="h-7 w-auto" style={{ filter: "invert(1) brightness(1.1)" }} />
-            <span>JVD Portal</span>
+            <span className="whitespace-nowrap">JVD Portal</span>
           </a>
-          <nav className="hidden items-center gap-7 lg:flex">
+          <nav className="hidden items-center gap-5 md:flex">
             {NAV.map((n) => (
               <a
                 key={n.href}
@@ -365,7 +379,7 @@ export default function JvdPortal() {
               </a>
             ))}
           </nav>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <button
               type="button"
               onClick={() => setPaletteOpen(true)}
@@ -373,8 +387,8 @@ export default function JvdPortal() {
               className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-muted-foreground hover:border-primary/60 hover:text-foreground"
             >
               <Search className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Search</span>
-              <kbd className="hidden rounded border border-border px-1 text-[10px] md:inline">⌘K</kbd>
+              <span className="hidden xl:inline">Search</span>
+              <kbd className="hidden rounded border border-border px-1 text-[10px] xl:inline">⌘K</kbd>
             </button>
             <a
               href="https://github.com/Juniper/jvd"
@@ -382,7 +396,7 @@ export default function JvdPortal() {
               rel="noreferrer"
               className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium hover:border-primary/60"
             >
-              <Github className="h-3.5 w-3.5" /> GitHub
+              <Github className="h-3.5 w-3.5" /> <span className="hidden xl:inline">GitHub</span>
             </a>
           </div>
         </div>
@@ -486,8 +500,10 @@ export default function JvdPortal() {
                   </span>
                   <div className="mt-2 font-semibold tracking-tight text-foreground">{s.title}</div>
                   <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{s.desc}</p>
-                  <span className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
-                    Open <ArrowRight className="h-3 w-3" />
+                  <div className="flex-1" />
+                  <span className="mt-4 inline-flex items-center gap-1.5 text-xs font-semibold text-primary">
+                    {s.cta}
+                    <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
                   </span>
                 </a>
               ))}
@@ -498,15 +514,6 @@ export default function JvdPortal() {
           </div>
         </div>
       </section>
-
-      {/* Technologies marquee */}
-      <div className="marquee-pause overflow-hidden border-b border-border bg-surface">
-        <div className="marquee-track flex w-max whitespace-nowrap py-2">
-          {[...MARQUEE_TAGS, ...MARQUEE_TAGS].map((t, i) => (
-            <MarqueeTag key={`${t}-${i}`} label={t} />
-          ))}
-        </div>
-      </div>
 
       {/* Catalog */}
       <section id="catalog" className="border-b border-border">
@@ -589,7 +596,7 @@ export default function JvdPortal() {
           ) : (
             <CatalogCarousel
               items={[...shuffledData, ...shuffledData]}
-              renderCard={(j) => <JvdCard j={j} className="w-full" />}
+              renderCard={(j) => <JvdCard j={j} className="h-full w-full" />}
             />
           )}
         </div>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -78,7 +78,7 @@ const LADDER = [
   {
     stage: "Build",
     title: "Config Generator",
-    desc: "Generate deterministic configuration from validated JVD building blocks.",
+    desc: "Create deterministic configuration from validated JVD building blocks.",
     href: "#generator",
     cta: "Build Something",
   },
@@ -481,7 +481,7 @@ export default function JvdPortal() {
                   key={s.href}
                   href={s.href}
                   className={
-                    "premium-card lift glow group relative flex flex-col rounded-xl border border-border bg-surface p-5 " +
+                    "premium-card lift glow group relative flex flex-col rounded-xl border border-border bg-surface px-5 pt-5 pb-4 " +
                     ((s as any).comingSoon ? "opacity-75 hover:opacity-100" : "")
                   }
                 >

--- a/portal/src/components/SnipLibrary.tsx
+++ b/portal/src/components/SnipLibrary.tsx
@@ -614,7 +614,7 @@ export default function SnipLibrary() {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-wider text-primary">
-              Stage 2 · Learn
+              Stage 2 · Explore
             </div>
             <div className="mt-1 flex items-center gap-2">
               <Layers className="h-5 w-5 text-primary" />

--- a/portal/src/styles.css
+++ b/portal/src/styles.css
@@ -49,7 +49,7 @@
   --secondary: oklch(0.26 0.02 255);
   --secondary-foreground: oklch(0.97 0.01 250);
   --muted: oklch(0.26 0.02 255);
-  --muted-foreground: oklch(0.7 0.02 255);
+  --muted-foreground: oklch(0.76 0.02 255);   /* raised for large-room / small-text legibility */
   --accent: oklch(0.72 0.17 130);
   --accent-foreground: oklch(0.16 0.02 255);
   --destructive: oklch(0.6 0.22 25);
@@ -57,6 +57,9 @@
   --border: oklch(0.3 0.02 255);
   --input: oklch(0.3 0.02 255);
   --ring: oklch(0.72 0.17 130);
+  /* Depth tokens for the premium card system */
+  --shadow-card: 0 1px 2px oklch(0 0 0 / 0.28), 0 10px 30px -14px oklch(0 0 0 / 0.6);
+  --shadow-card-hover: 0 2px 6px oklch(0 0 0 / 0.34), 0 22px 48px -18px oklch(0 0 0 / 0.7);
 }
 
 @layer base {
@@ -72,9 +75,22 @@
     color: var(--color-foreground);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
+    /* Faint accent glow anchored to the top of the page for depth */
+    background-image: radial-gradient(
+      ellipse 70% 45% at 50% -5%,
+      color-mix(in oklab, var(--color-primary) 5%, transparent),
+      transparent 70%
+    );
+    background-repeat: no-repeat;
+    background-attachment: fixed;
   }
   section[id] {
     scroll-margin-top: 5rem;
+  }
+  /* Consistent, on-brand keyboard focus */
+  :where(a, button, input, select, textarea, [tabindex]):focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--color-primary) 75%, transparent);
+    outline-offset: 2px;
   }
 }
 
@@ -103,4 +119,61 @@
 }
 .snip-body pre.shiki code {
   font-family: inherit;
+}
+
+/* ---------------------------------------------------------------------------
+ * Premium design system — elevation, micro-interactions, accented controls.
+ * Applied via className on cards, the stage ladder, nav links, and search.
+ * ------------------------------------------------------------------------- */
+
+/* Elevated surface: soft outer shadow + a 1px top-edge highlight ("card lip"). */
+.premium-card {
+  box-shadow: var(--shadow-card), inset 0 1px 0 0 oklch(1 0 0 / 0.05);
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+}
+/* Lift on hover for interactive cards. */
+.premium-card.lift:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card-hover), inset 0 1px 0 0 oklch(1 0 0 / 0.08);
+  border-color: color-mix(in oklab, var(--color-primary) 45%, var(--color-border));
+}
+
+/* Animated active/hover underline for top-nav links. */
+.nav-link {
+  position: relative;
+}
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-primary);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 200ms ease;
+}
+.nav-link:hover::after,
+.nav-link[data-active="true"]::after {
+  transform: scaleX(1);
+}
+.nav-link[data-active="true"] {
+  color: var(--color-foreground);
+}
+
+/* Accented search field: tinted at rest (not grey), glows on hover/focus. */
+.search-accent {
+  background: color-mix(in oklab, var(--color-primary) 6%, var(--color-surface));
+  border-color: color-mix(in oklab, var(--color-primary) 32%, transparent);
+  transition: box-shadow 200ms ease, border-color 200ms ease, background 200ms ease;
+}
+.search-accent:hover {
+  border-color: color-mix(in oklab, var(--color-primary) 55%, transparent);
+}
+.search-accent:focus-within {
+  border-color: var(--color-primary);
+  background: color-mix(in oklab, var(--color-primary) 9%, var(--color-surface));
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-primary) 16%, transparent);
 }

--- a/portal/src/styles.css
+++ b/portal/src/styles.css
@@ -137,6 +137,15 @@
   box-shadow: var(--shadow-card-hover), inset 0 1px 0 0 oklch(1 0 0 / 0.08);
   border-color: color-mix(in oklab, var(--color-primary) 45%, var(--color-border));
 }
+/* Extra-poppy hover for the stage tiles: bright primary outline + accent glow. */
+.premium-card.lift.glow:hover {
+  border-color: var(--color-primary);
+  box-shadow:
+    var(--shadow-card-hover),
+    inset 0 1px 0 0 oklch(1 0 0 / 0.1),
+    0 0 0 1px color-mix(in oklab, var(--color-primary) 60%, transparent),
+    0 10px 34px -10px color-mix(in oklab, var(--color-primary) 40%, transparent);
+}
 
 /* Animated active/hover underline for top-nav links. */
 .nav-link {


### PR DESCRIPTION
## What's New
A visual + UX refresh of the JVD Portal — a more premium look, clearer navigation, and a faster way to start with the AI assistant.

- **Five-stage journey up front** (Discover · Explore · Learn & Design · Build · Deploy) with bigger labels and per-stage calls-to-action.
- **Ask a question when launching BYOAI** — type a question (with suggested, JVD-aware prompts) and optionally pick a mode; it launches straight into Claude or ChatGPT pre-loaded.
- **Elevated, consistent cards** with depth and richer hover, plus an accented catalog search that's easier to spot.
- **Clearer naming** — "Design & Planner" → **JVD AI Assistant**; the Config Explorer stage is now **Explore**.

## Why
Feedback flagged the portal as functional but a little flat and hard to navigate. This pass improves visual hierarchy, readability, and the "wow" factor, and makes the AI assistant quicker to use.

## Details
- `portal/src/styles.css` — premium design system: elevated `.premium-card` (soft shadow + top-edge highlight + hover lift + `.glow` outline), accent focus rings, subtle background glow, accented `.search-accent` field, animated scrollspy nav underline, raised muted-text contrast.
- `portal/src/components/JvdPortal.tsx` — bigger green stage labels + per-stage CTAs (hover-reveal on desktop, always visible on mobile); taxonomy rename (Explore / Learn & Design / JVD AI Assistant / Config Generator); tighter tile copy; equal-height carousel cards; accented catalog search; tech marquee relocated to the top; scrollspy nav with icon-collapsed Search/GitHub so all items fit.
- `portal/src/components/ByoaiSection.tsx` — optional question + mode (Learn & Design / Configure) prefill into Claude/ChatGPT; VS Code greys out when a question is present (its install link can't carry one); JVD-aware suggested questions on focus; refreshed tile copy; small-print notes consolidated into a normal-size FAQ; section renamed to JVD AI Assistant.
- `portal/src/components/CatalogCarousel.tsx` — slides stretch so catalog cards are equal height.

## Testing
- `bun run build` — clean, no type errors.
- Browser-verified: stage tiles + CTAs, nav (no overlap at desktop widths), accented search, equal carousel card heights, BYOAI question → prefill (appends to the Claude/ChatGPT `?q=`), VS Code grey-out, and suggested questions on focus.

## Notes
Follow-ups intentionally deferred:
- Relabel the BYOAI mode menu ("Design mode" → "Learn & Design") across the per-JVD prompt bundles so the assistant's greeting matches the UI (the UI works today via the existing keyword).
- Optional hero graphic for extra polish, and a mobile nav menu (no top nav below the `md` breakpoint).