### PR TITLE
feat(portal): UX polish — hero graphic, mobile nav, stage tiles, BYOAI FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ Release notes for the Juniper Validated Design (JVD) configuration repository.
 
 ---
 
+## 2026-08-06
+
+A portal experience redesign. The JVD Portal gets a cleaner, more premium look, a
+clearer five-stage journey, and a faster way to put your own AI to work — plus
+mobile support and sharper copy throughout.
+
+### The portal, redesigned
+
+- **A clear five-stage journey** — Discover → Explore → Learn & Design → Build →
+  Deploy is now front and center, with bold stage labels and an inviting
+  call-to-action on each step, so it's obvious where to start and where to go next.
+- **Clearer names** — the configuration browser is the **Explore** stage (Config
+  Explorer), and the assistant is the **JVD AI Assistant**, grouped under a single
+  **Learn & Design** stage.
+- **A more premium look** — elevated cards with real depth and richer hover, an
+  accent-highlighted catalog search that's easy to spot, refined typography and
+  spacing, and a subtle animated network graphic on the landing page.
+- **Works on mobile** — a new menu makes the full navigation available on phones
+  and tablets.
+
+### Ask your AI a question — right from the portal
+
+- **Ask-a-question launch** — the **JVD AI Assistant** section adds an optional
+  question box: type what you need and, if you like, choose **Learn & Design** or
+  **Configure**, then launch straight into Claude or ChatGPT already loaded with
+  the design's validated prompt and your question.
+- **Guidance on model choice** — a new FAQ explains that most everyday
+  ("utility-tier") models work well, with quick recommendations, and the fine
+  print is consolidated into readable, normal-size answers.
+- **Smoother browsing** — the design catalog is now swipeable, and copy across
+  every section has been sharpened to make each tool's purpose clearer.
+
+---
+
 ## 2026-08-03
 
 A library-wide quality pass. The configuration building-block library gains more

--- a/portal/src/components/ByoaiSection.tsx
+++ b/portal/src/components/ByoaiSection.tsx
@@ -378,6 +378,16 @@ export default function ByoaiSection() {
               </summary>
               <div className="mt-3 space-y-3 text-sm leading-relaxed text-muted-foreground">
                 <div>
+                  <div className="font-medium text-foreground">Which model should I use?</div>
+                  <p className="mt-1">
+                    Most current models work well — the assistant does grounded retrieval and
+                    assembly, not heavy reasoning, so a fast utility-tier model (e.g. Claude Haiku or
+                    ChatGPT’s lighter modes) is usually plenty. The main exception is a few ultra-fast
+                    “instant” modes that can’t browse to fetch the prompt — use a standard/thinking
+                    mode, or download and attach the prompt.
+                  </p>
+                </div>
+                <div>
                   <div className="font-medium text-foreground">Does my AI need web access?</div>
                   <p className="mt-1">
                     Yes — it must fetch a URL to load the prompt. Most current tiers, including many

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -485,7 +485,12 @@ export default function JvdPortal() {
                     ((s as any).comingSoon ? "opacity-75 hover:opacity-100" : "")
                   }
                 >
-                  <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
+                  <div
+                    className={
+                      "flex gap-x-2.5 " +
+                      ((s as any).comingSoon ? "flex-wrap items-center gap-y-1.5" : "items-start")
+                    }
+                  >
                     <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-sm font-bold text-primary">
                       {i + 1}
                     </span>

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -485,20 +485,20 @@ export default function JvdPortal() {
                     ((s as any).comingSoon ? "opacity-75 hover:opacity-100" : "")
                   }
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="flex h-7 w-7 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-sm font-bold text-primary">
+                  <div className="flex items-center gap-2.5">
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-sm font-bold text-primary">
                       {i + 1}
                     </span>
+                    <span className="text-base font-bold uppercase tracking-wide text-primary">
+                      {s.stage}
+                    </span>
                     {(s as any).comingSoon && (
-                      <span className="ml-auto rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
+                      <span className="ml-auto shrink-0 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
                         Soon
                       </span>
                     )}
                   </div>
-                  <span className="mt-3 text-base font-bold uppercase tracking-wide text-primary">
-                    {s.stage}
-                  </span>
-                  <div className="mt-2 text-[15px] font-semibold tracking-tight text-foreground">{s.title}</div>
+                  <div className="mt-3 text-[15px] font-semibold tracking-tight text-foreground">{s.title}</div>
                   <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{s.desc}</p>
                   <div className="flex-1" />
                   <span className="mt-4 inline-flex items-center gap-1.5 text-xs font-semibold text-primary opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -148,6 +148,58 @@ function MarqueeTag({ label }: { label: string }) {
   );
 }
 
+// Decorative animated network mesh for the hero right side (pure SVG + CSS).
+function HeroNetwork() {
+  const nodes: [number, number][] = [
+    [80, 90], [210, 60], [360, 120], [140, 210], [280, 230],
+    [420, 260], [90, 340], [230, 370], [380, 400], [320, 320],
+  ];
+  const links: [number, number][] = [
+    [0, 1], [1, 2], [0, 3], [1, 4], [2, 5], [3, 4], [4, 5],
+    [3, 6], [4, 7], [5, 8], [6, 7], [7, 9], [9, 8], [4, 9], [2, 4],
+  ];
+  const accent = new Set([1, 4, 8]);
+  return (
+    <svg viewBox="0 0 500 500" fill="none" className="h-full w-full">
+      <g className="hero-net text-primary">
+        {links.map(([a, b], i) => (
+          <line
+            key={i}
+            x1={nodes[a][0]} y1={nodes[a][1]}
+            x2={nodes[b][0]} y2={nodes[b][1]}
+            stroke="currentColor"
+            strokeWidth={1.2}
+            strokeOpacity={0.3}
+          />
+        ))}
+        {nodes.map(([x, y], i) => (
+          <g key={i}>
+            {accent.has(i) && (
+              <>
+                <circle cx={x} cy={y} r={16} fill="currentColor" opacity={0.08} />
+                <circle
+                  cx={x} cy={y} r={10}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeOpacity={0.4}
+                  className="hero-ping"
+                  style={{ animationDelay: `${i * 0.6}s` }}
+                />
+              </>
+            )}
+            <circle
+              cx={x} cy={y} r={accent.has(i) ? 5.5 : 3}
+              fill="currentColor"
+              className="hero-node"
+              style={{ animationDelay: `${(i % 5) * 0.7}s` }}
+            />
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}
+
 function JvdCard({ j, className = "" }: { j: Jvd; className?: string }) {
   const families = Array.from(new Set(j.platforms.map(familyOf))).filter(Boolean);
   const steps: StepPill[] = [];
@@ -411,7 +463,17 @@ export default function JvdPortal() {
             "radial-gradient(ellipse 80% 50% at 50% -10%, color-mix(in oklab, var(--color-primary) 18%, transparent), transparent)",
         }}
       >
-        <div className="mx-auto max-w-7xl px-6 py-28 md:py-36">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute right-0 top-0 hidden h-[620px] w-[620px] md:block"
+          style={{
+            WebkitMaskImage: "radial-gradient(circle at 70% 35%, white, transparent 72%)",
+            maskImage: "radial-gradient(circle at 70% 35%, white, transparent 72%)",
+          }}
+        >
+          <HeroNetwork />
+        </div>
+        <div className="relative z-10 mx-auto max-w-7xl px-6 py-28 md:py-36">
           <div className="max-w-3xl">
             <span className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs text-muted-foreground">
               <span className="h-1.5 w-1.5 rounded-full bg-primary" />

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -485,7 +485,7 @@ export default function JvdPortal() {
                     ((s as any).comingSoon ? "opacity-75 hover:opacity-100" : "")
                   }
                 >
-                  <div className="flex items-center gap-2.5">
+                  <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
                     <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-primary/40 bg-primary/10 text-sm font-bold text-primary">
                       {i + 1}
                     </span>
@@ -493,7 +493,7 @@ export default function JvdPortal() {
                       {s.stage}
                     </span>
                     {(s as any).comingSoon && (
-                      <span className="ml-auto shrink-0 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
+                      <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
                         Soon
                       </span>
                     )}

--- a/portal/src/components/JvdPortal.tsx
+++ b/portal/src/components/JvdPortal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import jvds from "@/data/jvds.json";
-import { ArrowRight, Github, ExternalLink, Network, Layers, Info, Search, Sparkles, Wrench, PlugZap, Bell, type LucideIcon } from "lucide-react";
+import { ArrowRight, Github, ExternalLink, Network, Layers, Info, Search, Sparkles, Wrench, PlugZap, Bell, Menu, X, type LucideIcon } from "lucide-react";
 import brandLogo from "@/assets/hpe-juniper-networking.avif";
 import SnipLibrary from "@/components/SnipLibrary";
 import ByoaiSection from "@/components/ByoaiSection";
@@ -294,6 +294,7 @@ export default function JvdPortal() {
   const [queryF, setQueryF] = useState("");
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("home");
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   // Global shortcut: ⌘K / Ctrl+K toggles search; "/" opens it (unless typing).
   useEffect(() => {
@@ -450,8 +451,38 @@ export default function JvdPortal() {
             >
               <Github className="h-3.5 w-3.5" /> <span className="hidden xl:inline">GitHub</span>
             </a>
+            <button
+              type="button"
+              onClick={() => setMobileOpen((v) => !v)}
+              aria-label={mobileOpen ? "Close menu" : "Open menu"}
+              aria-expanded={mobileOpen}
+              className="inline-flex items-center justify-center rounded-md border border-border bg-surface p-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground md:hidden"
+            >
+              {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+            </button>
           </div>
         </div>
+        {mobileOpen && (
+          <nav className="border-t border-border bg-background/95 px-6 py-3 md:hidden">
+            <div className="flex flex-col gap-1">
+              {NAV.map((n) => (
+                <a
+                  key={n.href}
+                  href={n.href}
+                  onClick={() => setMobileOpen(false)}
+                  className={
+                    "rounded-md px-3 py-2 text-sm transition-colors hover:bg-surface hover:text-foreground " +
+                    (activeSection === n.href.slice(1)
+                      ? "bg-surface text-foreground"
+                      : "text-muted-foreground")
+                  }
+                >
+                  {n.label}
+                </a>
+              ))}
+            </div>
+          </nav>
+        )}
       </header>
 
       {/* Hero */}

--- a/portal/src/styles.css
+++ b/portal/src/styles.css
@@ -186,3 +186,32 @@
   background: color-mix(in oklab, var(--color-primary) 9%, var(--color-surface));
   box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-primary) 16%, transparent);
 }
+
+/* Ambient hero network mesh (decorative). */
+.hero-net {
+  animation: hero-drift 22s ease-in-out infinite;
+}
+.hero-node {
+  animation: hero-node-pulse 4s ease-in-out infinite;
+}
+.hero-ping {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: hero-ping 3.8s ease-out infinite;
+}
+@keyframes hero-node-pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+@keyframes hero-drift {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50% { transform: translate3d(-10px, 8px, 0); }
+}
+@keyframes hero-ping {
+  0% { transform: scale(0.6); opacity: 0.5; }
+  70% { opacity: 0; }
+  100% { transform: scale(1.9); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero-net, .hero-node, .hero-ping { animation: none; }
+}


### PR DESCRIPTION
## What's New
Follow-up polish to the JVD Portal, batched:

- **Animated network-mesh hero graphic** on the landing page.
- **Mobile nav menu** — a hamburger brings the full navigation to phones/tablets.
- **Refined stage tiles** — the number sits inline with the green stage title, the label wraps cleanly beneath it, and the DEPLOY "SOON" pill stays inside the card.
- **BYOAI model guidance** — a new first FAQ item: most everyday ("utility-tier") models work well.
- **CHANGELOG** — a `2026-08-06` "portal experience redesign" entry covering this plus the recent portal work.

## Why
Small UX refinements from feedback after the portal refresh: add landing-page polish, restore mobile navigation, and tidy the stage tiles and BYOAI guidance.

## Details
- `portal/src/components/JvdPortal.tsx` — `HeroNetwork` SVG mesh (uses `currentColor`, radial mask, hidden below `md`, reduced-motion aware); mobile hamburger + slide-down menu (`md:hidden`); stage-tile header uses a non-wrapping, top-aligned row so the number stays with the first word and the label wraps beneath; the DEPLOY "SOON" pill wraps inside the card instead of overflowing.
- `portal/src/components/ByoaiSection.tsx` — new "Which model should I use?" FAQ item.
- `portal/src/styles.css` — hero-mesh keyframes (node pulse / drift / ping) with a `prefers-reduced-motion` guard.
- `CHANGELOG.md` — new `2026-08-06` entry.

## Testing
- `bun run build` — clean, no type errors.
- Browser-verified: hero mesh renders at `md`+; the mobile menu toggles and lists all seven links (confirmed via the accessibility tree); stage tiles keep the number on the first line with the label beneath, and "SOON" stays inside the DEPLOY card.

## Notes
- The hero graphic is intentionally hidden on phones (shows at `md`+) so it never crowds the headline.